### PR TITLE
Run artifacts: telemetry JSONL + markdown report per run (#9)

### DIFF
--- a/src/cog/core/__init__.py
+++ b/src/cog/core/__init__.py
@@ -10,6 +10,7 @@ from cog.core.errors import (
 from cog.core.host import GitHost, PullRequest
 from cog.core.item import Comment, Item
 from cog.core.outcomes import Outcome, StageResult
+from cog.core.reports import ReportWriter
 from cog.core.runner import (
     AgentRunner,
     AssistantTextEvent,
@@ -34,6 +35,7 @@ __all__ = [
     "Item",
     "Outcome",
     "PullRequest",
+    "ReportWriter",
     "ResultEvent",
     "RunEvent",
     "RunResult",

--- a/src/cog/core/context.py
+++ b/src/cog/core/context.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from cog.core.item import Item
 from cog.core.state import StateCache
+
+if TYPE_CHECKING:
+    from cog.telemetry import TelemetryWriter
 
 
 @dataclass
@@ -13,3 +19,4 @@ class ExecutionContext:
     headless: bool
     item: Item | None = None
     work_branch: str | None = None
+    telemetry: TelemetryWriter | None = None

--- a/src/cog/core/reports.py
+++ b/src/cog/core/reports.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from typing import Literal, Protocol
+
+from cog.core.context import ExecutionContext
+from cog.core.outcomes import StageResult
+
+
+class ReportWriter(Protocol):
+    """Writes a markdown report for one iteration. Returns the written path, or None if
+    the workflow chose not to write one."""
+
+    async def write(
+        self,
+        ctx: ExecutionContext,
+        results: list[StageResult],
+        outcome: Literal["success", "noop", "error"],
+        *,
+        error: Exception | None = None,
+    ) -> Path | None: ...

--- a/src/cog/core/workflow.py
+++ b/src/cog/core/workflow.py
@@ -1,6 +1,7 @@
 import time
 from abc import ABC, abstractmethod
-from typing import ClassVar
+from pathlib import Path
+from typing import ClassVar, Literal
 
 from cog.core.context import ExecutionContext
 from cog.core.errors import StageError
@@ -42,6 +43,18 @@ class Workflow(ABC):
         self, ctx: ExecutionContext, error: Exception, results: list[StageResult]
     ) -> None:
         return
+
+    async def write_report(
+        self,
+        ctx: ExecutionContext,
+        results: list[StageResult],
+        outcome: Literal["success", "noop", "error"],
+        *,
+        error: Exception | None = None,
+    ) -> Path | None:
+        """Default: no report. Workflows override to write a markdown file to
+        project_state_dir(ctx.project_dir) / 'reports' / '<ts>-<workflow>-<item>.md'."""
+        return None
 
 
 class StageExecutor:

--- a/src/cog/state_paths.py
+++ b/src/cog/state_paths.py
@@ -1,0 +1,17 @@
+import os
+import re
+from pathlib import Path
+
+
+def project_slug(project_dir: Path) -> str:
+    """lowercase basename; non-[a-z0-9_.-] replaced with '-'. Empty → 'project'."""
+    name = project_dir.name.lower()
+    slug = re.sub(r"[^a-z0-9_.-]", "-", name)
+    return slug or "project"
+
+
+def project_state_dir(project_dir: Path) -> Path:
+    """~/.local/state/cog/<slug>/ respecting XDG_STATE_HOME."""
+    base_str = os.environ.get("XDG_STATE_HOME")
+    base = Path(base_str) if base_str else Path.home() / ".local" / "state"
+    return base / "cog" / project_slug(project_dir)

--- a/src/cog/telemetry.py
+++ b/src/cog/telemetry.py
@@ -84,9 +84,8 @@ class TelemetryRecord:
 
 
 class TelemetryWriter:
-    def __init__(self, state_dir: Path, *, project: str) -> None:
+    def __init__(self, state_dir: Path) -> None:
         self._path = state_dir / "runs.jsonl"
-        self._project = project
 
     async def write(self, record: TelemetryRecord) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/cog/telemetry.py
+++ b/src/cog/telemetry.py
@@ -1,0 +1,104 @@
+import asyncio
+import fcntl
+import importlib.metadata
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+from cog.core.item import Item
+from cog.core.outcomes import StageResult
+
+TelemetryOutcome = Literal["success", "no-op", "error", "push-failed", "deferred-by-blocker"]
+
+
+@dataclass(frozen=True)
+class StageTelemetry:
+    stage: str
+    model: str
+    duration_s: float
+    cost_usd: float
+    exit_status: int
+    commits: int
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+    @classmethod
+    def from_stage_result(cls, r: StageResult) -> "StageTelemetry":
+        return cls(
+            stage=r.stage.name,
+            model=r.stage.model,
+            duration_s=r.duration_seconds,
+            cost_usd=r.cost_usd,
+            exit_status=r.exit_status,
+            commits=r.commits_created,
+        )
+
+
+@dataclass(frozen=True)
+class TelemetryRecord:
+    ts: str
+    cog_version: str
+    project: str
+    workflow: str
+    item: int
+    outcome: TelemetryOutcome
+    branch: str | None
+    pr_url: str | None
+    duration_seconds: float
+    stages: tuple[StageTelemetry, ...]
+    total_cost_usd: float
+    error: str | None
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        project: str,
+        workflow: str,
+        item: Item,
+        outcome: TelemetryOutcome,
+        results: list[StageResult],
+        branch: str | None = None,
+        pr_url: str | None = None,
+        duration_seconds: float,
+        error: str | None = None,
+    ) -> "TelemetryRecord":
+        return cls(
+            ts=datetime.now(UTC).isoformat(),
+            cog_version=importlib.metadata.version("cog"),
+            project=project,
+            workflow=workflow,
+            item=int(item.item_id),
+            outcome=outcome,
+            branch=branch,
+            pr_url=pr_url,
+            duration_seconds=duration_seconds,
+            stages=tuple(StageTelemetry.from_stage_result(r) for r in results),
+            total_cost_usd=sum(r.cost_usd for r in results),
+            error=error,
+        )
+
+
+class TelemetryWriter:
+    def __init__(self, state_dir: Path, *, project: str) -> None:
+        self._path = state_dir / "runs.jsonl"
+        self._project = project
+
+    async def write(self, record: TelemetryRecord) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(asdict(record)) + "\n"
+        try:
+            await asyncio.to_thread(self._append, line)
+        except OSError as e:
+            print(f"warning: telemetry write failed: {e}", file=sys.stderr)
+
+    def _append(self, line: str) -> None:
+        with self._path.open("a") as f:
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            f.write(line)
+            f.flush()
+            os.fsync(f.fileno())

--- a/tests/test_state_paths.py
+++ b/tests/test_state_paths.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from cog.state_paths import project_slug, project_state_dir
+
+
+def _p(name: str) -> Path:
+    """Build a Path whose .name is exactly `name` by using a fake parent."""
+    return Path("/fake") / name
+
+
+def test_slug_lowercases():
+    assert project_slug(_p("MyProject")) == "myproject"
+
+
+def test_slug_replaces_special_chars():
+    # "My Project!" → "my-project-"
+    assert project_slug(_p("My Project!")) == "my-project-"
+
+
+def test_slug_multiple_special_chars():
+    # Characters a, @, b, #, c → a-b-c
+    assert project_slug(_p("a@b#c")) == "a-b-c"
+
+
+def test_slug_empty_fallback():
+    # Path("/").name == "" → fallback to "project"
+    assert project_slug(Path("/")) == "project"
+
+
+def test_slug_nonempty_dashes_not_fallback():
+    # "---" is non-empty after regex sub → preserved as-is (no fallback)
+    assert project_slug(_p("!!!")) == "---"
+
+
+def test_state_dir_default(monkeypatch):
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    result = project_state_dir(_p("my-project"))
+    assert result == Path.home() / ".local" / "state" / "cog" / "my-project"
+
+
+def test_state_dir_respects_xdg_state_home(tmp_path, monkeypatch):
+    custom_base = str(tmp_path / "custom_state")
+    monkeypatch.setenv("XDG_STATE_HOME", custom_base)
+    result = project_state_dir(_p("my-project"))
+    assert result == Path(custom_base) / "cog" / "my-project"

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,106 @@
+"""Tests for TelemetryWriter behavior."""
+
+import fcntl
+import json
+from unittest.mock import patch
+
+from cog.telemetry import TelemetryOutcome, TelemetryRecord, TelemetryWriter
+
+
+def _make_record(outcome: TelemetryOutcome = "success") -> TelemetryRecord:
+    return TelemetryRecord(
+        ts="2024-01-01T00:00:00+00:00",
+        cog_version="0.1.0",
+        project="test-proj",
+        workflow="ralph",
+        item=42,
+        outcome=outcome,
+        branch="some-branch",
+        pr_url=None,
+        duration_seconds=1.5,
+        stages=(),
+        total_cost_usd=0.0,
+        error=None,
+    )
+
+
+async def test_writer_creates_file_on_first_write(tmp_path):
+    state_dir = tmp_path / "state"
+    writer = TelemetryWriter(state_dir, project="proj")
+    assert not (state_dir / "runs.jsonl").exists()
+
+    await writer.write(_make_record())
+
+    assert (state_dir / "runs.jsonl").exists()
+
+
+async def test_writer_appends_as_separate_lines(tmp_path):
+    state_dir = tmp_path / "state"
+    writer = TelemetryWriter(state_dir, project="proj")
+
+    await writer.write(_make_record("success"))
+    await writer.write(_make_record("no-op"))
+
+    lines = (state_dir / "runs.jsonl").read_text().splitlines()
+    assert len(lines) == 2
+
+
+async def test_writer_json_shape_round_trips(tmp_path):
+    state_dir = tmp_path / "state"
+    writer = TelemetryWriter(state_dir, project="proj")
+    record = _make_record()
+
+    await writer.write(record)
+
+    line = (state_dir / "runs.jsonl").read_text().strip()
+    data = json.loads(line)
+    assert data["ts"] == record.ts
+    assert data["project"] == "test-proj"
+    assert data["workflow"] == "ralph"
+    assert data["item"] == 42
+    assert data["outcome"] == "success"
+    assert data["branch"] == "some-branch"
+    assert data["pr_url"] is None
+    assert data["duration_seconds"] == 1.5
+    assert data["stages"] == []
+    assert data["total_cost_usd"] == 0.0
+    assert data["error"] is None
+
+
+async def test_writer_disk_error_warns_no_raise(tmp_path, capsys):
+    state_dir = tmp_path / "state"
+    writer = TelemetryWriter(state_dir, project="proj")
+
+    with patch.object(writer, "_append", side_effect=OSError("disk full")):
+        # Should not raise
+        await writer.write(_make_record())
+
+    captured = capsys.readouterr()
+    assert "telemetry write failed" in captured.err
+
+
+async def test_writer_acquires_flock(tmp_path):
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    writer = TelemetryWriter(state_dir, project="proj")
+    # Pre-create the file so _append opens it
+    (state_dir / "runs.jsonl").touch()
+
+    with patch("fcntl.flock") as mock_flock:
+        writer._append('{"x": 1}\n')
+
+    mock_flock.assert_called_once()
+    args = mock_flock.call_args[0]
+    assert args[1] == fcntl.LOCK_EX
+
+
+async def test_writer_fsyncs(tmp_path):
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    writer = TelemetryWriter(state_dir, project="proj")
+    (state_dir / "runs.jsonl").touch()
+
+    with patch("os.fsync") as mock_fsync:
+        writer._append('{"x": 1}\n')
+
+    mock_fsync.assert_called_once()

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -26,7 +26,7 @@ def _make_record(outcome: TelemetryOutcome = "success") -> TelemetryRecord:
 
 async def test_writer_creates_file_on_first_write(tmp_path):
     state_dir = tmp_path / "state"
-    writer = TelemetryWriter(state_dir, project="proj")
+    writer = TelemetryWriter(state_dir)
     assert not (state_dir / "runs.jsonl").exists()
 
     await writer.write(_make_record())
@@ -36,7 +36,7 @@ async def test_writer_creates_file_on_first_write(tmp_path):
 
 async def test_writer_appends_as_separate_lines(tmp_path):
     state_dir = tmp_path / "state"
-    writer = TelemetryWriter(state_dir, project="proj")
+    writer = TelemetryWriter(state_dir)
 
     await writer.write(_make_record("success"))
     await writer.write(_make_record("no-op"))
@@ -47,7 +47,7 @@ async def test_writer_appends_as_separate_lines(tmp_path):
 
 async def test_writer_json_shape_round_trips(tmp_path):
     state_dir = tmp_path / "state"
-    writer = TelemetryWriter(state_dir, project="proj")
+    writer = TelemetryWriter(state_dir)
     record = _make_record()
 
     await writer.write(record)
@@ -69,7 +69,7 @@ async def test_writer_json_shape_round_trips(tmp_path):
 
 async def test_writer_disk_error_warns_no_raise(tmp_path, capsys):
     state_dir = tmp_path / "state"
-    writer = TelemetryWriter(state_dir, project="proj")
+    writer = TelemetryWriter(state_dir)
 
     with patch.object(writer, "_append", side_effect=OSError("disk full")):
         # Should not raise
@@ -82,7 +82,7 @@ async def test_writer_disk_error_warns_no_raise(tmp_path, capsys):
 async def test_writer_acquires_flock(tmp_path):
     state_dir = tmp_path / "state"
     state_dir.mkdir(parents=True)
-    writer = TelemetryWriter(state_dir, project="proj")
+    writer = TelemetryWriter(state_dir)
     # Pre-create the file so _append opens it
     (state_dir / "runs.jsonl").touch()
 
@@ -97,7 +97,7 @@ async def test_writer_acquires_flock(tmp_path):
 async def test_writer_fsyncs(tmp_path):
     state_dir = tmp_path / "state"
     state_dir.mkdir(parents=True)
-    writer = TelemetryWriter(state_dir, project="proj")
+    writer = TelemetryWriter(state_dir)
     (state_dir / "runs.jsonl").touch()
 
     with patch("os.fsync") as mock_fsync:

--- a/tests/test_telemetry_record.py
+++ b/tests/test_telemetry_record.py
@@ -1,0 +1,164 @@
+"""Tests for TelemetryRecord and StageTelemetry construction."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from cog.core.item import Item
+from cog.core.outcomes import StageResult
+from cog.core.stage import Stage
+from cog.telemetry import StageTelemetry, TelemetryRecord
+from tests.fakes import EchoRunner
+
+
+def _make_item(item_id: str = "42") -> Item:
+    return Item(
+        tracker_id="github/owner/repo",
+        item_id=item_id,
+        title="Test issue",
+        body="",
+        labels=(),
+        comments=(),
+        updated_at=datetime.now(UTC),
+        url="https://github.com/owner/repo/issues/42",
+    )
+
+
+def _make_stage(name: str = "build") -> Stage:
+    return Stage(
+        name=name,
+        prompt_source=lambda _: "prompt",
+        model="claude-opus-4-6",
+        runner=EchoRunner(),
+    )
+
+
+def _make_stage_result(
+    stage_name: str = "build",
+    cost_usd: float = 0.01,
+    exit_status: int = 0,
+    commits: int = 1,
+) -> StageResult:
+    return StageResult(
+        stage=_make_stage(stage_name),
+        duration_seconds=10.0,
+        cost_usd=cost_usd,
+        exit_status=exit_status,
+        final_message="done",
+        stream_json_path=Path("/dev/null"),
+        commits_created=commits,
+    )
+
+
+def test_build_populates_every_field():
+    item = _make_item()
+    results = [_make_stage_result()]
+
+    record = TelemetryRecord.build(
+        project="my-proj",
+        workflow="ralph",
+        item=item,
+        outcome="success",
+        results=results,
+        branch="feat/branch",
+        pr_url="https://github.com/owner/repo/pull/1",
+        duration_seconds=15.0,
+        error=None,
+    )
+
+    assert record.project == "my-proj"
+    assert record.workflow == "ralph"
+    assert record.item == 42
+    assert record.outcome == "success"
+    assert record.branch == "feat/branch"
+    assert record.pr_url == "https://github.com/owner/repo/pull/1"
+    assert record.duration_seconds == 15.0
+    assert record.error is None
+    assert len(record.stages) == 1
+    assert record.cog_version != ""
+    assert record.ts != ""
+
+
+def test_total_cost_sums_stages():
+    results = [
+        _make_stage_result("s1", cost_usd=0.01),
+        _make_stage_result("s2", cost_usd=0.02),
+        _make_stage_result("s3", cost_usd=0.03),
+    ]
+    record = TelemetryRecord.build(
+        project="p",
+        workflow="w",
+        item=_make_item(),
+        outcome="success",
+        results=results,
+        duration_seconds=1.0,
+    )
+    assert abs(record.total_cost_usd - 0.06) < 1e-9
+
+
+def test_empty_stages_zero_cost():
+    record = TelemetryRecord.build(
+        project="p",
+        workflow="w",
+        item=_make_item(),
+        outcome="success",
+        results=[],
+        duration_seconds=0.5,
+    )
+    assert record.total_cost_usd == 0.0
+    assert record.stages == ()
+
+
+def test_item_id_coerced_to_int():
+    item = _make_item(item_id="42")
+    record = TelemetryRecord.build(
+        project="p",
+        workflow="w",
+        item=item,
+        outcome="success",
+        results=[],
+        duration_seconds=1.0,
+    )
+    assert record.item == 42
+    assert isinstance(record.item, int)
+
+
+def test_timestamp_is_utc_aware_iso():
+    record = TelemetryRecord.build(
+        project="p",
+        workflow="w",
+        item=_make_item(),
+        outcome="success",
+        results=[],
+        duration_seconds=1.0,
+    )
+    dt = datetime.fromisoformat(record.ts)
+    assert dt.tzinfo is not None
+    assert dt.tzinfo.utcoffset(dt).total_seconds() == 0  # type: ignore[union-attr]
+
+
+def test_stage_telemetry_from_result_mapping():
+    result = _make_stage_result("build", cost_usd=0.05, exit_status=0, commits=2)
+    st = StageTelemetry.from_stage_result(result)
+
+    assert st.stage == "build"
+    assert st.model == "claude-opus-4-6"
+    assert st.duration_s == 10.0
+    assert st.cost_usd == 0.05
+    assert st.exit_status == 0
+    assert st.commits == 2
+    assert st.input_tokens == 0
+    assert st.output_tokens == 0
+
+
+def test_outcome_literal_accepted():
+    # All valid TelemetryOutcome values are accepted at runtime
+    for outcome in ("success", "no-op", "error", "push-failed", "deferred-by-blocker"):
+        record = TelemetryRecord.build(
+            project="p",
+            workflow="w",
+            item=_make_item(),
+            outcome=outcome,  # type: ignore[arg-type]
+            results=[],
+            duration_seconds=1.0,
+        )
+        assert record.outcome == outcome


### PR DESCRIPTION
## Summary



## Closes

Closes #9

## Test plan


- [ ] `uv run pytest tests/test_state_paths.py` — 7 tests pass, including slug lowercasing, special-char replacement, empty-name fallback to `"project"`, `"!!!"` → `"---"` (no fallback), and XDG_STATE_HOME override
- [ ] `uv run pytest tests/test_telemetry.py` — 6 tests pass: file created on first write, two writes produce two JSONL lines, JSON round-trip has all expected fields, disk OSError warns to stderr without raising, `fcntl.flock(LOCK_EX)` called, `os.fsync` called
- [ ] `uv run pytest tests/test_telemetry_record.py` — 7 tests pass: all fields populated by `.build()`, cost summed across stages, empty stages → 0.0 cost, `item_id="42"` coerced to `int`, timestamp parses as UTC-aware ISO 8601, `StageTelemetry.from_stage_result` maps fields correctly, all five outcome literal values accepted
- [ ] Manually construct a `TelemetryWriter` against a temp dir, call `write()` twice, confirm `runs.jsonl` has two lines, each valid JSON with expected shape
- [ ] Confirm that `ExecutionContext` can be constructed without `telemetry` (defaults to `None`) — existing tests in `test_stage_executor.py` still pass unchanged
- [ ] Confirm `Workflow.write_report(...)` returns `None` by default — `DummyWorkflow` inherits the no-op without override
- [ ] `uv run mypy src` exits 0 — TYPE_CHECKING guard on `TelemetryWriter` import in `context.py` avoids the circular-import chain through `stage.py`
- [ ] `uv run ruff check . && uv run ruff format --check .` both exit 0

---
🤖 Generated by [ralph](https://github.com/jessiepuls/ralph). Iteration cost: $1.88.