### PR TITLE
State cache: processed items, deferred items, remote recovery (#8)

### DIFF
--- a/src/cog/state.py
+++ b/src/cog/state.py
@@ -1,0 +1,198 @@
+import contextlib
+import fcntl
+import json
+import os
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from cog.core.host import GitHost
+from cog.core.item import Item
+from cog.core.tracker import IssueTracker
+
+
+@dataclass(frozen=True)
+class ProcessedRecord:
+    tracker_id: str
+    item_id: str
+    outcome: str  # from TelemetryOutcome vocabulary
+    ts: datetime  # tz-aware UTC
+
+
+@dataclass(frozen=True)
+class DeferredRecord:
+    tracker_id: str
+    item_id: str
+    reason: str  # e.g., "blocker"
+    blockers: tuple[str, ...]  # item_ids of blocking issues
+    ts: datetime
+
+
+class JsonFileStateCache:
+    """Satisfies cog.core.state.StateCache Protocol structurally.
+
+    Mutations are in-memory only; callers must invoke save() to persist.
+    Backing file lives at ~/.local/state/cog/<slug>/state.json (path set at construction).
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._processed: dict[tuple[str, str], ProcessedRecord] = {}
+        self._deferred: dict[tuple[str, str], DeferredRecord] = {}
+        self._last_run: datetime | None = None
+        self._loaded = False
+        self._corrupt = False
+
+    # --- file lifecycle ---
+
+    def load(self) -> None:
+        """Read state from disk. Missing/corrupt file → empty state + `was_corrupt()` set."""
+        self._loaded = True
+        if not self._path.exists():
+            self._corrupt = False
+            return
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            if data.get("schema_version") != 1:
+                raise ValueError(f"unsupported schema_version: {data.get('schema_version')!r}")
+            for rec in data.get("processed_items", []):
+                p = ProcessedRecord(
+                    tracker_id=rec["tracker_id"],
+                    item_id=rec["item_id"],
+                    outcome=rec["outcome"],
+                    ts=datetime.fromisoformat(rec["ts"]),
+                )
+                self._processed[(p.tracker_id, p.item_id)] = p
+            for rec in data.get("deferred_items", []):
+                d = DeferredRecord(
+                    tracker_id=rec["tracker_id"],
+                    item_id=rec["item_id"],
+                    reason=rec["reason"],
+                    blockers=tuple(rec.get("blockers", [])),
+                    ts=datetime.fromisoformat(rec["ts"]),
+                )
+                self._deferred[(d.tracker_id, d.item_id)] = d
+            self._last_run = (
+                datetime.fromisoformat(data["last_run"]) if data.get("last_run") else None
+            )
+            self._corrupt = False
+        except (json.JSONDecodeError, ValueError, KeyError, TypeError) as e:
+            print(f"warning: state file corrupt ({e}); starting empty", file=sys.stderr)
+            self._processed.clear()
+            self._deferred.clear()
+            self._last_run = None
+            self._corrupt = True
+
+    def was_corrupt(self) -> bool:
+        return self._corrupt
+
+    def is_empty(self) -> bool:
+        return not self._processed and not self._deferred
+
+    def save(self) -> None:
+        """Flush to disk. Flock-serialized, atomic (tempfile + os.replace). Raises on failure."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._last_run = datetime.now(UTC)
+        lock_path = self._path.with_name(self._path.name + ".lock")
+        with lock_path.open("a") as lock_file:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            fd, tmp_name = tempfile.mkstemp(
+                suffix=".json.tmp",
+                dir=str(self._path.parent),
+                text=False,
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as tmp:
+                    json.dump(self._serialize(), tmp, indent=2, sort_keys=True)
+                    tmp.flush()
+                    os.fsync(tmp.fileno())
+                os.replace(tmp_name, self._path)
+            except Exception:
+                with contextlib.suppress(FileNotFoundError):
+                    os.unlink(tmp_name)
+                raise
+
+    def _serialize(self) -> dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "processed_items": [
+                {
+                    "tracker_id": p.tracker_id,
+                    "item_id": p.item_id,
+                    "outcome": p.outcome,
+                    "ts": p.ts.isoformat(),
+                }
+                for p in sorted(self._processed.values(), key=lambda r: (r.tracker_id, r.item_id))
+            ],
+            "deferred_items": [
+                {
+                    "tracker_id": d.tracker_id,
+                    "item_id": d.item_id,
+                    "reason": d.reason,
+                    "blockers": list(d.blockers),
+                    "ts": d.ts.isoformat(),
+                }
+                for d in sorted(self._deferred.values(), key=lambda r: (r.tracker_id, r.item_id))
+            ],
+            "last_run": self._last_run.isoformat() if self._last_run else None,
+        }
+
+    # --- Protocol methods ---
+
+    def is_processed(self, item: Item) -> bool:
+        """True iff item has a processed record AND item.updated_at <= record.ts (revival rule)."""
+        rec = self._processed.get((item.tracker_id, item.item_id))
+        if rec is None:
+            return False
+        return item.updated_at <= rec.ts
+
+    def mark_processed(self, item: Item, outcome: str) -> None:
+        self._processed[(item.tracker_id, item.item_id)] = ProcessedRecord(
+            tracker_id=item.tracker_id,
+            item_id=item.item_id,
+            outcome=outcome,
+            ts=datetime.now(UTC),
+        )
+
+    def is_deferred(self, item: Item) -> bool:
+        return (item.tracker_id, item.item_id) in self._deferred
+
+    def mark_deferred(self, item: Item, reason: str, blockers: list[str]) -> None:
+        self._deferred[(item.tracker_id, item.item_id)] = DeferredRecord(
+            tracker_id=item.tracker_id,
+            item_id=item.item_id,
+            reason=reason,
+            blockers=tuple(blockers),
+            ts=datetime.now(UTC),
+        )
+
+    def clear_deferral(self, item: Item) -> None:
+        self._deferred.pop((item.tracker_id, item.item_id), None)
+
+    # --- recovery (not part of Protocol) ---
+
+    async def recover_from_remote(
+        self,
+        tracker: IssueTracker,
+        host: GitHost,
+        queue_label: str,
+    ) -> None:
+        """Best-effort: scan eligible-queue items; any item with an open PR mentioning it
+        is marked as processed with outcome='success'. Partial recovery is acceptable —
+        per-item failures are logged and skipped.
+        """
+        items = await tracker.list_by_label(queue_label, assignee="@me")
+        for item in items:
+            try:
+                prs = await host.get_open_prs_mentioning_item(item)
+            except Exception as e:
+                print(
+                    f"warning: could not fetch PRs for {item.tracker_id}#{item.item_id}: {e}",
+                    file=sys.stderr,
+                )
+                continue
+            if prs:
+                self.mark_processed(item, outcome="success")

--- a/tests/test_state/conftest.py
+++ b/tests/test_state/conftest.py
@@ -1,0 +1,34 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from cog.core.item import Item
+from cog.state import JsonFileStateCache
+
+
+def make_item(
+    *,
+    tracker_id: str = "github/org/repo",
+    item_id: str = "42",
+    updated_at: datetime | None = None,
+) -> Item:
+    return Item(
+        tracker_id=tracker_id,
+        item_id=item_id,
+        title="Test item",
+        body="body",
+        labels=(),
+        comments=(),
+        updated_at=updated_at or datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
+        url="https://github.com/org/repo/issues/42",
+    )
+
+
+@pytest.fixture
+def cache(tmp_path) -> JsonFileStateCache:
+    return JsonFileStateCache(tmp_path / "state.json")
+
+
+@pytest.fixture
+def item() -> Item:
+    return make_item()

--- a/tests/test_state/test_deferred.py
+++ b/tests/test_state/test_deferred.py
@@ -1,0 +1,37 @@
+from .conftest import make_item
+
+
+def test_mark_and_is_deferred(cache):
+    item = make_item()
+    cache.mark_deferred(item, reason="blocker", blockers=["10", "11"])
+    assert cache.is_deferred(item)
+
+
+def test_clear_deferral(cache):
+    item = make_item()
+    cache.mark_deferred(item, reason="blocker", blockers=["10"])
+    cache.clear_deferral(item)
+    assert not cache.is_deferred(item)
+
+
+def test_is_deferred_false_for_unknown_item(cache):
+    item = make_item()
+    assert not cache.is_deferred(item)
+
+
+def test_blockers_persist_as_tuple(cache):
+    item = make_item()
+    cache.mark_deferred(item, reason="blocker", blockers=["10", "11"])
+    data = cache._serialize()
+    rec = data["deferred_items"][0]
+    assert rec["blockers"] == ["10", "11"]
+    # Internal storage is a tuple
+    key = (item.tracker_id, item.item_id)
+    assert isinstance(cache._deferred[key].blockers, tuple)
+
+
+def test_clear_deferral_noop_for_unknown_item(cache):
+    item = make_item()
+    # Should not raise
+    cache.clear_deferral(item)
+    assert not cache.is_deferred(item)

--- a/tests/test_state/test_load.py
+++ b/tests/test_state/test_load.py
@@ -1,0 +1,80 @@
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from cog.state import JsonFileStateCache
+
+from .conftest import make_item
+
+
+def write_state(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_load_missing_file_is_empty_not_corrupt(tmp_path):
+    cache = JsonFileStateCache(tmp_path / "nonexistent" / "state.json")
+    cache.load()
+    assert not cache.was_corrupt()
+    assert cache.is_empty()
+
+
+def test_load_happy_path(tmp_path):
+    path = tmp_path / "state.json"
+    ts = "2024-06-01T10:00:00+00:00"
+    write_state(
+        path,
+        {
+            "schema_version": 1,
+            "processed_items": [
+                {"tracker_id": "github/org/repo", "item_id": "1", "outcome": "success", "ts": ts}
+            ],
+            "deferred_items": [
+                {
+                    "tracker_id": "github/org/repo",
+                    "item_id": "2",
+                    "reason": "blocker",
+                    "blockers": ["3"],
+                    "ts": ts,
+                }
+            ],
+            "last_run": ts,
+        },
+    )
+    cache = JsonFileStateCache(path)
+    cache.load()
+
+    assert not cache.was_corrupt()
+    item1 = make_item(item_id="1", updated_at=datetime(2024, 1, 1, tzinfo=UTC))
+    item2 = make_item(item_id="2", updated_at=datetime(2024, 1, 1, tzinfo=UTC))
+    assert cache.is_processed(item1)
+    assert cache.is_deferred(item2)
+
+
+def test_load_corrupt_json_marks_corrupt(tmp_path, capsys):
+    path = tmp_path / "state.json"
+    path.write_text("not valid json", encoding="utf-8")
+    cache = JsonFileStateCache(path)
+    cache.load()
+    assert cache.was_corrupt()
+    assert cache.is_empty()
+    assert "corrupt" in capsys.readouterr().err
+
+
+def test_load_wrong_schema_version_marks_corrupt(tmp_path, capsys):
+    path = tmp_path / "state.json"
+    write_state(path, {"schema_version": 2, "processed_items": [], "deferred_items": []})
+    cache = JsonFileStateCache(path)
+    cache.load()
+    assert cache.was_corrupt()
+    assert cache.is_empty()
+    assert "corrupt" in capsys.readouterr().err
+
+
+def test_load_missing_schema_version_marks_corrupt(tmp_path, capsys):
+    path = tmp_path / "state.json"
+    write_state(path, {"processed_items": [], "deferred_items": []})
+    cache = JsonFileStateCache(path)
+    cache.load()
+    assert cache.was_corrupt()
+    assert "corrupt" in capsys.readouterr().err

--- a/tests/test_state/test_processed.py
+++ b/tests/test_state/test_processed.py
@@ -1,0 +1,42 @@
+from datetime import UTC, datetime, timedelta
+
+from .conftest import make_item
+
+
+def test_mark_and_is_processed(cache):
+    item = make_item()
+    cache.mark_processed(item, outcome="success")
+    assert cache.is_processed(item)
+
+
+def test_is_processed_false_for_unknown_item(cache):
+    item = make_item()
+    assert not cache.is_processed(item)
+
+
+def test_revival_rule(cache):
+    """item.updated_at > processed.ts → is_processed returns False."""
+    item = make_item()
+    cache.mark_processed(item, outcome="success")
+    # Simulate user editing item after it was processed
+    updated_item = make_item(updated_at=datetime.now(UTC) + timedelta(hours=1))
+    assert not cache.is_processed(updated_item)
+
+
+def test_mark_processed_overwrites_previous_record(cache):
+    item = make_item()
+    cache.mark_processed(item, outcome="noop")
+    cache.mark_processed(item, outcome="success")
+    # Still processed; outcome updated (verified via serialization)
+    assert cache.is_processed(item)
+    data = cache._serialize()
+    assert data["processed_items"][0]["outcome"] == "success"
+
+
+def test_keyed_by_tracker_id_and_item_id(cache):
+    """Same item_id in different trackers are independent records."""
+    item_github = make_item(tracker_id="github/org/repo", item_id="1")
+    item_jira = make_item(tracker_id="jira/org/proj", item_id="1")
+    cache.mark_processed(item_github, outcome="success")
+    assert cache.is_processed(item_github)
+    assert not cache.is_processed(item_jira)

--- a/tests/test_state/test_recover.py
+++ b/tests/test_state/test_recover.py
@@ -1,0 +1,73 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cog.core.host import GitHost
+from cog.core.tracker import IssueTracker
+
+from .conftest import make_item
+
+
+@pytest.fixture
+def items():
+    return [make_item(item_id=str(i)) for i in range(1, 4)]
+
+
+@pytest.fixture
+def tracker(items):
+    mock = AsyncMock(spec=IssueTracker)
+    mock.list_by_label.return_value = items
+    return mock
+
+
+@pytest.fixture
+def host(items):
+    mock = AsyncMock(spec=GitHost)
+    # items 1 and 2 have open PRs; item 3 does not
+    mock.get_open_prs_mentioning_item.side_effect = lambda item: (
+        [object()] if item.item_id in ("1", "2") else []
+    )
+    return mock
+
+
+async def test_recover_marks_items_with_open_prs(cache, tracker, host, items):
+    await cache.recover_from_remote(tracker, host, queue_label="agent-ready")
+    assert cache.is_processed(items[0])
+    assert cache.is_processed(items[1])
+    assert not cache.is_processed(items[2])
+
+
+async def test_recover_tolerates_per_item_errors(cache, items, capsys):
+    tracker = AsyncMock(spec=IssueTracker)
+    tracker.list_by_label.return_value = items
+    host = AsyncMock(spec=GitHost)
+    # Second item raises; others return a PR
+    host.get_open_prs_mentioning_item.side_effect = [
+        [object()],
+        RuntimeError("network error"),
+        [object()],
+    ]
+    await cache.recover_from_remote(tracker, host, queue_label="agent-ready")
+    assert cache.is_processed(items[0])
+    assert not cache.is_processed(items[1])
+    assert cache.is_processed(items[2])
+    assert "warning" in capsys.readouterr().err
+
+
+async def test_recover_is_idempotent(cache, tracker, host, items):
+    await cache.recover_from_remote(tracker, host, queue_label="agent-ready")
+    await cache.recover_from_remote(tracker, host, queue_label="agent-ready")
+    # Still exactly 2 processed; no duplicates or errors
+    data = cache._serialize()
+    assert len(data["processed_items"]) == 2
+
+
+async def test_recover_uses_provided_queue_label(cache, tracker, host):
+    await cache.recover_from_remote(tracker, host, queue_label="my-custom-label")
+    tracker.list_by_label.assert_called_once_with("my-custom-label", assignee="@me")
+
+
+async def test_recover_passes_assignee_me(cache, tracker, host):
+    await cache.recover_from_remote(tracker, host, queue_label="agent-ready")
+    _, kwargs = tracker.list_by_label.call_args
+    assert kwargs["assignee"] == "@me"

--- a/tests/test_state/test_save.py
+++ b/tests/test_state/test_save.py
@@ -1,0 +1,118 @@
+import fcntl
+import json
+from unittest.mock import patch
+
+import pytest
+
+from cog.state import JsonFileStateCache
+
+from .conftest import make_item
+
+
+def test_save_writes_file_and_creates_parent_dir(tmp_path):
+    path = tmp_path / "nested" / "dir" / "state.json"
+    cache = JsonFileStateCache(path)
+    cache.save()
+    assert path.exists()
+
+
+def test_save_json_shape(tmp_path):
+    path = tmp_path / "state.json"
+    cache = JsonFileStateCache(path)
+    item = make_item(item_id="1")
+    cache.mark_processed(item, outcome="success")
+    deferred = make_item(item_id="2")
+    cache.mark_deferred(deferred, reason="blocker", blockers=["3"])
+    cache.save()
+
+    data = json.loads(path.read_text())
+    assert data["schema_version"] == 1
+    assert len(data["processed_items"]) == 1
+    assert len(data["deferred_items"]) == 1
+    assert data["last_run"] is not None
+
+
+def test_save_sorted_and_indented(tmp_path):
+    path = tmp_path / "state.json"
+    cache = JsonFileStateCache(path)
+    # Add items out of order
+    cache.mark_processed(make_item(item_id="20"), outcome="success")
+    cache.mark_processed(make_item(item_id="5"), outcome="noop")
+    cache.save()
+
+    text = path.read_text()
+    # Indented (not compact)
+    assert "\n" in text
+    data = json.loads(text)
+    ids = [r["item_id"] for r in data["processed_items"]]
+    assert ids == sorted(ids)
+
+
+def test_save_acquires_flock(tmp_path):
+    path = tmp_path / "state.json"
+    cache = JsonFileStateCache(path)
+    with patch("fcntl.flock") as mock_flock:
+        cache.save()
+    mock_flock.assert_called_once()
+    args = mock_flock.call_args[0]
+    assert args[1] == fcntl.LOCK_EX
+
+
+def test_save_tempfile_and_atomic_rename(tmp_path):
+    path = tmp_path / "state.json"
+    cache = JsonFileStateCache(path)
+    with patch("os.replace") as mock_replace:
+        cache.save()
+    mock_replace.assert_called_once()
+    dest = mock_replace.call_args[0][1]
+    assert dest == path
+
+
+def test_save_tempfile_cleanup_on_rename_failure(tmp_path):
+    path = tmp_path / "state.json"
+    cache = JsonFileStateCache(path)
+    with patch("os.replace", side_effect=OSError("disk full")):
+        with pytest.raises(OSError, match="disk full"):
+            cache.save()
+    # No .tmp files should linger
+    tmp_files = list(tmp_path.glob("*.json.tmp"))
+    assert tmp_files == []
+
+
+def test_save_raises_on_permission_denied(tmp_path):
+    path = tmp_path / "state.json"
+    cache = JsonFileStateCache(path)
+    # Make parent dir read-only so mkstemp fails
+    tmp_path.chmod(0o555)
+    try:
+        with pytest.raises(OSError):
+            cache.save()
+    finally:
+        tmp_path.chmod(0o755)
+
+
+def test_save_updates_last_run_timestamp(tmp_path):
+    path = tmp_path / "state.json"
+    cache = JsonFileStateCache(path)
+    assert cache._last_run is None
+    cache.save()
+    assert cache._last_run is not None
+    data = json.loads(path.read_text())
+    assert data["last_run"] is not None
+
+
+def test_load_after_save_roundtrip(tmp_path):
+    path = tmp_path / "state.json"
+    cache = JsonFileStateCache(path)
+    item1 = make_item(item_id="1")
+    item2 = make_item(item_id="2")
+    cache.mark_processed(item1, outcome="success")
+    cache.mark_deferred(item2, reason="blocker", blockers=["3", "4"])
+    cache.save()
+
+    cache2 = JsonFileStateCache(path)
+    cache2.load()
+    assert not cache2.was_corrupt()
+    assert cache2.is_processed(item1)
+    assert cache2.is_deferred(item2)
+    assert cache2._last_run is not None

--- a/tests/test_state/test_serialization.py
+++ b/tests/test_state/test_serialization.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+
+from .conftest import make_item
+
+
+def test_processed_record_json_shape(cache):
+    item = make_item()
+    cache.mark_processed(item, outcome="success")
+    data = cache._serialize()
+    rec = data["processed_items"][0]
+    assert set(rec.keys()) == {"tracker_id", "item_id", "outcome", "ts"}
+    assert rec["tracker_id"] == item.tracker_id
+    assert rec["item_id"] == item.item_id
+    assert rec["outcome"] == "success"
+    assert isinstance(rec["ts"], str)
+
+
+def test_deferred_record_json_shape(cache):
+    item = make_item()
+    cache.mark_deferred(item, reason="blocker", blockers=["10", "11"])
+    data = cache._serialize()
+    rec = data["deferred_items"][0]
+    assert set(rec.keys()) == {"tracker_id", "item_id", "reason", "blockers", "ts"}
+    assert rec["reason"] == "blocker"
+    assert rec["blockers"] == ["10", "11"]
+
+
+def test_ts_isoformat_utc_aware(cache):
+    """Timestamps survive a round-trip through isoformat / fromisoformat."""
+    item = make_item()
+    cache.mark_processed(item, outcome="success")
+    data = cache._serialize()
+    ts_str = data["processed_items"][0]["ts"]
+    recovered = datetime.fromisoformat(ts_str)
+    assert recovered.tzinfo is not None
+    assert recovered.utcoffset().total_seconds() == 0


### PR DESCRIPTION
## Summary

122 tests pass (3 skipped, docker-only), ruff and mypy both clean.

## Closes

Closes #8

## Test plan


- [ ] Instantiate `JsonFileStateCache` pointing at a nonexistent path, call `load()` — confirm `was_corrupt()` is `False` and `is_empty()` is `True`
- [ ] Write a valid `schema_version: 1` state file manually, call `load()` — confirm `is_processed` and `is_deferred` return `True` for the stored items
- [ ] Write a corrupt JSON file (e.g., `"garbage"`), call `load()` — confirm `was_corrupt()` is `True`, state is empty, and a warning appears on stderr
- [ ] Write a file with `schema_version: 2`, call `load()` — same corrupt behavior as above
- [ ] Call `mark_processed(item, "success")` then `is_processed(item)` — returns `True`
- [ ] Call `mark_processed(item)`, then construct a new `Item` with the same IDs but `updated_at` advanced by 1 hour, call `is_processed()` — returns `False` (revival rule)
- [ ] Call `mark_deferred(item, "blocker", ["10", "11"])`, verify `is_deferred()` is `True`, then `clear_deferral()` and verify `False`
- [ ] Same `item_id` in two different `tracker_id` values — confirm they are tracked independently
- [ ] Call `save()` on a cache with processed + deferred items; confirm file exists, is valid JSON with `schema_version: 1`, `processed_items` array sorted by `(tracker_id, item_id)`, `deferred_items` array, and non-null `last_run`
- [ ] Call `save()` to a path where the parent directory doesn't exist — confirm the directory is created and the file is written
- [ ] Make the state directory read-only and call `save()` — confirm an `OSError` is raised (not silently swallowed)
- [ ] Call `save()` then construct a second `JsonFileStateCache` from the same path, call `load()`, verify all records round-trip correctly including `last_run`
- [ ] Mock `fcntl.flock` and call `save()` — verify it was called with `LOCK_EX`
- [ ] Mock `os.replace` to raise `OSError`, call `save()` — verify no `.json.tmp` file is left behind
- [ ] `recover_from_remote`: mock tracker returning 3 items, host returning PRs for 2 of them — confirm 2 are marked processed, 1 is not
- [ ] `recover_from_remote`: mock one `get_open_prs_mentioning_item` call to raise — confirm the other items are still recovered and a warning appears on stderr
- [ ] `recover_from_remote` called twice — confirm idempotent (no duplicates, same 2 records)
- [ ] `recover_from_remote`: verify `list_by_label` is called with the exact `queue_label` argument and `assignee="@me"`

---
🤖 Generated by [ralph](https://github.com/jessiepuls/ralph). Iteration cost: $2.3.