### PR TITLE
StageExecutor: preserve partial StageResult + cause through StageError on raise (telemetry diagnostic fix) (#73)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,30 @@ Options for `cog refine`:
     --item N              Skip selection; run on issue number N
     --project-dir PATH    Project directory (default: cwd)
 
+## Telemetry
+
+Each run appends one JSON line to `<state-dir>/runs.jsonl` (default: `~/.local/share/cog/runs.jsonl`).
+
+Key fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ts` | string | ISO-8601 UTC timestamp |
+| `outcome` | string | `success`, `error`, `no-op`, `push-failed`, `deferred-by-blocker` |
+| `stages` | array | Per-stage entry with `stage`, `duration_s`, `cost_usd`, `exit_status`, `commits` |
+| `total_cost_usd` | float | Sum of stage costs |
+| `duration_seconds` | float | Wall time across all stages |
+| `error` | string\|null | `"stage 'X' failed \| cause=RunnerStalledError: ..."` on failure |
+| `cause_class` | string\|null | Exception class name of the underlying cause (e.g. `RunnerStalledError`, `RunnerTimeoutError`) |
+| `pr_url` | string\|null | PR URL if one was opened |
+
+`cause_class` is populated when a stage fails with a classifiable runner error — useful for filtering
+retry-eligible failures (`RunnerStalledError`, `RunnerTimeoutError`) from logic errors in telemetry queries.
+
+When a stage fails after the runner has done real work (e.g. committed code), the partial result is
+preserved: `stages` will contain an entry for the failed stage with accurate `duration_s`, `cost_usd`,
+and `commits` rather than zeroes.
+
 ## Development
 
     uv sync

--- a/src/cog/core/errors.py
+++ b/src/cog/core/errors.py
@@ -16,7 +16,12 @@ class StageError(WorkflowError):
         self.stage = stage
         self.result = result
         self.cause = cause
-        super().__init__(f"stage {stage.name!r} failed")
+        parts = [f"stage {stage.name!r} failed"]
+        if cause is not None:
+            parts.append(f"cause={type(cause).__name__}: {cause}")
+        if result is not None and result.exit_status not in (0, None):
+            parts.append(f"exit_status={result.exit_status}")
+        super().__init__(" | ".join(parts))
 
 
 class RunnerError(Exception):

--- a/src/cog/core/workflow.py
+++ b/src/cog/core/workflow.py
@@ -89,6 +89,11 @@ class StageExecutor:
                 await workflow.finalize_success(ctx, results)
             else:
                 await workflow.finalize_noop(ctx, results)
+        except StageError as e:
+            if e.result is not None and e.result not in results:
+                results.append(e.result)
+            await workflow.finalize_error(ctx, e, results)
+            raise
         except Exception as e:
             await workflow.finalize_error(ctx, e, results)
             raise
@@ -117,7 +122,10 @@ class StageExecutor:
                     await sink.emit(event)
         except Exception as e:
             if not stage.tolerate_failure:
-                raise StageError(stage, cause=e) from e
+                partial = await self._make_partial_stage_result(
+                    stage, start, head_before, ctx, run_result, e
+                )
+                raise StageError(stage, result=partial, cause=e) from e
             error = e
         duration = time.monotonic() - start
 
@@ -173,3 +181,42 @@ class StageExecutor:
                 raise StageError(stage, stage_result)
             stage_result = replace(stage_result, error=StageError(stage, stage_result))
         return stage_result
+
+    async def _make_partial_stage_result(
+        self,
+        stage: Stage,
+        start: float,
+        head_before: str | None,
+        ctx: ExecutionContext,
+        run_result: RunResult | None,
+        error: Exception | None,
+    ) -> StageResult:
+        """Best-effort StageResult for error paths."""
+        duration = time.monotonic() - start
+        commits_created = 0
+        if head_before is not None:
+            try:
+                commits_created = await git.commits_between(ctx.project_dir, head_before)
+            except GitError:
+                pass
+        if run_result is not None:
+            return StageResult(
+                stage=stage,
+                duration_seconds=duration,
+                cost_usd=run_result.total_cost_usd,
+                exit_status=run_result.exit_status,
+                final_message=run_result.final_message,
+                stream_json_path=run_result.stream_json_path,
+                commits_created=commits_created,
+                error=error,
+            )
+        return StageResult(
+            stage=stage,
+            duration_seconds=duration,
+            cost_usd=0.0,
+            exit_status=-1,
+            final_message="",
+            stream_json_path=Path("/dev/null"),
+            commits_created=commits_created,
+            error=error,
+        )

--- a/src/cog/telemetry.py
+++ b/src/cog/telemetry.py
@@ -52,6 +52,7 @@ class TelemetryRecord:
     stages: tuple[StageTelemetry, ...]
     total_cost_usd: float
     error: str | None
+    cause_class: str | None = None
 
     @classmethod
     def build(
@@ -66,6 +67,7 @@ class TelemetryRecord:
         pr_url: str | None = None,
         duration_seconds: float,
         error: str | None = None,
+        cause_class: str | None = None,
     ) -> "TelemetryRecord":
         return cls(
             ts=datetime.now(UTC).isoformat(),
@@ -80,6 +82,7 @@ class TelemetryRecord:
             stages=tuple(StageTelemetry.from_stage_result(r) for r in results),
             total_cost_usd=sum(r.cost_usd for r in results),
             error=error,
+            cause_class=cause_class,
         )
 
 

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -298,7 +298,7 @@ class RalphWorkflow(Workflow):
             )
         # KEEP agent-ready label — user fixes infra, ralph retries next run.
         # Don't mark processed — item stays eligible.
-        await self._write_telemetry(ctx, results, "error", error=str(error))
+        await self._write_telemetry(ctx, results, "error", error=error)
         await self.write_report(ctx, results, "error", error=error)
 
     async def write_report(
@@ -413,7 +413,7 @@ class RalphWorkflow(Workflow):
             pass
         # Don't mark processed — local commits exist; next run either reuses the
         # branch (v1.1 orphan-resume) or fails cleanly on create_branch (v1).
-        await self._write_telemetry(ctx, results, "push-failed", error=str(error))
+        await self._write_telemetry(ctx, results, "push-failed", error=error)
         await self.write_report(ctx, results, "error", error=error)
 
     async def _write_telemetry(
@@ -423,8 +423,14 @@ class RalphWorkflow(Workflow):
         outcome: str,
         *,
         pr_url: str | None = None,
-        error: str | None = None,
+        error: Exception | None = None,
     ) -> None:
+        error_str: str | None = None
+        cause_class: str | None = None
+        if error is not None:
+            error_str = str(error)
+            if isinstance(error, StageError) and error.cause is not None:
+                cause_class = type(error.cause).__name__
         if ctx.telemetry is None:
             return
         record = TelemetryRecord.build(
@@ -436,6 +442,7 @@ class RalphWorkflow(Workflow):
             branch=ctx.work_branch,
             pr_url=pr_url,
             duration_seconds=sum(r.duration_seconds for r in results),
-            error=error,
+            error=error_str,
+            cause_class=cause_class,
         )
         await ctx.telemetry.write(record)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,78 @@
+"""Tests for StageError message formatting."""
+
+from pathlib import Path
+
+from cog.core.errors import StageError
+from cog.core.outcomes import StageResult
+from cog.core.stage import Stage
+from tests.fakes import EchoRunner
+
+
+def _make_stage(name: str = "build") -> Stage:
+    return Stage(name=name, prompt_source=lambda _: "", model="m", runner=EchoRunner())
+
+
+def _make_result(stage: Stage, *, exit_status: int = 0) -> StageResult:
+    return StageResult(
+        stage=stage,
+        duration_seconds=1.0,
+        cost_usd=0.0,
+        exit_status=exit_status,
+        final_message="",
+        stream_json_path=Path("/dev/null"),
+        commits_created=0,
+    )
+
+
+def test_stage_error_no_cause_no_result_matches_legacy_format():
+    err = StageError(_make_stage())
+    assert str(err) == "stage 'build' failed"
+
+
+def test_stage_error_with_cause_includes_cause_class_and_message():
+    stage = _make_stage()
+    cause = RuntimeError("runner exploded")
+    err = StageError(stage, cause=cause)
+    assert "cause=RuntimeError: runner exploded" in str(err)
+
+
+def test_stage_error_with_result_non_zero_exit_includes_exit_status():
+    stage = _make_stage()
+    result = _make_result(stage, exit_status=-1)
+    err = StageError(stage, result=result)
+    assert "exit_status=-1" in str(err)
+
+
+def test_stage_error_with_both_cause_and_exit_status():
+    stage = _make_stage()
+    cause = RuntimeError("exploded")
+    result = _make_result(stage, exit_status=-1)
+    err = StageError(stage, result=result, cause=cause)
+    s = str(err)
+    assert s.startswith("stage 'build' failed")
+    assert "cause=RuntimeError: exploded" in s
+    assert "exit_status=-1" in s
+    assert s.index("cause=") < s.index("exit_status=")
+
+
+def test_stage_error_result_with_zero_exit_does_not_add_exit_status():
+    stage = _make_stage()
+    result = _make_result(stage, exit_status=0)
+    err = StageError(stage, result=result)
+    assert "exit_status" not in str(err)
+
+
+def test_stage_error_cause_preserves_type():
+    class CustomError(Exception):
+        pass
+
+    stage = _make_stage()
+    cause = CustomError("something")
+    err = StageError(stage, cause=cause)
+    assert err.cause is cause
+    assert isinstance(err.cause, CustomError)
+
+
+def test_stage_error_stage_name_in_message():
+    err = StageError(_make_stage("review"))
+    assert "review" in str(err)

--- a/tests/test_stage_executor.py
+++ b/tests/test_stage_executor.py
@@ -17,6 +17,25 @@ from cog.core.workflow import StageExecutor, Workflow
 from tests.fakes import EchoRunner, ExitNonZeroRunner, FailingRunner
 
 
+class _ResultThenRaisingRunner(AgentRunner):
+    """Yields a ResultEvent with given cost, then raises RuntimeError."""
+
+    def __init__(self, cost: float = 0.42) -> None:
+        self._cost = cost
+
+    async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+        yield ResultEvent(
+            result=RunResult(
+                final_message="partial",
+                total_cost_usd=self._cost,
+                exit_status=0,
+                stream_json_path=Path("/dev/null"),
+                duration_seconds=0.0,
+            )
+        )
+        raise RuntimeError("died after result")
+
+
 def _make_item() -> Item:
     return Item(
         tracker_id="test",
@@ -130,7 +149,8 @@ async def test_runner_raises_wraps_in_stage_error_with_cause(ctx_factory):
         await StageExecutor().run(wf, ctx_factory())
     err = exc_info.value
     assert err.stage.name == "s1"
-    assert err.result is None
+    assert err.result is not None
+    assert err.result.exit_status == -1
     assert isinstance(err.cause, RuntimeError)
     assert wf.finalize_called == "error"
 
@@ -330,3 +350,165 @@ async def test_subsequent_stages_run_after_tolerated_failure(ctx_factory):
     assert results[1].error is not None
     assert results[0].error is None
     assert results[2].error is None
+
+
+# --- partial-result capture on runner exception ---
+
+
+async def test_stage_executor_runner_exception_attaches_partial_stage_result(ctx_factory):
+    stage = _make_tolerate_stage(FailingRunner(), tolerate=False)
+    with pytest.raises(StageError) as exc_info:
+        await StageExecutor()._run_stage(stage, ctx_factory())
+    err = exc_info.value
+    assert err.result is not None
+    assert err.result.exit_status == -1
+    assert err.result.duration_seconds >= 0
+
+
+async def test_stage_executor_runner_exception_partial_result_has_commits_count(ctx_factory):
+    stage = _make_tolerate_stage(FailingRunner(), tolerate=False)
+    with (
+        patch("cog.core.workflow.git.current_head_sha", new=AsyncMock(return_value="abc123")),
+        patch("cog.core.workflow.git.commits_between", new=AsyncMock(return_value=2)),
+        pytest.raises(StageError) as exc_info,
+    ):
+        await StageExecutor()._run_stage(stage, ctx_factory())
+    assert exc_info.value.result is not None
+    assert exc_info.value.result.commits_created == 2
+
+
+async def test_stage_executor_runner_exception_partial_result_has_cost_when_result_emitted(
+    ctx_factory,
+):
+    stage = _make_tolerate_stage(_ResultThenRaisingRunner(cost=0.42), tolerate=False)
+    with pytest.raises(StageError) as exc_info:
+        await StageExecutor()._run_stage(stage, ctx_factory())
+    assert exc_info.value.result is not None
+    assert exc_info.value.result.cost_usd == pytest.approx(0.42)
+
+
+async def test_stage_executor_runner_exception_partial_result_zero_cost_when_no_result_event(
+    ctx_factory,
+):
+    stage = _make_tolerate_stage(FailingRunner(), tolerate=False)
+    with pytest.raises(StageError) as exc_info:
+        await StageExecutor()._run_stage(stage, ctx_factory())
+    assert exc_info.value.result is not None
+    assert exc_info.value.result.cost_usd == 0.0
+
+
+async def test_stage_executor_runner_exception_partial_result_captures_error(ctx_factory):
+    exc = RuntimeError("boom")
+    stage = _make_tolerate_stage(FailingRunner(exc), tolerate=False)
+    with pytest.raises(StageError) as exc_info:
+        await StageExecutor()._run_stage(stage, ctx_factory())
+    assert exc_info.value.result is not None
+    assert exc_info.value.result.error is exc
+
+
+# --- StageExecutor.run propagation ---
+
+
+async def test_stage_executor_appends_partial_result_from_stage_error_before_finalize_error(
+    ctx_factory,
+):
+    captured: list[StageResult] = []
+
+    class _CapturingWorkflow(_SimpleWorkflow):
+        async def finalize_error(self, ctx, error, results):
+            captured.extend(results)
+            await super().finalize_error(ctx, error, results)
+
+    wf = _CapturingWorkflow(_RaisingRunner())
+    with pytest.raises(StageError):
+        await StageExecutor().run(wf, ctx_factory())
+    assert len(captured) == 1
+    assert captured[0].exit_status == -1
+
+
+async def test_stage_executor_does_not_double_append_existing_result(ctx_factory):
+    captured: list[StageResult] = []
+
+    class _CapturingWorkflow(_SimpleWorkflow):
+        async def finalize_error(self, ctx, error, results):
+            captured.extend(results)
+            await super().finalize_error(ctx, error, results)
+
+    wf = _CapturingWorkflow(_FailRunner())
+    with pytest.raises(StageError):
+        await StageExecutor().run(wf, ctx_factory())
+    assert len(captured) == 1
+
+
+async def test_stage_executor_generic_exception_does_not_append_partial(ctx_factory):
+    captured: list[StageResult] = []
+
+    class _PreRaisingWorkflow(_SimpleWorkflow):
+        async def pre_stages(self, ctx):
+            raise RuntimeError("pre_stages failed")
+
+        async def finalize_error(self, ctx, error, results):
+            captured.extend(results)
+            await super().finalize_error(ctx, error, results)
+
+    wf = _PreRaisingWorkflow(EchoRunner())
+    with pytest.raises(RuntimeError):
+        await StageExecutor().run(wf, ctx_factory())
+    assert captured == []
+
+
+# --- _make_partial_stage_result unit tests ---
+
+
+async def test_make_partial_stage_result_with_run_result(ctx_factory):
+    executor = StageExecutor()
+    stage = _make_tolerate_stage(EchoRunner(), tolerate=False)
+    run_result = RunResult(
+        final_message="hello",
+        total_cost_usd=0.5,
+        exit_status=1,
+        stream_json_path=Path("/dev/null"),
+        duration_seconds=0.0,
+    )
+    import time
+
+    start = time.monotonic()
+    result = await executor._make_partial_stage_result(
+        stage, start, None, ctx_factory(), run_result, None
+    )
+    assert result.cost_usd == pytest.approx(0.5)
+    assert result.exit_status == 1
+    assert result.final_message == "hello"
+    assert result.commits_created == 0
+
+
+async def test_make_partial_stage_result_without_run_result(ctx_factory):
+    executor = StageExecutor()
+    stage = _make_tolerate_stage(EchoRunner(), tolerate=False)
+    import time
+
+    start = time.monotonic()
+    result = await executor._make_partial_stage_result(
+        stage, start, None, ctx_factory(), None, None
+    )
+    assert result.exit_status == -1
+    assert result.cost_usd == 0.0
+    assert result.final_message == ""
+    assert result.stream_json_path == Path("/dev/null")
+    assert result.commits_created == 0
+
+
+async def test_make_partial_stage_result_commits_count_tolerates_git_error(ctx_factory):
+    executor = StageExecutor()
+    stage = _make_tolerate_stage(EchoRunner(), tolerate=False)
+    import time
+
+    start = time.monotonic()
+    with patch(
+        "cog.core.workflow.git.commits_between",
+        new=AsyncMock(side_effect=GitError("counting failed")),
+    ):
+        result = await executor._make_partial_stage_result(
+            stage, start, "abc123", ctx_factory(), None, None
+        )
+    assert result.commits_created == 0

--- a/tests/test_telemetry_record.py
+++ b/tests/test_telemetry_record.py
@@ -1,5 +1,7 @@
 """Tests for TelemetryRecord and StageTelemetry construction."""
 
+import dataclasses
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -164,3 +166,80 @@ def test_outcome_literal_accepted():
             duration_seconds=1.0,
         )
         assert record.outcome == outcome
+
+
+def test_telemetry_record_cause_class_default_is_none():
+    record = TelemetryRecord.build(
+        project="p",
+        workflow="w",
+        item=_make_item(),
+        outcome="success",
+        results=[],
+        duration_seconds=1.0,
+    )
+    assert record.cause_class is None
+
+
+def test_telemetry_record_cause_class_populated_when_provided():
+    record = TelemetryRecord.build(
+        project="p",
+        workflow="w",
+        item=_make_item(),
+        outcome="error",
+        results=[],
+        duration_seconds=1.0,
+        cause_class="RunnerStalledError",
+    )
+    assert record.cause_class == "RunnerStalledError"
+
+
+def test_telemetry_record_cause_class_none_for_generic_exception():
+    record = TelemetryRecord.build(
+        project="p",
+        workflow="w",
+        item=_make_item(),
+        outcome="error",
+        results=[],
+        duration_seconds=1.0,
+        error="something went wrong",
+        cause_class=None,
+    )
+    assert record.cause_class is None
+
+
+def test_telemetry_record_json_includes_cause_class():
+    record = TelemetryRecord.build(
+        project="p",
+        workflow="w",
+        item=_make_item(),
+        outcome="error",
+        results=[],
+        duration_seconds=1.0,
+        error="some error",
+        cause_class="RunnerTimeoutError",
+    )
+    d = dataclasses.asdict(record)
+    line = json.dumps(d)
+    assert "cause_class" in line
+    assert "RunnerTimeoutError" in line
+
+
+def test_telemetry_record_backward_compat_missing_cause_class():
+    # Old JSONL lines without cause_class should parse correctly
+    # when cause_class defaults to None
+    record = TelemetryRecord.build(
+        project="p",
+        workflow="w",
+        item=_make_item(),
+        outcome="error",
+        results=[],
+        duration_seconds=1.0,
+        error="some error",
+    )
+    assert record.cause_class is None
+    d = dataclasses.asdict(record)
+    # Simulate old JSONL that doesn't have cause_class
+    d.pop("cause_class", None)
+    # Re-constructing from dict without cause_class uses the default
+    reconstructed = TelemetryRecord(**{**d, "stages": tuple(d["stages"])})  # type: ignore[arg-type]
+    assert reconstructed.cause_class is None

--- a/tests/test_workflows/test_ralph_finalization.py
+++ b/tests/test_workflows/test_ralph_finalization.py
@@ -712,3 +712,83 @@ async def test_full_iteration_end_to_end_noop(tmp_path: Path) -> None:
     tracker.add_label.assert_awaited_once_with(ctx.item, "agent-abandoned")
     tracker.remove_label.assert_awaited_once_with(ctx.item, "agent-ready")
     assert cache.is_processed(ctx.item)
+
+
+# ---------------------------------------------------------------------------
+# _write_telemetry cause_class population
+# ---------------------------------------------------------------------------
+
+
+async def test_finalize_error_telemetry_cause_class_populated_for_stage_error_with_cause(
+    tmp_path: Path,
+) -> None:
+    from cog.core.errors import RunnerStalledError
+    from cog.core.stage import Stage
+
+    tel = _make_telemetry()
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path, telemetry=tel)
+    stage = Stage(name="build", prompt_source=lambda _: "", model="m", runner=None)  # type: ignore[arg-type]
+    cause = RunnerStalledError(inactivity_seconds=120)
+    err = StageError(stage, cause=cause)
+    await wf.finalize_error(ctx, err, [])
+    record = tel.write.call_args.args[0]
+    assert record.cause_class == "RunnerStalledError"
+
+
+async def test_finalize_error_telemetry_cause_class_none_for_generic_exception(
+    tmp_path: Path,
+) -> None:
+    tel = _make_telemetry()
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path, telemetry=tel)
+    await wf.finalize_error(ctx, RuntimeError("boom"), [])
+    record = tel.write.call_args.args[0]
+    assert record.cause_class is None
+
+
+async def test_finalize_error_telemetry_cause_class_none_for_stage_error_without_cause(
+    tmp_path: Path,
+) -> None:
+    from cog.core.stage import Stage
+
+    tel = _make_telemetry()
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path, telemetry=tel)
+    stage = Stage(name="build", prompt_source=lambda _: "", model="m", runner=None)  # type: ignore[arg-type]
+    err = StageError(stage, result=make_stage_result("build"))
+    await wf.finalize_error(ctx, err, [])
+    record = tel.write.call_args.args[0]
+    assert record.cause_class is None
+
+
+async def test_finalize_error_includes_partial_stage_result_in_telemetry(
+    tmp_path: Path,
+) -> None:
+    from cog.core.stage import Stage
+
+    tel = _make_telemetry()
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path, telemetry=tel)
+    stage = Stage(name="build", prompt_source=lambda _: "", model="m", runner=None)  # type: ignore[arg-type]
+    partial = make_stage_result("build", cost=0.25, duration=5.0)
+    err = StageError(stage, result=partial, cause=RuntimeError("crash"))
+    await wf.finalize_error(ctx, err, [partial])
+    record = tel.write.call_args.args[0]
+    assert len(record.stages) == 1
+    assert record.stages[0].stage == "build"
+
+
+async def test_finalize_error_telemetry_error_string_contains_cause(tmp_path: Path) -> None:
+    from cog.core.stage import Stage
+
+    tel = _make_telemetry()
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path, telemetry=tel)
+    stage = Stage(name="build", prompt_source=lambda _: "", model="m", runner=None)  # type: ignore[arg-type]
+    cause = RuntimeError("runner exploded")
+    err = StageError(stage, cause=cause)
+    await wf.finalize_error(ctx, err, [])
+    record = tel.write.call_args.args[0]
+    assert record.error is not None
+    assert "runner exploded" in record.error


### PR DESCRIPTION
## Summary



## Closes

Closes #73

## Test plan

- [ ] Trigger a stage failure (e.g. `COG_RUNNER_TIMEOUT_SECONDS=5 cog ralph --item <N>`) → inspect `runs.jsonl` → `stages` array has an entry for the failed stage with non-zero `duration_seconds` and correct `cost_usd`
- [ ] Verify `error` field in the JSONL record contains `cause=RunnerTimeoutError: ...` (not just the generic `"stage 'build' failed"`)
- [ ] Verify `cause_class` field in the JSONL record is `"RunnerTimeoutError"` (not null)
- [ ] Trigger a runner stall (`RunnerStalledError`) → verify `cause_class` is `"RunnerStalledError"` and `error` contains the `last_event_summary`
- [ ] Trigger a non-zero exit (stage returns exit_status=1) → verify `error` includes `exit_status=1` and `cause_class` is null
- [ ] Confirm a fully successful run still writes `cause_class: null` and `error: null`
- [ ] Check that a stage that committed before failing (e.g. commit exists on disk) shows `commits_created > 0` in the partial stage telemetry entry
- [ ] Verify the `error` string in `StageError` with no cause/result is still exactly `"stage 'X' failed"` (backward-compatible format)
- [ ] After a runner crash, confirm `finalize_error` receives the partial `StageResult` in its `results` list (check via the comment posted to the issue tracker — it should reflect the build stage's final_message if any)

---
🤖 Generated by cog. Iteration cost: $2.408
