### PR TITLE
cog ralph --headless raises NotImplementedError — wire.py stub not replaced (#39)

### DIFF
--- a/src/cog/ui/wire.py
+++ b/src/cog/ui/wire.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from cog.core.context import ExecutionContext
 from cog.core.preflight import PreflightResult, print_results, run_checks
 from cog.core.workflow import Workflow
+from cog.headless import run_headless
 from cog.runners.claude_cli import ClaudeCliRunner
 from cog.runners.docker_sandbox import DockerSandbox
 from cog.state import JsonFileStateCache
@@ -66,13 +67,8 @@ async def build_and_run(
         ctx.item = await tracker.get(str(item_id))
 
     if headless:
-        return await _run_headless(workflow, ctx)
+        return await run_headless(workflow, ctx)
 
     from cog.ui.app import run_textual
 
     return await run_textual(workflow, ctx, loop=loop)
-
-
-async def _run_headless(workflow: Workflow, ctx: ExecutionContext) -> int:
-    """Headless run stub. Full implementation in #11."""
-    raise NotImplementedError("Headless mode implemented in #11")

--- a/tests/test_ui/test_wire.py
+++ b/tests/test_ui/test_wire.py
@@ -115,6 +115,38 @@ async def test_build_and_run_preselects_item_when_item_id_given(tmp_path: Path) 
     assert captured_ctx["ctx"].item == fake_item
 
 
+async def test_build_and_run_headless_invokes_run_headless(tmp_path: Path) -> None:
+    """--headless path dispatches to cog.headless.run_headless."""
+    from cog.ui.wire import build_and_run
+
+    run_headless_mock = AsyncMock(return_value=0)
+    cache_mock = MagicMock()
+    cache_mock.was_corrupt.return_value = False
+    cache_mock.is_empty.return_value = False
+
+    with (
+        patch("cog.ui.wire.run_checks", new=AsyncMock(return_value=[])),
+        patch("cog.ui.wire.print_results"),
+        patch("cog.ui.wire.DockerSandbox", return_value=MagicMock()),
+        patch("cog.ui.wire.ClaudeCliRunner", return_value=MagicMock()),
+        patch("cog.ui.wire.GitHubIssueTracker", return_value=MagicMock()),
+        patch("cog.ui.wire.JsonFileStateCache", return_value=cache_mock),
+        patch("cog.ui.wire.TelemetryWriter"),
+        patch("cog.ui.wire.project_state_dir", return_value=tmp_path / ".cog"),
+        patch("cog.ui.wire.run_headless", run_headless_mock),
+    ):
+        code = await build_and_run(
+            _FakeWorkflow,  # type: ignore[arg-type]
+            tmp_path,
+            item_id=None,
+            loop=False,
+            headless=True,
+        )
+
+    assert code == 0
+    run_headless_mock.assert_awaited_once()
+
+
 async def test_build_and_run_wires_full_stack(tmp_path: Path) -> None:
     """Verify ctx has state_cache set and run_textual is invoked."""
     from cog.ui.wire import build_and_run


### PR DESCRIPTION
## Summary

Done. Here's a summary of what was changed:

**`src/cog/ui/wire.py`**
- Added `from cog.headless import run_headless` import
- Replaced `return await _run_headless(workflow, ctx)` with `return await run_headless(workflow, ctx)`
- Deleted the `_run_headless` stub function

**`tests/test_ui/test_wire.py`**
- Added `test_build_and_run_headless_invokes_run_headless` which patches `cog.ui.wire.run_headless` and asserts it's awaited when `headless=True`

All 5 tests pass, mypy exits 0, ruff check and format --check exit 0.

## Closes

Closes #39

## Test plan

- [ ] Run `uv run pytest tests/test_ui/test_wire.py` — all 5 tests should pass, including the new `test_build_and_run_headless_invokes_run_headless`
- [ ] Run `uv run mypy src` — should exit 0
- [ ] Run `uv run ruff check . && uv run ruff format --check .` — should exit 0
- [ ] Manual: `uv run cog ralph --headless` in a repo with an `agent-ready` issue — should no longer raise `NotImplementedError`; should proceed into `run_headless` and attempt `StageExecutor().run(...)`
- [ ] Confirm the `supports_headless = False` guard still works: use a workflow class with `supports_headless = False` and verify exit code 2 with the appropriate stderr message

---
🤖 Generated by [ralph](https://github.com/jessiepuls/ralph). Iteration cost: $0.83.