### PR TITLE
RalphWorkflow.content_widget_cls not set — cog ralph (TUI) crashes on RunScreen mount (#38)

### DIFF
--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -23,6 +23,7 @@ from cog.core.tracker import IssueTracker
 from cog.core.workflow import Workflow
 from cog.state_paths import project_slug, project_state_dir
 from cog.telemetry import TelemetryRecord
+from cog.ui.widgets.log_pane import LogPaneWidget
 
 _PRIORITY_RE = re.compile(r"^p(\d+)$")
 _SLUG_RE = re.compile(r"[^a-z0-9-]+")
@@ -90,6 +91,7 @@ class RalphWorkflow(Workflow):
     name: ClassVar[str] = "ralph"
     queue_label: ClassVar[str] = "agent-ready"
     supports_headless: ClassVar[bool] = True
+    content_widget_cls = LogPaneWidget
     preflight_checks = RALPH_CHECKS
 
     def __init__(

--- a/tests/test_workflows/test_ralph_lifecycle.py
+++ b/tests/test_workflows/test_ralph_lifecycle.py
@@ -49,6 +49,12 @@ def test_class_attributes():
     assert RalphWorkflow.preflight_checks is RALPH_CHECKS
 
 
+def test_content_widget_cls_is_log_pane_widget():
+    from cog.ui.widgets.log_pane import LogPaneWidget
+
+    assert RalphWorkflow.content_widget_cls is LogPaneWidget
+
+
 async def test_classify_outcome_success_when_any_commits(tmp_path):
     wf = RalphWorkflow(EchoRunner(), AsyncMock(spec=IssueTracker))
     results = [_make_stage_result(2)]


### PR DESCRIPTION
## Summary

Committed. All tests and linters pass.

## Closes

Closes #38

## Test plan

- [ ] Run `uv run pytest tests/test_workflows/test_ralph_lifecycle.py -v` — all 5 tests should pass, including `test_content_widget_cls_is_log_pane_widget`
- [ ] Run `uv run mypy src` — should exit 0 with no errors
- [ ] Run `uv run ruff check . && uv run ruff format --check .` — should exit 0
- [ ] Run `uv run cog ralph --help` — should print help without error (no import regression)
- [ ] Manual: In a repo with at least one `agent-ready` issue, run `uv run cog ralph` — should reach the RunScreen and mount `LogPaneWidget` without raising `AssertionError: RalphWorkflow.content_widget_cls must not be None`

---
🤖 Generated by cog. Iteration cost: $0.929
