### PR TITLE
Ralph prompts: skim+triage review flow + bounded-tool-calls guidance + tracker-agnostic language (#49)

### DIFF
--- a/src/cog/prompts/claude/ralph/build.md
+++ b/src/cog/prompts/claude/ralph/build.md
@@ -1,21 +1,21 @@
 # Ralph: build stage
 
-You are working autonomously on a single GitHub issue. The wrapper has
+You are working autonomously on a single tracked item. The wrapper has
 already pulled the latest default branch and checked out the work branch
 for you. The project's `CLAUDE.md` (if present) is loaded into your context
 through the normal claude-code mechanism — read it for project-specific
 conventions, code style, how to run tests, and how to run the linter.
 
-Your job in this stage: implement the issue, write tests, run tests and
+Your job in this stage: implement the item, write tests, run tests and
 linter, fix failures, commit. Nothing else. Pushing the branch, opening
-the PR, and commenting on the issue all happen in the wrapper after you
+the PR, and commenting on the item all happen in the wrapper after you
 exit.
 
 ## Steps
 
-1. Read the issue title, body, and comments (provided in the runtime
+1. Read the item title, body, and comments (provided in the runtime
    context section appended below).
-2. Implement the change required by the issue.
+2. Implement the change required by the item.
 3. Write or update tests that exercise the new or changed behavior.
 4. Run the project's test suite. Fix any failures.
 5. Run the project's linter. Fix any errors.
@@ -23,10 +23,10 @@ exit.
    (e.g. `Fix password reset timing bug (#42)`). You may make multiple
    commits if it helps you reason about the work.
 
-If the issue is unclear, contradictory, or requires information you don't
+If the item is unclear, contradictory, or requires information you don't
 have, do NOT guess. Write a final message explaining what's missing and
 exit without committing. The wrapper will post your message as a comment
-on the issue and remove the `agent-ready` label so a human can address it.
+on the item and remove the `agent-ready` label so a human can address it.
 
 ## Anti-verbosity (apply while writing, not just at review time)
 
@@ -44,6 +44,22 @@ These are concrete maintainability rules, not stylistic preferences:
   workaround).
 
 The project's `CLAUDE.md` may override these thresholds — its rules win.
+
+## Bounded tool calls (important)
+
+Claude Code persists any single tool output >30KB to a session-scoped file
+and tells you to `Read` that file. In this container, the subsequent `Read`
+has been observed to hang indefinitely. To avoid this:
+
+- Do NOT run `cat` on large generated or vendored files (e.g. lockfiles,
+  `node_modules/**`, minified assets).
+- Do NOT run `grep -r` over the whole repo. Use `Grep` (Claude Code's
+  built-in) with `head_limit` or file-type filters.
+- Do NOT run `find .` across repos with heavy dependency trees — scope it
+  with `-path` exclusions or use `Glob` instead.
+- When running a command that might produce large output, pipe through
+  `head -c 30000` or equivalent defensively.
+- Prefer per-file inspection via `Read <file>` over broad shell expansions.
 
 ## Final message format
 
@@ -69,7 +85,7 @@ Example format:
 
 - Make commits locally; do not push them. The wrapper pushes the branch
   after you exit.
-- Do not open PRs or comment on issues. The wrapper handles both.
+- Do not open PRs or comment on items. The wrapper handles both.
 - Never delete branches.
 - And absolutely never push or force-push to the default branch
   (`main` / `master`), even by accident — that's the highest-blast-radius

--- a/src/cog/prompts/claude/ralph/document.md
+++ b/src/cog/prompts/claude/ralph/document.md
@@ -22,18 +22,40 @@ Focus on user-facing changes that aren't self-evident from the code:
 
 ## Steps
 
-1. Run `git diff main..HEAD` to see what changed.
-2. Read the issue body (provided in the runtime context below) for context
+1. Run `git diff --stat $(git merge-base HEAD main 2>/dev/null || git merge-base HEAD master)..HEAD`
+   to get a scope overview of what changed.
+2. For each changed user-facing file (README, CHANGELOG, docs/*, docstrings
+   in public-API files): `Read` the file and check whether its content
+   aligns with the changes.
+3. Run `git log --oneline $(git merge-base HEAD main 2>/dev/null || git merge-base HEAD master)..HEAD`
+   for bounded commit subjects to inform the narrative (NOT `-p`, which
+   includes full patches).
+4. Read the item body (provided in the runtime context below) for context
    on the intent of the change.
-3. Update relevant documentation files (README, CHANGELOG, docstrings,
+5. Update relevant documentation files (README, CHANGELOG, docstrings,
    inline comments that explain WHY — not what).
-4. If there is nothing to document (internal refactors, test-only changes),
+6. If there is nothing to document (internal refactors, test-only changes),
    say so in your final message and exit without committing.
-5. Commit any documentation changes with a clear message.
+7. Commit any documentation changes with a clear message.
+
+## Bounded tool calls (important)
+
+Claude Code persists any single tool output >30KB to a session-scoped file
+and tells you to `Read` that file. In this container, the subsequent `Read`
+has been observed to hang indefinitely. To avoid this:
+
+- Do NOT run `git diff <base>..HEAD` without file filters — produces
+  unbounded output on any non-trivial branch.
+- Do NOT run `grep -r` over the whole repo. Use `Grep` (Claude Code's
+  built-in) with `head_limit` or file-type filters.
+- When running a command that might produce large output, pipe through
+  `head -c 30000` or equivalent defensively.
+- Prefer per-file inspection via `Read <file>` over patch-level inspection
+  via `git diff`.
 
 ## Git rules (hard)
 
 - Make commits locally; do not push them.
-- Do not open PRs or comment on issues.
+- Do not open PRs or comment on items.
 - Never delete branches.
 - Never push or force-push to main/master.

--- a/src/cog/prompts/claude/ralph/review.md
+++ b/src/cog/prompts/claude/ralph/review.md
@@ -10,8 +10,8 @@ final message.
 
 ## What to review
 
-1. **Correctness** — does the implementation satisfy the issue requirements?
-   Check the issue body and acceptance criteria against the diff.
+1. **Correctness** — does the implementation satisfy the item requirements?
+   Check the item body and acceptance criteria against the diff.
 2. **Tests** — are the tests present, meaningful, and correct? Do they
    cover edge cases and failure paths, not just the happy path?
 3. **Code quality** — does the code follow the project's conventions?
@@ -24,16 +24,39 @@ final message.
 
 ## Steps
 
-1. Run `git diff main..HEAD` to see all commits on this branch.
-2. Read the issue body (provided in the runtime context below).
-3. Identify any defects, missing coverage, or style violations.
-4. Fix what you can directly. Commit fixes with clear messages.
-5. In your final message, list any remaining concerns that require human
+1. Run `git diff --stat $(git merge-base HEAD main 2>/dev/null || git merge-base HEAD master)..HEAD`
+   to get a bounded overview of changed files and line counts.
+2. Triage: from the stat output, identify the 3–5 highest-risk files
+   (largest changes, core-abstraction-touching, security-adjacent).
+3. For each triaged file: `Read <file>` for current state, then
+   `git log -p --follow -- <file>` for change context.
+4. For other changed files: optionally run
+   `git diff <base>..HEAD -- <file>` (bounded per-file diff) if you want
+   more context; skip if the stat is self-explanatory.
+5. Read the item body (provided in the runtime context below).
+6. Identify any defects, missing coverage, or style violations.
+7. Fix what you can directly. Commit fixes with clear messages.
+8. In your final message, list any remaining concerns that require human
    attention (things you couldn't fix, architectural trade-offs, etc.).
+
+## Bounded tool calls (important)
+
+Claude Code persists any single tool output >30KB to a session-scoped file
+and tells you to `Read` that file. In this container, the subsequent `Read`
+has been observed to hang indefinitely. To avoid this:
+
+- Do NOT run `git diff <base>..HEAD` without file filters — produces
+  unbounded output on any non-trivial branch.
+- Do NOT run `grep -r` over the whole repo. Use `Grep` (Claude Code's
+  built-in) with `head_limit` or file-type filters.
+- When running a command that might produce large output, pipe through
+  `head -c 30000` or equivalent defensively.
+- Prefer per-file inspection via `Read <file>` over patch-level inspection
+  via `git diff`.
 
 ## Git rules (hard)
 
 - Make commits locally; do not push them.
-- Do not open PRs or comment on issues.
+- Do not open PRs or comment on items.
 - Never delete branches.
 - Never push or force-push to main/master.

--- a/tests/test_workflows/test_ralph_prompts.py
+++ b/tests/test_workflows/test_ralph_prompts.py
@@ -1,5 +1,6 @@
 """Tests for RalphWorkflow prompt loading and assembly."""
 
+import re
 from datetime import UTC, datetime
 
 import pytest
@@ -8,6 +9,8 @@ from cog.core.context import ExecutionContext
 from cog.core.item import Comment
 from cog.workflows.ralph import _build_prompt, _load_prompt
 from tests.fakes import InMemoryStateCache, make_item
+
+_UNBOUNDED_DIFF_RE = re.compile(r"git diff\s+(?:main|master)\.\.HEAD(?!\s+--?)")
 
 
 def _make_ctx(tmp_path, item=None, work_branch=None):
@@ -87,3 +90,32 @@ def test_build_prompt_raises_when_item_unset(tmp_path):
     ctx = _make_ctx(tmp_path, item=None)
     with pytest.raises(AssertionError):
         _build_prompt("build", ctx)
+
+
+def test_no_unbounded_git_diff_in_prompts():
+    for stage in ("build", "review", "document"):
+        content = _load_prompt(stage)
+        assert _UNBOUNDED_DIFF_RE.search(content) is None, (
+            f"{stage}.md contains unbounded git diff — see #48/#49"
+        )
+
+
+def test_bounded_tool_calls_section_present():
+    for stage in ("build", "review", "document"):
+        content = _load_prompt(stage)
+        assert "## Bounded tool calls (important)" in content, (
+            f"{stage}.md is missing '## Bounded tool calls (important)' section"
+        )
+
+
+def test_tracker_agnostic_language():
+    for stage in ("build", "review", "document"):
+        content = _load_prompt(stage)
+        assert "GitHub issue" not in content, (
+            f"{stage}.md uses 'GitHub issue' — prefer 'tracked item'"
+        )
+
+
+def test_build_prompt_uses_tracked_item_language():
+    content = _load_prompt("build")
+    assert "tracked item" in content


### PR DESCRIPTION
## Summary

Everything is committed. The branch is clean with commit `e18f6db` containing all the changes.

## Closes

Closes #49

## Test plan

- [ ] Run `uv run pytest tests/test_workflows/test_ralph_prompts.py -v` and verify all 13 tests pass, including the 4 new regression tests
- [ ] Verify `review.md` step 1 is now `git diff --stat ... $(git merge-base ...)..HEAD` (not `git diff main..HEAD`)
- [ ] Verify `document.md` step 1 is now the bounded stat command (not `git diff main..HEAD`)
- [ ] Verify all three prompt files contain `## Bounded tool calls (important)` section
- [ ] Verify `build.md` contains "tracked item" and no "GitHub issue" anywhere
- [ ] Grep all three files for `git diff main..HEAD` or `git diff master..HEAD` — should find nothing
- [ ] Run `cog ralph --item <N>` on a branch with 30+ changed files and confirm the review stage completes without hanging (no persist-then-Read hang)
- [ ] Confirm review quality on the output PR is not degraded — the skim+triage approach should still catch meaningful issues

---
🤖 Generated by cog. Iteration cost: $1.166
