### PR TITLE
ClaudeCliRunner stream-inactivity timeout: RunnerStalledError + SIGTERM / SIGKILL path (#48)

### DIFF
--- a/src/cog/core/errors.py
+++ b/src/cog/core/errors.py
@@ -27,6 +27,23 @@ class RunnerTimeoutError(RunnerError):
     """Subprocess exceeded COG_RUNNER_TIMEOUT_SECONDS; process was terminated."""
 
 
+class RunnerStalledError(RunnerError):
+    """Subprocess produced no stream events within the inactivity window; terminated."""
+
+    def __init__(
+        self,
+        *,
+        inactivity_seconds: float,
+        last_event_summary: str | None = None,
+    ) -> None:
+        self.inactivity_seconds = inactivity_seconds
+        self.last_event_summary = last_event_summary
+        super().__init__(
+            f"no stream event for {inactivity_seconds:.0f}s; subprocess terminated. "
+            f"last event: {last_event_summary or '(none)'}"
+        )
+
+
 class StreamJsonParseError(RunnerError):
     """Claude emitted a line that wasn't parseable JSON or had unexpected shape."""
 

--- a/src/cog/runners/claude_cli.py
+++ b/src/cog/runners/claude_cli.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import sys
 import tempfile
 import time
 from collections.abc import AsyncIterator, Iterator
@@ -8,7 +9,7 @@ from pathlib import Path
 from subprocess import PIPE
 from typing import Any
 
-from cog.core.errors import RunnerTimeoutError, StreamJsonParseError
+from cog.core.errors import RunnerStalledError, RunnerTimeoutError, StreamJsonParseError
 from cog.core.runner import (
     AgentRunner,
     AssistantTextEvent,
@@ -43,10 +44,28 @@ def _append_line(path: Path, line: str) -> None:
         f.write(line + "\n")
 
 
+def _parse_float_env(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        print(
+            f"WARNING: {name}={raw!r} is not a valid number; defaulting to {default}",
+            file=sys.stderr,
+        )
+        return default
+
+
 class ClaudeCliRunner(AgentRunner):
     def __init__(self, sandbox: Sandbox) -> None:
         self._sandbox = sandbox
-        self._timeout_seconds = float(os.environ.get("COG_RUNNER_TIMEOUT_SECONDS", "1800"))
+        self._timeout_seconds = _parse_float_env("COG_RUNNER_TIMEOUT_SECONDS", 1800.0)
+        self._inactivity_timeout_seconds = _parse_float_env(
+            "COG_RUNNER_INACTIVITY_TIMEOUT_SECONDS", 120.0
+        )
+        self._sigterm_grace_seconds = 5.0
 
     async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
         await self._sandbox.prepare()
@@ -76,38 +95,72 @@ class ClaudeCliRunner(AgentRunner):
 
         final_text = ""
         result_record: dict[str, Any] | None = None
+        last_event_summary: str | None = None
         _waited = False
+        _proc_cleaned = False
 
         try:
             async with asyncio.timeout(self._timeout_seconds):
-                async for raw_line in proc.stdout:
+                while True:
+                    try:
+                        raw_line = await asyncio.wait_for(
+                            proc.stdout.readline(),
+                            timeout=self._inactivity_timeout_seconds,
+                        )
+                    except TimeoutError:
+                        proc.terminate()
+                        try:
+                            await asyncio.wait_for(proc.wait(), timeout=self._sigterm_grace_seconds)
+                        except TimeoutError:
+                            proc.kill()
+                            await proc.wait()
+                        _proc_cleaned = True
+                        _waited = True
+                        raise RunnerStalledError(
+                            inactivity_seconds=self._inactivity_timeout_seconds,
+                            last_event_summary=last_event_summary,
+                        ) from None
+
+                    if not raw_line:
+                        break  # EOF
+
                     line = raw_line.decode("utf-8", errors="replace").rstrip("\n")
                     if not line:
                         continue
+
                     _append_line(stream_path, line)
                     try:
                         record: dict[str, Any] = json.loads(line)
                     except json.JSONDecodeError as exc:
                         raise StreamJsonParseError(f"bad JSON line: {line!r}") from exc
+
                     if record.get("type") == "result":
                         result_record = record
                         continue
+
                     for event in _record_to_events(record):
                         if isinstance(event, AssistantTextEvent):
                             final_text = event.text
+                            last_event_summary = f"assistant: {event.text[:80]}"
+                        elif isinstance(event, ToolUseEvent):
+                            cmd_or_path = (
+                                event.input.get("command") or event.input.get("file_path") or ""
+                            )
+                            last_event_summary = f"{event.tool}: {cmd_or_path[:120]}"
                         yield event
         except TimeoutError:
             proc.terminate()
             try:
-                await asyncio.wait_for(proc.wait(), timeout=5.0)
+                await asyncio.wait_for(proc.wait(), timeout=self._sigterm_grace_seconds)
             except TimeoutError:
                 proc.kill()
                 await proc.wait()
             _waited = True
             raise RunnerTimeoutError(f"claude exceeded {self._timeout_seconds}s") from None
         except Exception:
-            proc.kill()
-            await proc.wait()
+            if not _proc_cleaned:
+                proc.kill()
+                await proc.wait()
             _waited = True
             raise
         finally:

--- a/tests/test_runners/helpers.py
+++ b/tests/test_runners/helpers.py
@@ -1,7 +1,7 @@
 """Shared test helpers for ClaudeCliRunner tests."""
 
 import asyncio
-from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -40,14 +40,17 @@ def fixture_proc(name: str, returncode: int = 0) -> FakeProcess:
     return FakeProcess(_make_reader(data), returncode)
 
 
-async def _hanging_stdout() -> AsyncIterator[bytes]:
-    yield b'{"type":"system","subtype":"init"}\n'
-    await asyncio.sleep(10)
+class _HangingStdout:
+    """Stdout that hangs forever on readline() — for wall-clock timeout tests."""
+
+    async def readline(self) -> bytes:
+        await asyncio.sleep(10)
+        return b""
 
 
 def hanging_proc() -> FakeProcess:
     """Fake process whose stdout never closes — for timeout tests."""
-    proc = FakeProcess(_hanging_stdout(), returncode=0)
+    proc = FakeProcess(_HangingStdout(), returncode=0)
 
     def _terminate() -> None:
         proc.terminated = True
@@ -64,6 +67,84 @@ def hanging_proc() -> FakeProcess:
 
 def patch_exec(proc: FakeProcess) -> Any:
     """Context manager that patches asyncio.create_subprocess_exec to return proc."""
+    return patch(
+        "cog.runners.claude_cli.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=proc),
+    )
+
+
+@dataclass
+class StreamEvent:
+    """A scripted event for PausingMockProc."""
+
+    data: bytes
+    delay_before: float = 0.0
+
+
+class _PausingStdout:
+    def __init__(self, proc: "PausingMockProc", events: list[StreamEvent]) -> None:
+        self._proc = proc
+        self._events = events
+        self._idx = 0
+
+    async def readline(self) -> bytes:
+        if self._idx >= len(self._events):
+            self._signal_eof()
+            return b""
+        event = self._events[self._idx]
+        self._idx += 1
+        if event.delay_before > 0:
+            await asyncio.sleep(event.delay_before)
+        if not event.data:
+            self._signal_eof()
+        return event.data
+
+    def _signal_eof(self) -> None:
+        if self._proc.returncode is None:
+            self._proc.returncode = 0
+            self._proc._done.set()
+
+
+class PausingMockProc:
+    """Mock asyncio subprocess that emits scripted events with configurable delays.
+
+    Use StreamEvent(b'', delay_before=9999) to simulate an infinite hang.
+    """
+
+    def __init__(
+        self,
+        events: list[StreamEvent],
+        *,
+        respects_sigterm: bool = True,
+    ) -> None:
+        self._respects_sigterm = respects_sigterm
+        self._terminated = False
+        self._killed = False
+        self.returncode: int | None = None
+        self._done = asyncio.Event()
+        self.stdout = _PausingStdout(self, events)
+        self.stderr = None
+
+    def terminate(self) -> None:
+        self._terminated = True
+        if self._respects_sigterm:
+            self.returncode = 143
+            self._done.set()
+
+    def kill(self) -> None:
+        self._killed = True
+        self.returncode = 137
+        self._done.set()
+
+    async def wait(self) -> int:
+        if self.returncode is not None:
+            return self.returncode
+        await self._done.wait()
+        return self.returncode  # type: ignore[return-value]
+
+
+def patch_pausing_exec(proc: "PausingMockProc") -> Any:
+    """Context manager that patches asyncio.create_subprocess_exec to return a PausingMockProc."""
     return patch(
         "cog.runners.claude_cli.asyncio.create_subprocess_exec",
         new=AsyncMock(return_value=proc),

--- a/tests/test_runners/test_claude_cli_inactivity.py
+++ b/tests/test_runners/test_claude_cli_inactivity.py
@@ -1,0 +1,305 @@
+"""Tests for ClaudeCliRunner stream-inactivity timeout behavior."""
+
+import json
+
+import pytest
+
+from cog.core.errors import RunnerError, RunnerStalledError, RunnerTimeoutError
+from cog.runners.claude_cli import ClaudeCliRunner
+from cog.runners.sandbox import NullSandbox
+from tests.test_runners.helpers import PausingMockProc, StreamEvent, patch_pausing_exec
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_ASSISTANT_TEXT = (
+    json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "content": [{"type": "text", "text": "I will help you."}],
+            },
+        }
+    ).encode()
+    + b"\n"
+)
+
+_TOOL_USE = (
+    json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "content": [{"type": "tool_use", "name": "Bash", "input": {"command": "echo hi"}}],
+            },
+        }
+    ).encode()
+    + b"\n"
+)
+
+_READ_TOOL_USE = (
+    json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "/tmp/some/path.txt"},
+                    }
+                ],
+            },
+        }
+    ).encode()
+    + b"\n"
+)
+
+_RESULT = (
+    json.dumps(
+        {
+            "type": "result",
+            "exit_status": 0,
+            "total_cost_usd": 0.01,
+        }
+    ).encode()
+    + b"\n"
+)
+
+
+def _runner(*, inactivity: float = 0.05, wall_clock: float = 30.0) -> ClaudeCliRunner:
+    r = ClaudeCliRunner(NullSandbox())
+    r._inactivity_timeout_seconds = inactivity
+    r._timeout_seconds = wall_clock
+    r._sigterm_grace_seconds = 0.05
+    return r
+
+
+async def _drain(runner: ClaudeCliRunner, proc: PausingMockProc) -> list:
+    events = []
+    with patch_pausing_exec(proc):
+        async for ev in runner.stream("hello", model="m"):
+            events.append(ev)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Core behavior
+# ---------------------------------------------------------------------------
+
+
+async def test_inactivity_timeout_fires_when_no_events():
+    proc = PausingMockProc(
+        [
+            StreamEvent(_ASSISTANT_TEXT),
+            StreamEvent(_ASSISTANT_TEXT),
+            StreamEvent(_ASSISTANT_TEXT),
+            StreamEvent(b"", delay_before=9999),  # hang forever
+        ]
+    )
+    runner = _runner()
+    with pytest.raises(RunnerStalledError):
+        await _drain(runner, proc)
+
+
+async def test_inactivity_timeout_does_not_fire_for_fast_stream():
+    proc = PausingMockProc(
+        [
+            StreamEvent(_ASSISTANT_TEXT),
+            StreamEvent(_RESULT),
+            StreamEvent(b""),  # EOF
+        ]
+    )
+    runner = _runner(inactivity=5.0)
+    events = await _drain(runner, proc)
+    assert len(events) >= 1
+
+
+async def test_inactivity_timeout_does_not_fire_for_healthy_stream_with_pauses():
+    # Each event has a small delay well under the inactivity timeout.
+    proc = PausingMockProc(
+        [
+            StreamEvent(_ASSISTANT_TEXT, delay_before=0.01),
+            StreamEvent(_ASSISTANT_TEXT, delay_before=0.01),
+            StreamEvent(_RESULT, delay_before=0.01),
+            StreamEvent(b""),
+        ]
+    )
+    runner = _runner(inactivity=5.0)
+    events = await _drain(runner, proc)
+    assert len(events) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Error population
+# ---------------------------------------------------------------------------
+
+
+async def test_stalled_error_includes_inactivity_seconds():
+    proc = PausingMockProc([StreamEvent(b"", delay_before=9999)])
+    runner = _runner(inactivity=0.07)
+    with pytest.raises(RunnerStalledError) as exc_info:
+        await _drain(runner, proc)
+    assert exc_info.value.inactivity_seconds == pytest.approx(0.07)
+
+
+async def test_stalled_error_last_event_summary_for_tool_use():
+    proc = PausingMockProc(
+        [
+            StreamEvent(_TOOL_USE),
+            StreamEvent(b"", delay_before=9999),
+        ]
+    )
+    runner = _runner()
+    with pytest.raises(RunnerStalledError) as exc_info:
+        await _drain(runner, proc)
+    summary = exc_info.value.last_event_summary
+    assert summary is not None
+    assert "Bash" in summary
+    assert "echo hi" in summary
+
+
+async def test_stalled_error_last_event_summary_for_assistant_text():
+    proc = PausingMockProc(
+        [
+            StreamEvent(_ASSISTANT_TEXT),
+            StreamEvent(b"", delay_before=9999),
+        ]
+    )
+    runner = _runner()
+    with pytest.raises(RunnerStalledError) as exc_info:
+        await _drain(runner, proc)
+    summary = exc_info.value.last_event_summary
+    assert summary is not None
+    assert "assistant:" in summary
+    assert "I will help you." in summary
+
+
+async def test_stalled_error_last_event_summary_none_when_hang_before_any_event():
+    proc = PausingMockProc([StreamEvent(b"", delay_before=9999)])
+    runner = _runner()
+    with pytest.raises(RunnerStalledError) as exc_info:
+        await _drain(runner, proc)
+    assert exc_info.value.last_event_summary is None
+
+
+async def test_stalled_error_message_includes_last_event():
+    proc = PausingMockProc(
+        [
+            StreamEvent(_ASSISTANT_TEXT),
+            StreamEvent(b"", delay_before=9999),
+        ]
+    )
+    runner = _runner()
+    with pytest.raises(RunnerStalledError) as exc_info:
+        await _drain(runner, proc)
+    assert "I will help you." in str(exc_info.value)
+
+
+async def test_stalled_error_message_shows_none_when_no_prior_event():
+    proc = PausingMockProc([StreamEvent(b"", delay_before=9999)])
+    runner = _runner()
+    with pytest.raises(RunnerStalledError) as exc_info:
+        await _drain(runner, proc)
+    assert "(none)" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Process termination
+# ---------------------------------------------------------------------------
+
+
+async def test_inactivity_sigterm_sent_on_stall():
+    proc = PausingMockProc([StreamEvent(b"", delay_before=9999)])
+    runner = _runner()
+    with pytest.raises(RunnerStalledError):
+        await _drain(runner, proc)
+    assert proc._terminated
+
+
+async def test_inactivity_sigkill_after_grace_when_sigterm_ignored():
+    proc = PausingMockProc([StreamEvent(b"", delay_before=9999)], respects_sigterm=False)
+    runner = _runner()
+    with pytest.raises(RunnerStalledError):
+        await _drain(runner, proc)
+    assert proc._killed
+
+
+async def test_inactivity_proc_waited_before_raise():
+    """No zombie: returncode is set before RunnerStalledError propagates."""
+    proc = PausingMockProc([StreamEvent(b"", delay_before=9999)])
+    runner = _runner()
+    with pytest.raises(RunnerStalledError):
+        await _drain(runner, proc)
+    assert proc.returncode is not None
+
+
+# ---------------------------------------------------------------------------
+# Env var configuration
+# ---------------------------------------------------------------------------
+
+
+async def test_inactivity_default_is_120_seconds(monkeypatch):
+    monkeypatch.delenv("COG_RUNNER_INACTIVITY_TIMEOUT_SECONDS", raising=False)
+    runner = ClaudeCliRunner(NullSandbox())
+    assert runner._inactivity_timeout_seconds == 120.0
+
+
+async def test_inactivity_env_var_override(monkeypatch):
+    monkeypatch.setenv("COG_RUNNER_INACTIVITY_TIMEOUT_SECONDS", "60")
+    runner = ClaudeCliRunner(NullSandbox())
+    assert runner._inactivity_timeout_seconds == 60.0
+
+
+async def test_inactivity_env_var_invalid_falls_back_to_default(monkeypatch, capsys):
+    monkeypatch.setenv("COG_RUNNER_INACTIVITY_TIMEOUT_SECONDS", "not-a-number")
+    runner = ClaudeCliRunner(NullSandbox())
+    assert runner._inactivity_timeout_seconds == 120.0
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Interaction with wall-clock timeout
+# ---------------------------------------------------------------------------
+
+
+async def test_wall_clock_fires_independently_when_stream_runs_too_long():
+    # Stream flows continuously but wall-clock is very short.
+    proc = PausingMockProc([StreamEvent(b"", delay_before=9999)])
+    runner = _runner(inactivity=0.5, wall_clock=0.05)
+    with pytest.raises(RunnerTimeoutError):
+        await _drain(runner, proc)
+
+
+async def test_inactivity_fires_when_smaller_than_wall_clock():
+    proc = PausingMockProc([StreamEvent(b"", delay_before=9999)])
+    runner = _runner(inactivity=0.05, wall_clock=30.0)
+    with pytest.raises(RunnerStalledError):
+        await _drain(runner, proc)
+
+
+async def test_both_error_classes_subclass_runner_error():
+    assert issubclass(RunnerStalledError, RunnerError)
+    assert issubclass(RunnerTimeoutError, RunnerError)
+
+
+# ---------------------------------------------------------------------------
+# last_event_summary details
+# ---------------------------------------------------------------------------
+
+
+async def test_last_event_summary_tool_use_uses_file_path_when_no_command():
+    proc = PausingMockProc(
+        [
+            StreamEvent(_READ_TOOL_USE),
+            StreamEvent(b"", delay_before=9999),
+        ]
+    )
+    runner = _runner()
+    with pytest.raises(RunnerStalledError) as exc_info:
+        await _drain(runner, proc)
+    summary = exc_info.value.last_event_summary
+    assert summary is not None
+    assert "Read" in summary
+    assert "/tmp/some/path.txt" in summary

--- a/tests/test_stage_executor.py
+++ b/tests/test_stage_executor.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from cog.core.context import ExecutionContext
-from cog.core.errors import GitError, StageError
+from cog.core.errors import GitError, RunnerStalledError, StageError
 from cog.core.item import Item
 from cog.core.outcomes import Outcome, StageResult
 from cog.core.runner import AgentRunner, ResultEvent, RunEvent, RunResult
@@ -240,6 +240,55 @@ async def test_tolerate_failure_nonzero_exit_stores_stage_error_as_error(ctx_fac
     result = await executor._run_stage(stage, ctx_factory())
     assert isinstance(result.error, StageError)
     assert result.exit_status == 2
+
+
+async def test_stage_executor_wraps_runner_stalled_in_stage_error(ctx_factory):
+    stalled = RunnerStalledError(inactivity_seconds=120, last_event_summary="Bash: echo hi")
+
+    class _StalledRunner(AgentRunner):
+        async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+            raise stalled
+            yield  # type: ignore[misc]
+
+    wf = _SimpleWorkflow(_StalledRunner())
+    with pytest.raises(StageError) as exc_info:
+        await StageExecutor().run(wf, ctx_factory())
+    assert isinstance(exc_info.value.cause, RunnerStalledError)
+    assert wf.finalize_called == "error"
+
+
+async def test_stalled_error_cause_preserved_through_stage_error(ctx_factory):
+    original = RunnerStalledError(inactivity_seconds=60, last_event_summary="Read: /tmp/x")
+
+    class _StalledRunner(AgentRunner):
+        async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+            raise original
+            yield  # type: ignore[misc]
+
+    wf = _SimpleWorkflow(_StalledRunner())
+    with pytest.raises(StageError) as exc_info:
+        await StageExecutor().run(wf, ctx_factory())
+    assert exc_info.value.cause is original
+
+
+async def test_stage_executor_stalled_path_has_exit_minus_one_and_error(ctx_factory):
+    stalled = RunnerStalledError(inactivity_seconds=120)
+
+    class _StalledRunner(AgentRunner):
+        async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+            raise stalled
+            yield  # type: ignore[misc]
+
+    stage = Stage(
+        name="s1",
+        prompt_source=lambda _: "hello",
+        model="m",
+        runner=_StalledRunner(),
+        tolerate_failure=True,
+    )
+    result = await StageExecutor()._run_stage(stage, ctx_factory())
+    assert result.exit_status == -1
+    assert result.error is stalled
 
 
 async def test_subsequent_stages_run_after_tolerated_failure(ctx_factory):


### PR DESCRIPTION
## Summary

Replaces the \`async for raw_line in proc.stdout\` loop in \`ClaudeCliRunner.stream()\` with a \`while True\` + \`asyncio.wait_for(readline(), timeout=inactivity_timeout)\` pattern. When no stream event arrives within the inactivity window, the subprocess is terminated (SIGTERM → 5s grace → SIGKILL) and \`RunnerStalledError\` is raised. This terminates hung claude processes in seconds instead of waiting for the 30-minute wall-clock timeout.

Distinguished from \`RunnerTimeoutError\` so downstream retry logic (#22) can branch on the failure mode: stalls are retry-worthy (likely transient hang); wall-clock overruns probably aren't.

### Key behaviors

- **Per-line inactivity timeout** via \`asyncio.wait_for\` — no watchdog task, simpler control flow
- **New \`COG_RUNNER_INACTIVITY_TIMEOUT_SECONDS\` env var** (default 120)
- **\`RunnerStalledError\`** carries \`inactivity_seconds\` and \`last_event_summary\` for diagnostics
- **Wall-clock \`COG_RUNNER_TIMEOUT_SECONDS\` coexists** — both guards fire independently
- **Interview turns (refine #18) inherit automatically** — per-turn subprocess each gets a fresh inactivity window

## Closes

Closes #48

## Test plan

- [ ] Run \`uv run pytest tests/test_runners/test_claude_cli_inactivity.py -v\` — all 19 new tests pass (core behavior, error population, termination paths, env var handling, wall-clock/inactivity coexistence)
- [ ] Run \`uv run pytest tests/test_stage_executor.py -v\` — 3 new StageExecutor tests pass (stalled-error wrapping + StageEndEvent emission)
- [ ] Run \`uv run pytest\` — full suite green
- [ ] Run \`uv run mypy src\` — exits 0
- [ ] Run \`uv run ruff check .\` + \`uv run ruff format --check .\` — exit 0
- [ ] Set \`COG_RUNNER_INACTIVITY_TIMEOUT_SECONDS=10\` and run \`cog ralph --item <N>\` against a branch likely to hit the hang from #48's reproducer (large git diff in review stage) — verify \`RunnerStalledError\` surfaces within ~15s (10 + 5s grace) instead of 30 min
- [ ] Verify \`RunnerStalledError\` is distinguishable from \`RunnerTimeoutError\` via type check (both subclass \`RunnerError\`)
- [ ] Inspect \`runs.jsonl\` after a stalled iteration — telemetry \`error\` field should contain \`RunnerStalledError\` summary with \`last_event_summary\` populated (e.g., \`Read: /tmp/cog-home/...\`)
- [ ] Confirm normal fast-response tool cycles don't false-positive trigger the inactivity timeout

---
🤖 Finalized manually — autonomous iteration's build stage succeeded but finalize_success never ran (telemetry shows the iteration errored with 0 duration / 0 cost / empty stages list despite the commit landing; root cause unclear but unrelated to this PR's content).