### PR TITLE
RalphWorkflow dependency safety net: Blocked by / Depends on + self-healing deferral + Item.state (#15)

### DIFF
--- a/src/cog/core/item.py
+++ b/src/cog/core/item.py
@@ -17,6 +17,7 @@ class Item:
     body: str
     labels: tuple[str, ...]
     comments: tuple[Comment, ...]
+    state: str  # "open" | "closed"
     created_at: datetime
     updated_at: datetime
     url: str

--- a/src/cog/trackers/github.py
+++ b/src/cog/trackers/github.py
@@ -34,7 +34,7 @@ class GitHubIssueTracker(IssueTracker):
             "--state",
             "open",
             "--json",
-            "number,title,body,labels,createdAt,updatedAt,url",
+            "number,title,body,labels,state,createdAt,updatedAt,url",
         ]
         if assignee is not None:
             args += ["--assignee", assignee]
@@ -148,6 +148,7 @@ class GitHubIssueTracker(IssueTracker):
             body=record["body"] or "",
             labels=tuple(lbl["name"] for lbl in record.get("labels", [])),
             comments=comments,
+            state=(record.get("state") or "open").lower(),
             created_at=datetime.fromisoformat(record["createdAt"].replace("Z", "+00:00")),
             updated_at=datetime.fromisoformat(record["updatedAt"].replace("Z", "+00:00")),
             url=record["url"],

--- a/src/cog/workflows/dummy.py
+++ b/src/cog/workflows/dummy.py
@@ -24,6 +24,7 @@ class DummyWorkflow(Workflow):
             body="",
             labels=(),
             comments=(),
+            state="open",
             created_at=datetime.now(UTC),
             updated_at=datetime.now(UTC),
             url="",

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -28,6 +28,7 @@ from cog.ui.widgets.log_pane import LogPaneWidget
 _PRIORITY_RE = re.compile(r"^p(\d+)$")
 _SLUG_RE = re.compile(r"[^a-z0-9-]+")
 _COLLAPSE_RE = re.compile(r"-+")
+_BLOCKER_RE = re.compile(r"\b(?:blocked by|depends on)\s+#(\d+)", re.IGNORECASE)
 _TEST_PLAN_RE = re.compile(
     r"###\s+Test plan\s*\n(.*?)(?=\n###|\Z)",
     re.DOTALL | re.IGNORECASE,
@@ -107,19 +108,69 @@ class RalphWorkflow(Workflow):
 
     async def select_item(self, ctx: ExecutionContext) -> Item | None:
         items = await self._tracker.list_by_label("agent-ready", assignee="@me")
+        # NOTE: intentionally do NOT filter by is_deferred here — we re-scan
+        # per iteration so items whose blockers have closed become eligible again.
         eligible = [
             item
             for item in items
             if (item.tracker_id, item.item_id) not in self._processed_this_loop
             and not ctx.state_cache.is_processed(item)
-            and not ctx.state_cache.is_deferred(item)
         ]
-        if not eligible:
-            return None
         eligible.sort(key=lambda i: (_priority_tier(i), i.created_at))
-        chosen = eligible[0]
-        self._processed_this_loop.add((chosen.tracker_id, chosen.item_id))
-        return chosen
+
+        for candidate in eligible:
+            full = await self._tracker.get(candidate.item_id)
+            open_blockers = await self._find_open_blockers(full)
+            if open_blockers:
+                ctx.state_cache.mark_deferred(full, "blocker", [str(b) for b in open_blockers])
+                ctx.state_cache.save()
+                await self._write_deferred_telemetry(ctx, full, open_blockers)
+                self._processed_this_loop.add((full.tracker_id, full.item_id))
+                continue
+            if ctx.state_cache.is_deferred(full):
+                ctx.state_cache.clear_deferral(full)
+                ctx.state_cache.save()
+            self._processed_this_loop.add((full.tracker_id, full.item_id))
+            return full
+        return None
+
+    async def _find_open_blockers(self, item: Item) -> list[int]:
+        """Scan body + comments for 'blocked by #N' / 'depends on #N' references.
+        Returns item_ids of referenced blockers that are currently open, sorted."""
+        text_sources = [item.body] + [c.body for c in item.comments]
+        referenced = {
+            int(m.group(1)) for source in text_sources for m in _BLOCKER_RE.finditer(source)
+        }
+        open_blockers: list[int] = []
+        for blocker_id in sorted(referenced):
+            try:
+                blocker = await self._tracker.get(str(blocker_id))
+            except Exception:
+                continue  # ghost reference; don't defer on an item we can't fetch
+            if blocker.state == "open":
+                open_blockers.append(blocker_id)
+        return open_blockers
+
+    async def _write_deferred_telemetry(
+        self,
+        ctx: ExecutionContext,
+        item: Item,
+        open_blockers: list[int],
+    ) -> None:
+        if ctx.telemetry is None:
+            return
+        record = TelemetryRecord.build(
+            project=project_slug(ctx.project_dir),
+            workflow=self.name,
+            item=item,
+            outcome="deferred-by-blocker",
+            results=[],
+            branch=None,
+            pr_url=None,
+            duration_seconds=0.0,
+            error=f"blocked by: {', '.join(f'#{b}' for b in open_blockers)}",
+        )
+        await ctx.telemetry.write(record)
 
     async def pre_stages(self, ctx: ExecutionContext) -> None:
         assert ctx.item is not None, "RalphWorkflow.pre_stages requires ctx.item"

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -13,7 +13,7 @@ from typing import ClassVar, Literal
 import cog.git as git
 from cog.checks import RALPH_CHECKS
 from cog.core.context import ExecutionContext
-from cog.core.errors import HostError, StageError
+from cog.core.errors import HostError, StageError, TrackerError
 from cog.core.host import GitHost
 from cog.core.item import Item
 from cog.core.outcomes import Outcome, StageResult
@@ -145,7 +145,7 @@ class RalphWorkflow(Workflow):
         for blocker_id in sorted(referenced):
             try:
                 blocker = await self._tracker.get(str(blocker_id))
-            except Exception:
+            except TrackerError:
                 continue  # ghost reference; don't defer on an item we can't fetch
             if blocker.state == "open":
                 open_blockers.append(blocker_id)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -57,6 +57,7 @@ def make_item(
     body: str = "",
     labels: tuple[str, ...] = (),
     comments: tuple[Comment, ...] = (),
+    state: str = "open",
     created_at: datetime | None = None,
     updated_at: datetime | None = None,
     url: str = "https://github.com/org/repo/issues/1",
@@ -68,10 +69,17 @@ def make_item(
         body=body,
         labels=labels,
         comments=comments,
+        state=state,
         created_at=created_at or _EPOCH,
         updated_at=updated_at or _EPOCH,
         url=url,
     )
+
+
+def make_item_with_blocker_refs(refs: list[int], *, item_id: str = "1") -> Item:
+    """Construct an Item whose body contains 'blocked by #N' for each ref."""
+    body = " ".join(f"blocked by #{n}" for n in refs)
+    return make_item(item_id=item_id, body=body)
 
 
 @dataclass

--- a/tests/fixtures/gh/list_by_label_happy.json
+++ b/tests/fixtures/gh/list_by_label_happy.json
@@ -4,6 +4,7 @@
     "title": "Fix login bug",
     "body": "Users can't log in with SSO.",
     "labels": [{"name": "agent-ready", "color": "0075ca", "description": "Ready for agent"}, {"name": "bug", "color": "d73a4a", "description": "Something isn't working"}],
+    "state": "OPEN",
     "createdAt": "2026-04-01T10:00:00Z",
     "updatedAt": "2026-04-10T12:30:00Z",
     "url": "https://github.com/jessiepuls/cog/issues/10"
@@ -13,6 +14,7 @@
     "title": "Add dark mode",
     "body": "Users want a dark theme option.",
     "labels": [{"name": "agent-ready", "color": "0075ca", "description": "Ready for agent"}, {"name": "enhancement", "color": "a2eeef", "description": "New feature or request"}],
+    "state": "OPEN",
     "createdAt": "2026-04-05T08:00:00Z",
     "updatedAt": "2026-04-15T09:00:00Z",
     "url": "https://github.com/jessiepuls/cog/issues/11"
@@ -22,6 +24,7 @@
     "title": "Update dependencies",
     "body": "Several packages are out of date.",
     "labels": [{"name": "agent-ready", "color": "0075ca", "description": "Ready for agent"}],
+    "state": "OPEN",
     "createdAt": "2026-04-08T14:00:00Z",
     "updatedAt": "2026-04-17T16:45:00Z",
     "url": "https://github.com/jessiepuls/cog/issues/12"

--- a/tests/test_headless/test_run_headless.py
+++ b/tests/test_headless/test_run_headless.py
@@ -24,6 +24,7 @@ def _make_item() -> Item:
         body="",
         labels=(),
         comments=(),
+        state="open",
         created_at=now,
         updated_at=now,
         url="",

--- a/tests/test_hosts/test_github_mentioning_item.py
+++ b/tests/test_hosts/test_github_mentioning_item.py
@@ -17,6 +17,7 @@ def make_item(item_id: str) -> Item:
         body="",
         labels=(),
         comments=(),
+        state="open",
         created_at=datetime(2024, 1, 1, tzinfo=UTC),
         updated_at=datetime(2024, 1, 1, tzinfo=UTC),
         url=f"https://github.com/jessiepuls/cog/issues/{item_id}",

--- a/tests/test_stage_executor.py
+++ b/tests/test_stage_executor.py
@@ -25,6 +25,7 @@ def _make_item() -> Item:
         body="",
         labels=(),
         comments=(),
+        state="open",
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
         url="",

--- a/tests/test_state/conftest.py
+++ b/tests/test_state/conftest.py
@@ -19,6 +19,7 @@ def make_item(
         body="body",
         labels=(),
         comments=(),
+        state="open",
         created_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
         updated_at=updated_at or datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
         url="https://github.com/org/repo/issues/42",

--- a/tests/test_telemetry_record.py
+++ b/tests/test_telemetry_record.py
@@ -18,6 +18,7 @@ def _make_item(item_id: str = "42") -> Item:
         body="",
         labels=(),
         comments=(),
+        state="open",
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
         url="https://github.com/owner/repo/issues/42",

--- a/tests/test_trackers/test_github_errors.py
+++ b/tests/test_trackers/test_github_errors.py
@@ -7,7 +7,7 @@ from cog.trackers.github import GitHubIssueTracker
 from tests.fakes import FakeSubprocessRegistry
 from tests.test_trackers.conftest import register_repo
 
-LIST_FIELDS = "number,title,body,labels,createdAt,updatedAt,url"
+LIST_FIELDS = "number,title,body,labels,state,createdAt,updatedAt,url"
 LIST_ARGV = (
     "gh",
     "issue",

--- a/tests/test_trackers/test_github_list.py
+++ b/tests/test_trackers/test_github_list.py
@@ -6,7 +6,7 @@ from cog.trackers.github import GitHubIssueTracker
 from tests.fakes import FakeSubprocessRegistry
 from tests.test_trackers.conftest import load_fixture, register_repo
 
-LIST_FIELDS = "number,title,body,labels,createdAt,updatedAt,url"
+LIST_FIELDS = "number,title,body,labels,state,createdAt,updatedAt,url"
 LIST_BASE_ARGV = (
     "gh",
     "issue",
@@ -95,7 +95,25 @@ async def test_list_by_label_json_fields(
     json_idx = list(list_call).index("--json")
     field_str = list_call[json_idx + 1]
     fields = set(field_str.split(","))
-    assert fields == {"number", "title", "body", "labels", "createdAt", "updatedAt", "url"}
+    assert fields == {"number", "title", "body", "labels", "state", "createdAt", "updatedAt", "url"}
+
+
+async def test_list_by_label_json_field_list_includes_state(
+    registry: FakeSubprocessRegistry, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    register_repo(registry)
+    registry.expect(LIST_BASE_ARGV, stdout=load_fixture("list_by_label_happy.json"))
+    items = await list_by_label(registry, tmp_path, monkeypatch=monkeypatch)
+    assert all(item.state == "open" for item in items)
+
+
+async def test_list_by_label_state_lowercased(
+    registry: FakeSubprocessRegistry, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    register_repo(registry)
+    registry.expect(LIST_BASE_ARGV, stdout=load_fixture("list_by_label_happy.json"))
+    items = await list_by_label(registry, tmp_path, monkeypatch=monkeypatch)
+    assert all(item.state == item.state.lower() for item in items)
 
 
 async def test_list_by_label_label_normalization(

--- a/tests/test_trackers/test_github_mutations.py
+++ b/tests/test_trackers/test_github_mutations.py
@@ -14,6 +14,7 @@ DUMMY_ITEM = Item(
     body="Body text",
     labels=(),
     comments=(),
+    state="open",
     created_at=datetime(2026, 4, 18, tzinfo=UTC),
     updated_at=datetime(2026, 4, 18, tzinfo=UTC),
     url="https://github.com/jessiepuls/cog/issues/42",

--- a/tests/test_trackers/test_github_tracker_id.py
+++ b/tests/test_trackers/test_github_tracker_id.py
@@ -6,7 +6,7 @@ from cog.trackers.github import GitHubIssueTracker
 from tests.fakes import FakeSubprocessRegistry
 from tests.test_trackers.conftest import register_repo
 
-LIST_FIELDS = "number,title,body,labels,createdAt,updatedAt,url"
+LIST_FIELDS = "number,title,body,labels,state,createdAt,updatedAt,url"
 LIST_ARGV = (
     "gh",
     "issue",

--- a/tests/test_ui/test_main_menu.py
+++ b/tests/test_ui/test_main_menu.py
@@ -21,6 +21,7 @@ def _item(n: int) -> Item:
         body="",
         labels=(),
         comments=(),
+        state="open",
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
         url="",

--- a/tests/test_ui/test_run_screen.py
+++ b/tests/test_ui/test_run_screen.py
@@ -24,6 +24,7 @@ def _item() -> Item:
         body="",
         labels=(),
         comments=(),
+        state="open",
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
         url="",

--- a/tests/test_ui/test_wire.py
+++ b/tests/test_ui/test_wire.py
@@ -73,6 +73,7 @@ async def test_build_and_run_preselects_item_when_item_id_given(tmp_path: Path) 
         body="",
         labels=(),
         comments=(),
+        state="open",
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
         url="",

--- a/tests/test_workflow_lifecycle.py
+++ b/tests/test_workflow_lifecycle.py
@@ -19,6 +19,7 @@ def _make_item() -> Item:
         body="",
         labels=(),
         comments=(),
+        state="open",
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
         url="",

--- a/tests/test_workflows/test_ralph_dependencies.py
+++ b/tests/test_workflows/test_ralph_dependencies.py
@@ -1,0 +1,385 @@
+"""Tests for RalphWorkflow dependency safety net (#15)."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from cog.core.errors import TrackerError
+from cog.core.item import Comment
+from cog.core.tracker import IssueTracker
+from cog.workflows.ralph import _BLOCKER_RE, RalphWorkflow
+from tests.fakes import InMemoryStateCache, make_item, make_item_with_blocker_refs
+
+
+def _make_workflow() -> RalphWorkflow:
+    return RalphWorkflow(runner=AsyncMock(), tracker=AsyncMock(spec=IssueTracker))
+
+
+def _make_ctx(cache: InMemoryStateCache | None = None, *, telemetry=None):
+    from cog.core.context import ExecutionContext
+
+    ctx = ExecutionContext(
+        project_dir=Path("/tmp"),
+        tmp_dir=Path("/tmp"),
+        state_cache=cache or InMemoryStateCache(),
+        headless=True,
+    )
+    ctx.telemetry = telemetry
+    return ctx
+
+
+# --- Regex tests ---
+
+
+def test_blocker_regex_matches_blocked_by() -> None:
+    assert _BLOCKER_RE.search("blocked by #42") is not None
+
+
+def test_blocker_regex_matches_depends_on() -> None:
+    assert _BLOCKER_RE.search("depends on #7") is not None
+
+
+def test_blocker_regex_case_insensitive() -> None:
+    assert _BLOCKER_RE.search("Blocked By #1") is not None
+    assert _BLOCKER_RE.search("DEPENDS ON #2") is not None
+
+
+def test_blocker_regex_extracts_number() -> None:
+    m = _BLOCKER_RE.search("blocked by #123")
+    assert m is not None
+    assert m.group(1) == "123"
+
+
+def test_blocker_regex_multiple_refs_in_one_source() -> None:
+    text = "blocked by #1 and depends on #2"
+    matches = {int(m.group(1)) for m in _BLOCKER_RE.finditer(text)}
+    assert matches == {1, 2}
+
+
+def test_blocker_regex_matches_across_line_boundaries() -> None:
+    text = "blocked by\n#99"
+    assert _BLOCKER_RE.search(text) is not None
+
+
+def test_blocker_regex_ignores_close_keywords() -> None:
+    assert _BLOCKER_RE.search("Closes #42") is None
+    assert _BLOCKER_RE.search("Fixes #42") is None
+    assert _BLOCKER_RE.search("Resolves #42") is None
+
+
+def test_blocker_regex_ignores_bare_hash_refs() -> None:
+    assert _BLOCKER_RE.search("see #42") is None
+
+
+# --- _find_open_blockers tests ---
+
+
+async def test_find_open_blockers_empty_when_no_refs() -> None:
+    wf = _make_workflow()
+    item = make_item(body="no references here")
+    result = await wf._find_open_blockers(item)
+    assert result == []
+
+
+async def test_find_open_blockers_dedupes_across_body_and_comments() -> None:
+    comment = Comment(
+        author="alice", body="blocked by #42", created_at=datetime(2024, 1, 1, tzinfo=UTC)
+    )
+    item = make_item(body="blocked by #42", comments=(comment,))
+    blocker = make_item(item_id="42", state="open")
+    wf = _make_workflow()
+    wf._tracker.get = AsyncMock(return_value=blocker)
+
+    result = await wf._find_open_blockers(item)
+
+    assert result == [42]
+    wf._tracker.get.assert_awaited_once_with("42")
+
+
+async def test_find_open_blockers_returns_only_open_ones() -> None:
+    item = make_item(body="blocked by #1 and depends on #2")
+    blocker_open = make_item(item_id="1", state="open")
+    blocker_closed = make_item(item_id="2", state="closed")
+    wf = _make_workflow()
+    wf._tracker.get = AsyncMock(
+        side_effect=lambda iid: blocker_open if iid == "1" else blocker_closed
+    )
+
+    result = await wf._find_open_blockers(item)
+
+    assert result == [1]
+
+
+async def test_find_open_blockers_tolerates_ghost_refs() -> None:
+    item = make_item(body="blocked by #99 and depends on #100")
+    real_blocker = make_item(item_id="100", state="open")
+    wf = _make_workflow()
+
+    def side_effect(iid: str):
+        if iid == "99":
+            raise TrackerError("not found")
+        return real_blocker
+
+    wf._tracker.get = AsyncMock(side_effect=side_effect)
+
+    result = await wf._find_open_blockers(item)
+
+    assert result == [100]
+
+
+async def test_find_open_blockers_sorts_numerically() -> None:
+    item = make_item(body="depends on #10 and blocked by #2 and blocked by #5")
+    wf = _make_workflow()
+    wf._tracker.get = AsyncMock(side_effect=lambda iid: make_item(item_id=iid, state="open"))
+
+    result = await wf._find_open_blockers(item)
+
+    assert result == [2, 5, 10]
+
+
+# --- select_item integration tests ---
+
+
+async def test_select_item_defers_when_blocker_open() -> None:
+    item_blocked = make_item_with_blocker_refs([99], item_id="5")
+    item_free = make_item(item_id="6")
+    cache = InMemoryStateCache()
+    wf = _make_workflow()
+    wf._tracker.list_by_label = AsyncMock(return_value=[item_blocked, item_free])
+
+    blocker = make_item(item_id="99", state="open")
+
+    def get_side_effect(iid: str):
+        if iid == "5":
+            return make_item_with_blocker_refs([99], item_id="5")
+        if iid == "6":
+            return make_item(item_id="6")
+        if iid == "99":
+            return blocker
+        raise AssertionError(f"unexpected get({iid!r})")
+
+    wf._tracker.get = AsyncMock(side_effect=get_side_effect)
+    ctx = _make_ctx(cache)
+
+    result = await wf.select_item(ctx)
+
+    assert result is not None
+    assert result.item_id == "6"
+    assert cache.is_deferred(item_blocked)
+
+
+async def test_select_item_returns_when_all_blockers_closed() -> None:
+    item = make_item_with_blocker_refs([10], item_id="5")
+    blocker = make_item(item_id="10", state="closed")
+    cache = InMemoryStateCache()
+    wf = _make_workflow()
+    wf._tracker.list_by_label = AsyncMock(return_value=[item])
+
+    def get_side_effect(iid: str):
+        if iid == "5":
+            return make_item_with_blocker_refs([10], item_id="5")
+        return blocker
+
+    wf._tracker.get = AsyncMock(side_effect=get_side_effect)
+    ctx = _make_ctx(cache)
+
+    result = await wf.select_item(ctx)
+
+    assert result is not None
+    assert result.item_id == "5"
+
+
+async def test_select_item_returns_when_no_blocker_refs() -> None:
+    item = make_item(item_id="3", body="No dependencies here.")
+    wf = _make_workflow()
+    wf._tracker.list_by_label = AsyncMock(return_value=[item])
+    wf._tracker.get = AsyncMock(return_value=make_item(item_id="3"))
+    ctx = _make_ctx()
+
+    result = await wf.select_item(ctx)
+
+    assert result is not None
+    assert result.item_id == "3"
+
+
+async def test_select_item_returns_none_when_all_eligible_blocked() -> None:
+    item = make_item_with_blocker_refs([1], item_id="5")
+    blocker = make_item(item_id="1", state="open")
+    wf = _make_workflow()
+    wf._tracker.list_by_label = AsyncMock(return_value=[item])
+
+    def get_side_effect(iid: str):
+        if iid == "5":
+            return make_item_with_blocker_refs([1], item_id="5")
+        return blocker
+
+    wf._tracker.get = AsyncMock(side_effect=get_side_effect)
+    ctx = _make_ctx()
+
+    result = await wf.select_item(ctx)
+
+    assert result is None
+
+
+async def test_select_item_deferred_candidate_added_to_processed_this_loop() -> None:
+    item = make_item_with_blocker_refs([1], item_id="5")
+    blocker = make_item(item_id="1", state="open")
+    wf = _make_workflow()
+    wf._tracker.list_by_label = AsyncMock(return_value=[item])
+
+    def get_side_effect(iid: str):
+        if iid == "5":
+            return make_item_with_blocker_refs([1], item_id="5")
+        return blocker
+
+    wf._tracker.get = AsyncMock(side_effect=get_side_effect)
+    ctx = _make_ctx()
+
+    await wf.select_item(ctx)
+
+    assert ("github/org/repo", "5") in wf._processed_this_loop
+
+
+async def test_select_item_does_not_filter_is_deferred_up_front() -> None:
+    """Regression guard: a previously-deferred item whose blocker has closed is revived."""
+    item = make_item_with_blocker_refs([10], item_id="5")
+    cache = InMemoryStateCache()
+    cache.mark_deferred(item, "blocker", ["10"])
+    blocker_now_closed = make_item(item_id="10", state="closed")
+    wf = _make_workflow()
+    wf._tracker.list_by_label = AsyncMock(return_value=[item])
+
+    def get_side_effect(iid: str):
+        if iid == "5":
+            return make_item_with_blocker_refs([10], item_id="5")
+        return blocker_now_closed
+
+    wf._tracker.get = AsyncMock(side_effect=get_side_effect)
+    ctx = _make_ctx(cache)
+
+    result = await wf.select_item(ctx)
+
+    assert result is not None
+    assert result.item_id == "5"
+
+
+async def test_select_item_clears_deferral_on_successful_selection() -> None:
+    item = make_item_with_blocker_refs([10], item_id="5")
+    cache = InMemoryStateCache()
+    cache.mark_deferred(item, "blocker", ["10"])
+    blocker_closed = make_item(item_id="10", state="closed")
+    wf = _make_workflow()
+    wf._tracker.list_by_label = AsyncMock(return_value=[item])
+
+    def get_side_effect(iid: str):
+        if iid == "5":
+            return make_item_with_blocker_refs([10], item_id="5")
+        return blocker_closed
+
+    wf._tracker.get = AsyncMock(side_effect=get_side_effect)
+    ctx = _make_ctx(cache)
+
+    await wf.select_item(ctx)
+
+    assert not cache.is_deferred(make_item(item_id="5"))
+
+
+async def test_select_item_saves_state_cache_after_deferral() -> None:
+    item = make_item_with_blocker_refs([1], item_id="5")
+    blocker = make_item(item_id="1", state="open")
+    cache = InMemoryStateCache()
+    save_calls = []
+    cache.save = lambda: save_calls.append(True)  # type: ignore[method-assign]
+    wf = _make_workflow()
+    wf._tracker.list_by_label = AsyncMock(return_value=[item])
+
+    def get_side_effect(iid: str):
+        if iid == "5":
+            return make_item_with_blocker_refs([1], item_id="5")
+        return blocker
+
+    wf._tracker.get = AsyncMock(side_effect=get_side_effect)
+    ctx = _make_ctx(cache)
+
+    await wf.select_item(ctx)
+
+    assert len(save_calls) >= 1
+
+
+# --- Telemetry tests ---
+
+
+async def test_deferred_telemetry_outcome_is_deferred_by_blocker() -> None:
+    wf = _make_workflow()
+    item = make_item(item_id="5")
+    telemetry = AsyncMock()
+    ctx = _make_ctx(telemetry=telemetry)
+
+    await wf._write_deferred_telemetry(ctx, item, [3])
+
+    telemetry.write.assert_awaited_once()
+    record = telemetry.write.call_args[0][0]
+    assert record.outcome == "deferred-by-blocker"
+
+
+async def test_deferred_telemetry_error_encodes_blocker_list() -> None:
+    wf = _make_workflow()
+    item = make_item(item_id="5")
+    telemetry = AsyncMock()
+    ctx = _make_ctx(telemetry=telemetry)
+
+    await wf._write_deferred_telemetry(ctx, item, [1, 2])
+
+    record = telemetry.write.call_args[0][0]
+    assert record.error == "blocked by: #1, #2"
+
+
+async def test_deferred_telemetry_skipped_when_ctx_telemetry_is_none() -> None:
+    wf = _make_workflow()
+    item = make_item(item_id="5")
+    ctx = _make_ctx(telemetry=None)
+
+    # Should not raise
+    await wf._write_deferred_telemetry(ctx, item, [1])
+
+
+# --- Self-healing integration test ---
+
+
+async def test_deferred_item_revives_when_blocker_closes() -> None:
+    """Two separate workflow runs share a state cache. Item deferred in run 1,
+    revived in run 2 when blocker closes."""
+    cache = InMemoryStateCache()
+    item = make_item_with_blocker_refs([10], item_id="5")
+
+    blocker_open = make_item(item_id="10", state="open")
+    blocker_closed = make_item(item_id="10", state="closed")
+
+    def get_open(iid: str):
+        if iid == "5":
+            return make_item_with_blocker_refs([10], item_id="5")
+        return blocker_open
+
+    def get_closed(iid: str):
+        if iid == "5":
+            return make_item_with_blocker_refs([10], item_id="5")
+        return blocker_closed
+
+    # Run 1: blocker open → item deferred
+    wf1 = _make_workflow()
+    wf1._tracker.list_by_label = AsyncMock(return_value=[item])
+    wf1._tracker.get = AsyncMock(side_effect=get_open)
+    ctx1 = _make_ctx(cache)
+    result1 = await wf1.select_item(ctx1)
+    assert result1 is None
+    assert cache.is_deferred(item)
+
+    # Run 2: blocker now closed → item revived
+    wf2 = _make_workflow()
+    wf2._tracker.list_by_label = AsyncMock(return_value=[item])
+    wf2._tracker.get = AsyncMock(side_effect=get_closed)
+    ctx2 = _make_ctx(cache)
+    result2 = await wf2.select_item(ctx2)
+    assert result2 is not None
+    assert result2.item_id == "5"
+    assert not cache.is_deferred(item)

--- a/tests/test_workflows/test_ralph_finalization.py
+++ b/tests/test_workflows/test_ralph_finalization.py
@@ -614,6 +614,7 @@ async def test_full_iteration_end_to_end_success(tmp_path: Path) -> None:
 
     tracker = _make_tracker()
     tracker.list_by_label.return_value = [make_item(item_id="42", title="Fix")]
+    tracker.get = AsyncMock(return_value=make_item(item_id="42", title="Fix"))
     pr = _make_pr(url="https://github.com/org/repo/pull/1")
     host = _make_host(pr=None)
     host.create_pr.return_value = pr
@@ -669,6 +670,7 @@ async def test_full_iteration_end_to_end_noop(tmp_path: Path) -> None:
 
     tracker = _make_tracker()
     tracker.list_by_label.return_value = [make_item(item_id="42", title="Fix")]
+    tracker.get = AsyncMock(return_value=make_item(item_id="42", title="Fix"))
     host = _make_host()
 
     wf = RalphWorkflow(runner=EchoRunner(), tracker=tracker, host=host)

--- a/tests/test_workflows/test_ralph_integration.py
+++ b/tests/test_workflows/test_ralph_integration.py
@@ -96,6 +96,7 @@ async def test_end_to_end_with_real_git(git_env: Path) -> None:
 
     tracker_mock = AsyncMock(spec=IssueTracker)
     tracker_mock.list_by_label = AsyncMock(return_value=[item])
+    tracker_mock.get = AsyncMock(return_value=item)
     host_mock = AsyncMock(spec=GitHost)
 
     wf = RalphWorkflow(runner=EchoRunner(), tracker=tracker_mock, host=host_mock)

--- a/tests/test_workflows/test_ralph_select.py
+++ b/tests/test_workflows/test_ralph_select.py
@@ -73,6 +73,7 @@ async def test_select_item_sorts_by_priority_tier_asc() -> None:
     ]
     wf = _make_workflow()
     wf._tracker.list_by_label = AsyncMock(return_value=items)
+    wf._tracker.get = AsyncMock(side_effect=lambda iid: make_item(item_id=iid))
     ctx = _make_ctx()
     result = await wf.select_item(ctx)
     assert result is not None
@@ -90,6 +91,7 @@ async def test_select_item_within_tier_sorts_by_created_at_asc() -> None:
     ]
     wf = _make_workflow()
     wf._tracker.list_by_label = AsyncMock(return_value=items)
+    wf._tracker.get = AsyncMock(side_effect=lambda iid: make_item(item_id=iid))
     ctx = _make_ctx()
     result = await wf.select_item(ctx)
     assert result is not None
@@ -119,23 +121,12 @@ async def test_select_item_skips_processed_in_state_cache() -> None:
     assert result is None
 
 
-async def test_select_item_skips_deferred_in_state_cache() -> None:
-    t = datetime(2024, 1, 1, tzinfo=UTC)
-    item = make_item(item_id="1", created_at=t)
-    cache = InMemoryStateCache()
-    cache.mark_deferred(item, "blocked", [])
-    wf = _make_workflow()
-    wf._tracker.list_by_label = AsyncMock(return_value=[item])
-    ctx = _make_ctx(cache)
-    result = await wf.select_item(ctx)
-    assert result is None
-
-
 async def test_select_item_adds_chosen_to_local_set() -> None:
     t = datetime(2024, 1, 1, tzinfo=UTC)
     item = make_item(item_id="42", created_at=t)
     wf = _make_workflow()
     wf._tracker.list_by_label = AsyncMock(return_value=[item])
+    wf._tracker.get = AsyncMock(return_value=make_item(item_id="42"))
     ctx = _make_ctx()
     result = await wf.select_item(ctx)
     assert result is not None


### PR DESCRIPTION
## Summary

Ships the dependency safety net for ralph: before running stages on a selected issue, scan its body and comments for `blocked by #N` / `depends on #N` references. If any reference points to a still-open issue, the item is silently deferred with blocker metadata in the state cache, and ralph moves on to the next eligible item.

On subsequent runs, deferred items are re-evaluated automatically — when blockers close, deferred items revive without any manual cache cleanup.

Also adds the `Item.state` field (populated from gh's `state` JSON, normalized to lowercase `"open"` / `"closed"`), which the blocker check depends on.

### Key design decisions

- **Inline in `RalphWorkflow.select_item`**, not a new `Workflow` lifecycle hook — single-workflow concern, refine doesn't care.
- **Self-healing via re-scan.** `select_item` deliberately does NOT filter `is_deferred` items up-front. Instead, blockers are re-evaluated on every iteration. No manual deferral expiry logic needed.
- **Regex `\b(?:blocked by|depends on)\s+#(\d+)`** (case-insensitive, matches across line breaks). Ignores close-keywords (`Closes` / `Fixes` / `Resolves`) — those are emission-direction, not dependency-direction.
- **Ghost references tolerated.** `TrackerError` on blocker fetch is swallowed; the candidate is NOT deferred on unfetchable `#N` references.
- **Deferred telemetry** records `outcome="deferred-by-blocker"` and encodes blockers in the `error` field as `"blocked by: #1, #2"`. State cache owns the structured blockers list; telemetry is a log.

## Closes

Closes #15

## Test plan

- [ ] `uv run pytest tests/test_workflows/test_ralph_dependencies.py -v` — all 30+ tests pass (regex, `_find_open_blockers`, `select_item` integration, telemetry, self-healing)
- [ ] `uv run pytest` — full suite including existing-test backfills for `Item.state` kwarg passes
- [ ] `uv run mypy src` exits 0
- [ ] `uv run ruff check . && uv run ruff format --check .` exits 0
- [ ] Manual: create an issue whose body contains `blocked by #<open-issue-N>`, label it `agent-ready`, run `cog ralph --headless`. Verify the item is silently skipped (no comment, no label change) and a `deferred_items` entry appears in `~/.local/state/cog/<project>/state.json` with the blocker number recorded.
- [ ] Manual: close the blocker issue, run `cog ralph --headless` again. Verify the previously-deferred item is selected, processed, and the deferral cleared from state cache.
- [ ] Manual: create an issue with body `blocked by #99999` (non-existent issue). Verify it is NOT deferred (ghost ref tolerated) and proceeds to the stages normally.
- [ ] Manual: create an issue with body `Closes #<open-issue-N>`. Verify it is NOT treated as a blocked-by reference.
- [ ] Inspect `~/.local/state/cog/<project>/runs.jsonl` for a run that hit the deferral path — verify `outcome` is `"deferred-by-blocker"` and `error` encodes the blocker list.

## Known follow-ups (non-blocking)

- `tests/fixtures/gh/get_with_comments.json` and `get_no_comments.json` weren't updated with the new `state` field. `_to_item` defaults via `record.get("state") or "open"`, so tests pass, but those fixtures no longer round-trip real gh output. Fix in a follow-up.
- Manual review + push after the original ralph iteration's review stage failed mid-stream (claude subscription rate-limit hit during review — see #44 for the error-diagnostics gap that kept it opaque).

---
🤖 Manually opened from the cog/15-* branch after the autonomous review-stage failure. Build stage succeeded; only review + document didn't run.