### PR TITLE
Ralph --loop + --max-iterations: autonomous queue-drain mode across headless + Textual (#16)

### DIFF
--- a/src/cog/cli.py
+++ b/src/cog/cli.py
@@ -32,11 +32,19 @@ def callback(
 def ralph(
     item: int | None = typer.Option(None, "--item", help="Skip selection; run on this issue."),
     loop: bool = typer.Option(False, "--loop", help="Autonomous queue-drain mode (#16)."),
+    max_iterations: int | None = typer.Option(
+        None,
+        "--max-iterations",
+        help="Stop after N iterations (implies --loop).",
+    ),
     headless: bool = typer.Option(False, "--headless", help="Bypass Textual; log to stderr."),
     project_dir: Path | None = typer.Option(None, "--project-dir"),  # noqa: B008
 ) -> None:
     """Autonomous agent: picks next agent-ready issue, runs build/review/document, opens PR."""
     from cog.workflows.ralph import RalphWorkflow
+
+    if max_iterations is not None:
+        loop = True  # --max-iterations N implies --loop
 
     try:
         exit_code = asyncio.run(
@@ -45,6 +53,7 @@ def ralph(
                 project_dir or Path.cwd(),
                 item_id=item,
                 loop=loop,
+                max_iterations=max_iterations,
                 headless=headless,
             )
         )

--- a/src/cog/headless.py
+++ b/src/cog/headless.py
@@ -11,6 +11,7 @@ from cog.core.runner import (
     ToolUseEvent,
 )
 from cog.core.workflow import StageExecutor, Workflow
+from cog.loop import LoopState, fresh_iteration_context
 
 
 class StderrEventSink:
@@ -37,33 +38,55 @@ class StderrEventSink:
 
 async def run_headless(
     workflow: Workflow,
-    ctx: ExecutionContext,
+    base_ctx: ExecutionContext,
     *,
-    loop: bool = False,  # unused here; the #16 loop wrapper consumes this
+    loop: bool = False,
+    max_iterations: int | None = None,
 ) -> int:
-    """Run one workflow iteration in headless mode. Returns 0/1 exit code."""
-    ctx.event_sink = StderrEventSink()
-    # ctx.input_provider stays None — headless cannot prompt
-
+    """Run workflow iterations in headless mode. Returns 0/1 exit code."""
+    base_ctx.event_sink = StderrEventSink()
+    state = LoopState()
     start = time.monotonic()
-    try:
-        results = await StageExecutor().run(workflow, ctx)
-    except StageError as e:
-        duration = time.monotonic() - start
+    while True:
+        if max_iterations is not None and state.iteration >= max_iterations:
+            break
+        state.iteration += 1
+        if loop:
+            sys.stderr.write(f"\n═══ iteration {state.iteration} ═══\n")
+        ctx = fresh_iteration_context(base_ctx)
+        try:
+            results = await StageExecutor().run(workflow, ctx)
+        except StageError as e:
+            duration = time.monotonic() - start
+            sys.stderr.write(
+                f"\niteration FAILED: stage {e.stage.name!r} failed after {duration:.0f}s\n"
+            )
+            return 1
+        except Exception as e:  # noqa: BLE001 - surface any unexpected failure
+            duration = time.monotonic() - start
+            sys.stderr.write(
+                f"\niteration FAILED: {type(e).__name__}: {e} (after {duration:.0f}s)\n"
+            )
+            return 1
+        if not results:
+            state.iteration -= 1  # empty-queue probe: don't count as an iteration
+            break
+        state.cumulative_cost_usd += sum(r.cost_usd for r in results)
+        iter_duration = sum(r.duration_seconds for r in results)
+        outcome = "success" if any(r.commits_created > 0 for r in results) else "no-op"
         sys.stderr.write(
-            f"\niteration FAILED: stage {e.stage.name!r} failed after {duration:.0f}s\n"
+            f"iteration complete: outcome={outcome}, "
+            f"cost=${sum(r.cost_usd for r in results):.3f}, "
+            f"duration={iter_duration:.0f}s\n"
         )
-        return 1
-    except Exception as e:  # noqa: BLE001 - surface any unexpected failure
-        duration = time.monotonic() - start
-        sys.stderr.write(f"\niteration FAILED: {type(e).__name__}: {e} (after {duration:.0f}s)\n")
-        return 1
+        if not loop:
+            break
 
-    duration = time.monotonic() - start
-    total_cost = sum(r.cost_usd for r in results)
-    outcome = "success" if results else "no-op"
-    sys.stderr.write(
-        f"\niteration complete: outcome={outcome}, "
-        f"cost=${total_cost:.3f}, duration={duration:.0f}s\n"
-    )
+    total = time.monotonic() - start
+    if loop:
+        sys.stderr.write(
+            f"\nloop complete: {state.iteration} iteration(s), "
+            f"total cost ${state.cumulative_cost_usd:.3f}, "
+            f"total duration {total:.0f}s\n"
+        )
     return 0

--- a/src/cog/loop.py
+++ b/src/cog/loop.py
@@ -1,0 +1,23 @@
+import tempfile
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+from cog.core.context import ExecutionContext
+
+
+@dataclass
+class LoopState:
+    """Cross-iteration accumulators (counter, cumulative cost)."""
+
+    iteration: int = 0
+    cumulative_cost_usd: float = 0.0
+
+
+def fresh_iteration_context(base: ExecutionContext) -> ExecutionContext:
+    """New ExecutionContext for the next iteration.
+
+    Preserves project_dir / state_cache / telemetry / event_sink / input_provider / headless.
+    Resets item / work_branch. Creates a new tmp_dir.
+    """
+    new_tmp = Path(tempfile.mkdtemp(prefix="cog-"))
+    return replace(base, tmp_dir=new_tmp, item=None, work_branch=None)

--- a/src/cog/ui/app.py
+++ b/src/cog/ui/app.py
@@ -21,9 +21,14 @@ class CogApp(App):
         self.push_screen(self._initial)
 
 
-async def run_textual(workflow: Workflow, ctx: ExecutionContext, *, loop: bool) -> int:
-    """Single-run launcher. Loop semantics live in #16."""
-    run_screen = RunScreen(workflow, ctx)
+async def run_textual(
+    workflow: Workflow,
+    ctx: ExecutionContext,
+    *,
+    loop: bool,
+    max_iterations: int | None = None,
+) -> int:
+    run_screen = RunScreen(workflow, ctx, loop=loop, max_iterations=max_iterations)
     app = CogApp(run_screen)
     await app.run_async()
     return 0 if run_screen._state in ("completed", "cancelled") else 1

--- a/src/cog/ui/screens/run.py
+++ b/src/cog/ui/screens/run.py
@@ -11,7 +11,6 @@ from textual.widgets import Footer, Header, Static
 from textual.worker import Worker
 
 from cog.core.context import ExecutionContext
-from cog.core.outcomes import StageResult
 from cog.core.runner import RunEvent, StageEndEvent
 from cog.core.workflow import StageExecutor, Workflow
 from cog.loop import LoopState, fresh_iteration_context
@@ -121,7 +120,6 @@ class RunScreen(Screen):
                 if not results:
                     self._loop_state.iteration -= 1  # empty-queue probe: don't count
                     break
-                self._loop_state.cumulative_cost_usd += sum(r.cost_usd for r in results)
                 self._refresh_footer()
         except asyncio.CancelledError:
             self._state = "cancelled"
@@ -160,17 +158,13 @@ class RunScreen(Screen):
 
     def _show_loop_summary_panel(self) -> None:
         iterations = self._loop_state.iteration
-        cost = self._loop_state.cumulative_cost_usd
+        cost = self._cumulative_cost
         if self._loop:
             self._set_result_panel(
                 f"[green]✓ Complete[/green] — {iterations} iteration(s), ${cost:.3f}"
             )
         else:
             self._set_result_panel(f"[green]✓ Complete[/green] — ${cost:.3f}")
-
-    def _show_completion_panel(self, results: list[StageResult]) -> None:
-        cost = sum(r.cost_usd for r in results)
-        self._set_result_panel(f"[green]✓ Complete[/green] — ${cost:.3f}")
 
     def _show_error_panel(self, e: Exception) -> None:
         self._set_result_panel(f"[red]✗ Failed:[/red] {e!s}")

--- a/src/cog/ui/screens/run.py
+++ b/src/cog/ui/screens/run.py
@@ -1,4 +1,4 @@
-"""RunScreen — single-run lifecycle. Loop semantics deferred to #16."""
+"""RunScreen — multi-iteration lifecycle (#16)."""
 
 import asyncio
 import time
@@ -14,6 +14,7 @@ from cog.core.context import ExecutionContext
 from cog.core.outcomes import StageResult
 from cog.core.runner import RunEvent, StageEndEvent
 from cog.core.workflow import StageExecutor, Workflow
+from cog.loop import LoopState, fresh_iteration_context
 
 
 class _CountingSink:
@@ -37,12 +38,23 @@ class RunScreen(Screen):
         ("q", "quit_or_return", "Quit / back"),
     ]
 
-    def __init__(self, workflow: Workflow, ctx: ExecutionContext) -> None:
+    def __init__(
+        self,
+        workflow: Workflow,
+        ctx: ExecutionContext,
+        *,
+        loop: bool = False,
+        max_iterations: int | None = None,
+    ) -> None:
         super().__init__()
         self._workflow = workflow
-        self._ctx = ctx
+        self._base_ctx = ctx
+        self._loop = loop
+        # Single-run is implemented as loop with max_iterations=1
+        self._max_iterations = max_iterations if loop else 1
         self._state: Literal["running", "completed", "failed", "cancelled"] = "running"
         self._cumulative_cost = 0.0
+        self._loop_state = LoopState()
         self._started_at = 0.0
         self._content: Widget | None = None
         self._footer_widget: Static | None = None
@@ -62,11 +74,11 @@ class RunScreen(Screen):
 
     def on_mount(self) -> None:
         self._started_at = time.monotonic()
-        self._ctx.event_sink = _CountingSink(self._content, self)
+        self._base_ctx.event_sink = _CountingSink(self._content, self)
         if hasattr(self._content, "prompt"):
-            self._ctx.input_provider = self._content
+            self._base_ctx.input_provider = self._content
         self.set_interval(1.0, self._update_clock)
-        self._worker = self.run_worker(self._run_once(), exclusive=True)
+        self._worker = self.run_worker(self._run_loop(), exclusive=True)
 
     def _elapsed(self) -> str:
         if self._started_at == 0.0:
@@ -77,7 +89,15 @@ class RunScreen(Screen):
         return f"{secs // 60}m{secs % 60:02d}s"
 
     def _footer_text(self) -> str:
-        return f"state={self._state}  elapsed={self._elapsed()}  cost=${self._cumulative_cost:.3f}"
+        iteration = self._loop_state.iteration
+        max_iter = self._max_iterations
+        if self._loop and max_iter is not None:
+            counter = f"iteration {iteration}/{max_iter}"
+        elif self._loop:
+            counter = f"iteration {iteration}"
+        else:
+            counter = f"state={self._state}"
+        return f"{counter}  cost=${self._cumulative_cost:.3f}  elapsed={self._elapsed()}"
 
     def _refresh_footer(self) -> None:
         if self._footer_widget is not None:
@@ -86,19 +106,47 @@ class RunScreen(Screen):
     def _update_clock(self) -> None:
         self._refresh_footer()
 
-    async def _run_once(self) -> None:
+    async def _run_loop(self) -> None:
         try:
-            results = await StageExecutor().run(self._workflow, self._ctx)
-            self._state = "completed"
-            self._show_completion_panel(results)
+            while True:
+                if (
+                    self._max_iterations is not None
+                    and self._loop_state.iteration >= self._max_iterations
+                ):
+                    break
+                self._loop_state.iteration += 1
+                self._announce_iteration_divider()
+                ctx = fresh_iteration_context(self._base_ctx)
+                results = await StageExecutor().run(self._workflow, ctx)
+                if not results:
+                    self._loop_state.iteration -= 1  # empty-queue probe: don't count
+                    break
+                self._loop_state.cumulative_cost_usd += sum(r.cost_usd for r in results)
+                self._refresh_footer()
         except asyncio.CancelledError:
             self._state = "cancelled"
             self._show_cancellation_panel()
+            raise
         except Exception as e:
             self._state = "failed"
             self._show_error_panel(e)
-        finally:
-            self._refresh_footer()
+            return
+        self._state = "completed"
+        self._show_loop_summary_panel()
+        self._refresh_footer()
+
+    def _announce_iteration_divider(self) -> None:
+        if not self._loop or self._loop_state.iteration <= 1:
+            return
+        if not self.is_attached:
+            return
+        self.mount(
+            Static(
+                f"═══ iteration {self._loop_state.iteration} ═══",
+                classes="iteration-divider",
+            ),
+            before=self._footer_widget,
+        )
 
     def _set_result_panel(self, markup: str) -> None:
         """Mount or update the result panel."""
@@ -109,6 +157,16 @@ class RunScreen(Screen):
             panels.first(Static).update(markup)
         else:
             self.mount(Static(markup, id="result-panel"))
+
+    def _show_loop_summary_panel(self) -> None:
+        iterations = self._loop_state.iteration
+        cost = self._loop_state.cumulative_cost_usd
+        if self._loop:
+            self._set_result_panel(
+                f"[green]✓ Complete[/green] — {iterations} iteration(s), ${cost:.3f}"
+            )
+        else:
+            self._set_result_panel(f"[green]✓ Complete[/green] — ${cost:.3f}")
 
     def _show_completion_panel(self, results: list[StageResult]) -> None:
         cost = sum(r.cost_usd for r in results)

--- a/src/cog/ui/wire.py
+++ b/src/cog/ui/wire.py
@@ -23,6 +23,7 @@ async def build_and_run(
     item_id: int | None,
     loop: bool,
     headless: bool,
+    max_iterations: int | None = None,
 ) -> int:
     # 1. Preflight
     results: list[PreflightResult] = await run_checks(workflow_cls.preflight_checks, project_dir)
@@ -67,8 +68,8 @@ async def build_and_run(
         ctx.item = await tracker.get(str(item_id))
 
     if headless:
-        return await run_headless(workflow, ctx)
+        return await run_headless(workflow, ctx, loop=loop, max_iterations=max_iterations)
 
     from cog.ui.app import run_textual
 
-    return await run_textual(workflow, ctx, loop=loop)
+    return await run_textual(workflow, ctx, loop=loop, max_iterations=max_iterations)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+from unittest.mock import AsyncMock
 
 from textual.app import ComposeResult
 from textual.widget import Widget
@@ -185,6 +186,29 @@ class ExitNonZeroRunner(AgentRunner):
                 duration_seconds=0.0,
             )
         )
+
+
+def make_queue_tracker(items_per_call: list[list[Item]]) -> AsyncMock:
+    """AsyncMock IssueTracker whose list_by_label returns successive lists.
+
+    Simulates items disappearing as ralph processes them. The final empty list
+    signals queue drained. If more calls occur than lists provided, returns [].
+    """
+    call_index = 0
+    responses = list(items_per_call)
+
+    async def _list_by_label(*args: Any, **kwargs: Any) -> list[Item]:
+        nonlocal call_index
+        if call_index < len(responses):
+            result = responses[call_index]
+        else:
+            result = []
+        call_index += 1
+        return result
+
+    mock = AsyncMock()
+    mock.list_by_label.side_effect = _list_by_label
+    return mock
 
 
 class FakeSubprocessRegistry:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock
 
 from textual.app import ComposeResult
 from textual.widget import Widget
@@ -186,29 +185,6 @@ class ExitNonZeroRunner(AgentRunner):
                 duration_seconds=0.0,
             )
         )
-
-
-def make_queue_tracker(items_per_call: list[list[Item]]) -> AsyncMock:
-    """AsyncMock IssueTracker whose list_by_label returns successive lists.
-
-    Simulates items disappearing as ralph processes them. The final empty list
-    signals queue drained. If more calls occur than lists provided, returns [].
-    """
-    call_index = 0
-    responses = list(items_per_call)
-
-    async def _list_by_label(*args: Any, **kwargs: Any) -> list[Item]:
-        nonlocal call_index
-        if call_index < len(responses):
-            result = responses[call_index]
-        else:
-            result = []
-        call_index += 1
-        return result
-
-    mock = AsyncMock()
-    mock.list_by_label.side_effect = _list_by_label
-    return mock
 
 
 class FakeSubprocessRegistry:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -105,6 +105,47 @@ def test_cog_ralph_headless_forwards_flag(monkeypatch, tmp_path):
     assert calls[0]["headless"] is True
 
 
+def test_cog_ralph_max_iterations_forwards(monkeypatch, tmp_path):
+    calls: list[dict] = []
+
+    async def fake_build_and_run(*args: Any, **kwargs: Any) -> int:
+        calls.append({"args": args, **kwargs})
+        return 0
+
+    monkeypatch.setattr("cog.cli.build_and_run", fake_build_and_run)
+    result = runner.invoke(app, ["ralph", "--project-dir", str(tmp_path), "--max-iterations", "3"])
+    assert result.exit_code == 0
+    assert len(calls) == 1
+    assert calls[0]["max_iterations"] == 3
+
+
+def test_cog_ralph_max_iterations_implies_loop(monkeypatch, tmp_path):
+    calls: list[dict] = []
+
+    async def fake_build_and_run(*args: Any, **kwargs: Any) -> int:
+        calls.append({"args": args, **kwargs})
+        return 0
+
+    monkeypatch.setattr("cog.cli.build_and_run", fake_build_and_run)
+    result = runner.invoke(app, ["ralph", "--project-dir", str(tmp_path), "--max-iterations", "3"])
+    assert result.exit_code == 0
+    assert calls[0]["loop"] is True
+
+
+def test_cog_ralph_loop_without_max_iterations(monkeypatch, tmp_path):
+    calls: list[dict] = []
+
+    async def fake_build_and_run(*args: Any, **kwargs: Any) -> int:
+        calls.append({"args": args, **kwargs})
+        return 0
+
+    monkeypatch.setattr("cog.cli.build_and_run", fake_build_and_run)
+    result = runner.invoke(app, ["ralph", "--project-dir", str(tmp_path), "--loop"])
+    assert result.exit_code == 0
+    assert calls[0]["loop"] is True
+    assert calls[0]["max_iterations"] is None
+
+
 def test_cog_ralph_keyboard_interrupt_exits_130(monkeypatch, tmp_path):
     import asyncio
     import inspect

--- a/tests/test_headless/test_run_headless.py
+++ b/tests/test_headless/test_run_headless.py
@@ -86,15 +86,16 @@ async def test_run_headless_happy_path(tmp_path, capsys):
     exit_code = await run_headless(wf, _make_ctx(tmp_path))
     assert exit_code == 0
     captured = capsys.readouterr()
-    assert "outcome=success" in captured.err
+    assert "iteration complete:" in captured.err
 
 
 async def test_run_headless_empty_queue(tmp_path, capsys):
     wf = _EmptyQueueWorkflow(EchoRunner())
     exit_code = await run_headless(wf, _make_ctx(tmp_path))
     assert exit_code == 0
+    # Queue drained immediately: no iteration summary, no loop summary
     captured = capsys.readouterr()
-    assert "outcome=no-op" in captured.err
+    assert "loop complete" not in captured.err
 
 
 async def test_run_headless_stage_error_returns_1(tmp_path, capsys):

--- a/tests/test_headless/test_run_headless_loop.py
+++ b/tests/test_headless/test_run_headless_loop.py
@@ -1,0 +1,226 @@
+"""Tests for run_headless loop/max_iterations behavior."""
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+from cog.core.context import ExecutionContext
+from cog.core.item import Item
+from cog.core.outcomes import Outcome, StageResult
+from cog.core.runner import AgentRunner, ResultEvent, RunEvent, RunResult
+from cog.core.stage import Stage
+from cog.core.workflow import Workflow
+from cog.headless import run_headless
+from tests.fakes import EchoRunner, InMemoryStateCache
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _make_item(item_id: str = "1") -> Item:
+    return Item(
+        tracker_id="test",
+        item_id=item_id,
+        title=f"item-{item_id}",
+        body="",
+        labels=(),
+        comments=(),
+        state="open",
+        created_at=_now(),
+        updated_at=_now(),
+        url="",
+    )
+
+
+def _make_ctx(tmp_path: Path) -> ExecutionContext:
+    return ExecutionContext(
+        project_dir=tmp_path,
+        tmp_dir=tmp_path / "tmp",
+        state_cache=InMemoryStateCache(),
+        headless=True,
+    )
+
+
+class _QueueWorkflow(Workflow):
+    """Workflow that pops items from a queue; returns None when exhausted."""
+
+    name = "queue"
+    queue_label = "test"
+    supports_headless = True
+
+    def __init__(self, runner: AgentRunner, items: list[Item]) -> None:
+        self._runner = runner
+        self._items = list(items)
+        self.select_calls = 0
+
+    async def select_item(self, ctx: ExecutionContext) -> Item | None:
+        self.select_calls += 1
+        return self._items.pop(0) if self._items else None
+
+    def stages(self, ctx: ExecutionContext) -> list[Stage]:
+        return [Stage(name="s", prompt_source=lambda _: "hi", model="m", runner=self._runner)]
+
+    async def classify_outcome(self, ctx: ExecutionContext, results: list[StageResult]) -> Outcome:
+        return "success"
+
+
+class _CostRunner(AgentRunner):
+    def __init__(self, cost: float) -> None:
+        self._cost = cost
+
+    async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+        yield ResultEvent(
+            result=RunResult(
+                final_message="ok",
+                total_cost_usd=self._cost,
+                exit_status=0,
+                stream_json_path=Path("/dev/null"),
+                duration_seconds=1.0,
+            )
+        )
+
+
+async def test_single_run_mode_runs_once_even_when_queue_has_more(tmp_path: Path, capsys) -> None:
+    items = [_make_item("1"), _make_item("2"), _make_item("3")]
+    wf = _QueueWorkflow(EchoRunner(), items)
+    exit_code = await run_headless(wf, _make_ctx(tmp_path), loop=False)
+    assert exit_code == 0
+    assert wf.select_calls == 1
+
+
+async def test_loop_continues_until_queue_empty(tmp_path: Path, capsys) -> None:
+    items = [_make_item("1"), _make_item("2"), _make_item("3")]
+    wf = _QueueWorkflow(EchoRunner(), items)
+    exit_code = await run_headless(wf, _make_ctx(tmp_path), loop=True)
+    assert exit_code == 0
+    # 3 items + 1 empty-queue call = 4 select_item calls
+    assert wf.select_calls == 4
+
+
+async def test_loop_respects_max_iterations(tmp_path: Path, capsys) -> None:
+    items = [_make_item(str(i)) for i in range(5)]
+    wf = _QueueWorkflow(EchoRunner(), items)
+    exit_code = await run_headless(wf, _make_ctx(tmp_path), loop=True, max_iterations=2)
+    assert exit_code == 0
+    assert wf.select_calls == 2
+
+
+async def test_loop_cumulative_cost_sums_across_iterations(tmp_path: Path, capsys) -> None:
+    items = [_make_item("1"), _make_item("2")]
+    runner = _CostRunner(cost=0.1)
+    wf = _QueueWorkflow(runner, items)
+    await run_headless(wf, _make_ctx(tmp_path), loop=True)
+    captured = capsys.readouterr()
+    assert "total cost $0.200" in captured.err
+
+
+async def test_loop_iteration_counter_increments(tmp_path: Path, capsys) -> None:
+    items = [_make_item("1"), _make_item("2")]
+    wf = _QueueWorkflow(EchoRunner(), items)
+    await run_headless(wf, _make_ctx(tmp_path), loop=True)
+    captured = capsys.readouterr()
+    assert "2 iteration(s)" in captured.err
+
+
+async def test_loop_workflow_instance_reused(tmp_path: Path) -> None:
+    """Regression guard: same workflow object is reused across iterations."""
+    items = [_make_item("1"), _make_item("2")]
+    wf = _QueueWorkflow(EchoRunner(), items)
+    await run_headless(wf, _make_ctx(tmp_path), loop=True)
+    # Both items consumed from the same workflow instance
+    assert len(wf._items) == 0
+
+
+async def test_loop_stage_error_aborts_loop_with_exit_1(tmp_path: Path, capsys) -> None:
+    from collections.abc import AsyncIterator
+
+    from cog.core.runner import AgentRunner, RunEvent
+
+    class _FailRunner(AgentRunner):
+        async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+            yield ResultEvent(
+                result=RunResult(
+                    final_message="failed",
+                    total_cost_usd=0.0,
+                    exit_status=1,
+                    stream_json_path=Path("/dev/null"),
+                    duration_seconds=0.0,
+                )
+            )
+
+    items = [_make_item("1"), _make_item("2"), _make_item("3")]
+    wf = _QueueWorkflow(_FailRunner(), items)
+    exit_code = await run_headless(wf, _make_ctx(tmp_path), loop=True)
+    assert exit_code == 1
+    # First iteration fails; subsequent iterations never run
+    assert wf.select_calls == 1
+
+
+async def test_loop_banner_emitted_per_iteration(tmp_path: Path, capsys) -> None:
+    items = [_make_item("1"), _make_item("2"), _make_item("3")]
+    wf = _QueueWorkflow(EchoRunner(), items)
+    await run_headless(wf, _make_ctx(tmp_path), loop=True)
+    captured = capsys.readouterr()
+    assert "═══ iteration 1 ═══" in captured.err
+    assert "═══ iteration 2 ═══" in captured.err
+    assert "═══ iteration 3 ═══" in captured.err
+
+
+async def test_loop_final_summary_on_clean_exit(tmp_path: Path, capsys) -> None:
+    items = [_make_item("1")]
+    wf = _QueueWorkflow(EchoRunner(), items)
+    await run_headless(wf, _make_ctx(tmp_path), loop=True)
+    captured = capsys.readouterr()
+    assert "loop complete: 1 iteration(s)" in captured.err
+
+
+async def test_loop_no_final_summary_in_single_run_mode(tmp_path: Path, capsys) -> None:
+    items = [_make_item("1")]
+    wf = _QueueWorkflow(EchoRunner(), items)
+    await run_headless(wf, _make_ctx(tmp_path), loop=False)
+    captured = capsys.readouterr()
+    assert "loop complete" not in captured.err
+
+
+async def test_loop_fresh_context_per_iteration(tmp_path: Path) -> None:
+    """Each iteration gets a fresh ctx (item/work_branch reset); state_cache persists."""
+    seen_items: list[Item | None] = []
+    seen_caches: list[object] = []
+
+    class _ObservingWorkflow(Workflow):
+        name = "obs"
+        queue_label = "test"
+        supports_headless = True
+
+        def __init__(self) -> None:
+            self._calls = 0
+
+        async def select_item(self, ctx: ExecutionContext) -> Item | None:
+            self._calls += 1
+            seen_caches.append(ctx.state_cache)
+            seen_items.append(ctx.item)
+            return _make_item(str(self._calls)) if self._calls <= 2 else None
+
+        def stages(self, ctx: ExecutionContext) -> list[Stage]:
+            return [
+                Stage(
+                    name="s",
+                    prompt_source=lambda _: "hi",
+                    model="m",
+                    runner=EchoRunner(),
+                )
+            ]
+
+        async def classify_outcome(
+            self, ctx: ExecutionContext, results: list[StageResult]
+        ) -> Outcome:
+            return "success"
+
+    wf = _ObservingWorkflow()
+    ctx = _make_ctx(tmp_path)
+    await run_headless(wf, ctx, loop=True)
+    # item is always None at start of each iteration (reset by fresh_iteration_context)
+    assert all(item is None for item in seen_items)
+    # state_cache is the same object across iterations
+    assert all(cache is ctx.state_cache for cache in seen_caches)

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,0 +1,61 @@
+"""Tests for cog.loop primitives."""
+
+from pathlib import Path
+
+from cog.core.context import ExecutionContext
+from cog.loop import LoopState, fresh_iteration_context
+from tests.fakes import InMemoryStateCache
+
+
+def _make_ctx(tmp_path: Path) -> ExecutionContext:
+    return ExecutionContext(
+        project_dir=tmp_path,
+        tmp_dir=tmp_path / "tmp",
+        state_cache=InMemoryStateCache(),
+        headless=True,
+    )
+
+
+def test_loop_state_iteration_starts_at_zero() -> None:
+    state = LoopState()
+    assert state.iteration == 0
+
+
+def test_loop_state_cumulative_cost_accumulates() -> None:
+    state = LoopState()
+    state.cumulative_cost_usd += 0.5
+    state.cumulative_cost_usd += 0.3
+    assert state.cumulative_cost_usd == 0.8
+
+
+def test_fresh_iteration_context_resets_item_and_branch(tmp_path: Path) -> None:
+    from tests.fakes import make_item
+
+    ctx = _make_ctx(tmp_path)
+    ctx.item = make_item()
+    ctx.work_branch = "feat/123"
+    fresh = fresh_iteration_context(ctx)
+    assert fresh.item is None
+    assert fresh.work_branch is None
+
+
+def test_fresh_iteration_context_preserves_state_cache_and_telemetry(tmp_path: Path) -> None:
+    cache = InMemoryStateCache()
+    ctx = ExecutionContext(
+        project_dir=tmp_path,
+        tmp_dir=tmp_path / "tmp",
+        state_cache=cache,
+        headless=True,
+    )
+    fresh = fresh_iteration_context(ctx)
+    assert fresh.state_cache is cache
+    assert fresh.headless is True
+    assert fresh.project_dir == tmp_path
+
+
+def test_fresh_iteration_context_creates_new_tmp_dir(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    original_tmp = ctx.tmp_dir
+    fresh = fresh_iteration_context(ctx)
+    assert fresh.tmp_dir != original_tmp
+    assert fresh.tmp_dir.exists()

--- a/tests/test_ui/test_run_screen.py
+++ b/tests/test_ui/test_run_screen.py
@@ -234,6 +234,143 @@ async def test_run_screen_shows_error_panel_on_workflow_exception(tmp_path: Path
         assert len(pilot.app.query("#result-panel")) > 0
 
 
+class _MultiItemWorkflow(_FakeWorkflow):
+    """Workflow that serves N items then returns None (queue empty)."""
+
+    def __init__(self, runner: EchoRunner, item_count: int) -> None:
+        super().__init__(runner)
+        self._remaining = item_count
+
+    async def select_item(self, ctx: ExecutionContext) -> Item | None:
+        if self._remaining > 0:
+            self._remaining -= 1
+            return _item()
+        return None
+
+
+def _make_loop_app(
+    workflow: Workflow,
+    ctx: ExecutionContext,
+    *,
+    loop: bool = True,
+    max_iterations: int | None = None,
+) -> App:
+    class _TestApp(App):
+        def compose(self) -> ComposeResult:
+            return iter([])
+
+        def on_mount(self) -> None:
+            self.push_screen(RunScreen(workflow, ctx, loop=loop, max_iterations=max_iterations))
+
+    return _TestApp()
+
+
+async def test_run_screen_loop_mode_iterates_multiple_times(tmp_path: Path) -> None:
+    workflow = _MultiItemWorkflow(EchoRunner(), item_count=3)
+    ctx = _ctx(tmp_path)
+    async with _make_loop_app(workflow, ctx).run_test(headless=True) as pilot:
+        for _ in range(20):
+            await pilot.pause()
+        screen = pilot.app.query_one(RunScreen)
+        assert screen._state == "completed"
+        assert screen._loop_state.iteration == 3
+
+
+async def test_run_screen_loop_mode_divider_between_iterations(tmp_path: Path) -> None:
+    workflow = _MultiItemWorkflow(EchoRunner(), item_count=2)
+    ctx = _ctx(tmp_path)
+    async with _make_loop_app(workflow, ctx).run_test(headless=True) as pilot:
+        for _ in range(20):
+            await pilot.pause()
+        dividers = pilot.app.query(".iteration-divider")
+        assert len(dividers) >= 1
+
+
+async def test_run_screen_loop_mode_iteration_counter_in_footer(tmp_path: Path) -> None:
+    workflow = _MultiItemWorkflow(EchoRunner(), item_count=2)
+    ctx = _ctx(tmp_path)
+    async with _make_loop_app(workflow, ctx).run_test(headless=True) as pilot:
+        for _ in range(20):
+            await pilot.pause()
+        screen = pilot.app.query_one(RunScreen)
+        assert screen._loop_state.iteration == 2
+
+
+async def test_run_screen_loop_mode_exits_on_queue_empty(tmp_path: Path) -> None:
+    workflow = _MultiItemWorkflow(EchoRunner(), item_count=1)
+    ctx = _ctx(tmp_path)
+    async with _make_loop_app(workflow, ctx).run_test(headless=True) as pilot:
+        for _ in range(20):
+            await pilot.pause()
+        screen = pilot.app.query_one(RunScreen)
+        assert screen._state == "completed"
+
+
+async def test_run_screen_loop_mode_respects_max_iterations(tmp_path: Path) -> None:
+    workflow = _MultiItemWorkflow(EchoRunner(), item_count=10)
+    ctx = _ctx(tmp_path)
+    async with _make_loop_app(workflow, ctx, loop=True, max_iterations=2).run_test(
+        headless=True
+    ) as pilot:
+        for _ in range(20):
+            await pilot.pause()
+        screen = pilot.app.query_one(RunScreen)
+        assert screen._state == "completed"
+        assert screen._loop_state.iteration == 2
+
+
+async def test_run_screen_loop_mode_ctrl_c_cancels_current_iteration(tmp_path: Path) -> None:
+    workflow = _MultiItemWorkflow(_SlowRunner(), item_count=5)
+    ctx = _ctx(tmp_path)
+    async with _make_loop_app(workflow, ctx).run_test(headless=True) as pilot:
+        await pilot.pause()
+        screen = pilot.app.query_one(RunScreen)
+        assert screen._state == "running"
+        await pilot.press("ctrl+c")
+        for _ in range(10):
+            await pilot.pause()
+        assert screen._state == "cancelled"
+
+
+async def test_run_screen_loop_mode_stage_error_shows_error_panel_and_exits(
+    tmp_path: Path,
+) -> None:
+    class _ErrWorkflow(_FakeWorkflow):
+        def stages(self, ctx: ExecutionContext):
+            async def _err(prompt: str, *, model: str):
+                raise RuntimeError("stage boom")
+                yield  # type: ignore[misc]
+
+            class _R:
+                def stream(self, prompt, *, model):
+                    return _err(prompt, model=model)
+
+                async def run(self, prompt, *, model):  # pragma: no cover
+                    pass
+
+            return [Stage(name="s", prompt_source=lambda _: "hi", model="m", runner=_R())]
+
+    workflow = _ErrWorkflow(EchoRunner())
+    ctx = _ctx(tmp_path)
+    async with _make_loop_app(workflow, ctx).run_test(headless=True) as pilot:
+        for _ in range(10):
+            await pilot.pause()
+        screen = pilot.app.query_one(RunScreen)
+        assert screen._state == "failed"
+        assert len(pilot.app.query("#result-panel")) > 0
+
+
+async def test_run_screen_loop_mode_completion_panel_after_clean_exit(tmp_path: Path) -> None:
+    workflow = _MultiItemWorkflow(EchoRunner(), item_count=1)
+    ctx = _ctx(tmp_path)
+    async with _make_loop_app(workflow, ctx).run_test(headless=True) as pilot:
+        for _ in range(20):
+            await pilot.pause()
+        screen = pilot.app.query_one(RunScreen)
+        assert screen._state == "completed"
+        assert len(pilot.app.query("#result-panel")) > 0
+
+
 async def test_run_screen_shows_cancellation_panel_after_cancel(tmp_path: Path) -> None:
     # Verify that _show_cancellation_panel mounts the result panel when called
     # while the screen is still attached. (During real ctrl+c, the screen may

--- a/tests/test_ui/test_wire.py
+++ b/tests/test_ui/test_wire.py
@@ -81,7 +81,7 @@ async def test_build_and_run_preselects_item_when_item_id_given(tmp_path: Path) 
 
     captured_ctx = {}
 
-    async def _fake_run_textual(workflow, ctx, *, loop):
+    async def _fake_run_textual(workflow, ctx, *, loop, max_iterations=None):
         captured_ctx["ctx"] = ctx
         return 0
 
@@ -180,3 +180,82 @@ async def test_build_and_run_wires_full_stack(tmp_path: Path) -> None:
     run_textual_mock.assert_awaited_once()
     _, call_ctx = run_textual_mock.call_args[0]
     assert call_ctx.state_cache is cache_mock
+
+
+def _patched_wire_context(tmp_path: Path):
+    """Context manager that patches all wire.py external dependencies."""
+    cache_mock = MagicMock()
+    cache_mock.was_corrupt.return_value = False
+    cache_mock.is_empty.return_value = False
+    return (
+        patch("cog.ui.wire.run_checks", new=AsyncMock(return_value=[])),
+        patch("cog.ui.wire.print_results"),
+        patch("cog.ui.wire.DockerSandbox", return_value=MagicMock()),
+        patch("cog.ui.wire.ClaudeCliRunner", return_value=MagicMock()),
+        patch("cog.ui.wire.GitHubIssueTracker", return_value=MagicMock()),
+        patch("cog.ui.wire.JsonFileStateCache", return_value=cache_mock),
+        patch("cog.ui.wire.TelemetryWriter"),
+        patch("cog.ui.wire.project_state_dir", return_value=tmp_path / ".cog"),
+    )
+
+
+async def test_build_and_run_forwards_max_iterations_to_run_headless(tmp_path: Path) -> None:
+    from cog.ui.wire import build_and_run
+
+    run_headless_mock = AsyncMock(return_value=0)
+
+    patches = _patched_wire_context(tmp_path)
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patches[5],
+        patches[6],
+        patches[7],
+        patch("cog.ui.wire.run_headless", run_headless_mock),
+    ):
+        await build_and_run(
+            _FakeWorkflow,  # type: ignore[arg-type]
+            tmp_path,
+            item_id=None,
+            loop=True,
+            headless=True,
+            max_iterations=3,
+        )
+
+    _, kwargs = run_headless_mock.call_args
+    assert kwargs.get("max_iterations") == 3
+    assert kwargs.get("loop") is True
+
+
+async def test_build_and_run_forwards_max_iterations_to_run_textual(tmp_path: Path) -> None:
+    from cog.ui.wire import build_and_run
+
+    run_textual_mock = AsyncMock(return_value=0)
+
+    patches = _patched_wire_context(tmp_path)
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patches[5],
+        patches[6],
+        patches[7],
+        patch("cog.ui.app.run_textual", run_textual_mock),
+    ):
+        await build_and_run(
+            _FakeWorkflow,  # type: ignore[arg-type]
+            tmp_path,
+            item_id=None,
+            loop=True,
+            headless=False,
+            max_iterations=5,
+        )
+
+    _, kwargs = run_textual_mock.call_args
+    assert kwargs.get("max_iterations") == 5
+    assert kwargs.get("loop") is True


### PR DESCRIPTION
## Summary

Adds autonomous queue-drain mode for the ralph workflow. Instead of a single iteration per invocation, `--loop` runs until the queue is drained, the iteration cap is hit, a stage fails, or the user interrupts.

- New `cog/loop.py` with `LoopState` + `fresh_iteration_context` primitives shared across headless and Textual paths.
- `run_headless` now loops: per-iteration `═══ iteration N ═══` banner on stderr, per-iteration summary line, and a final `loop complete: …` line when exiting cleanly in loop mode. Single-run mode (`loop=False`) falls through the same path with an implicit cap of 1.
- `RunScreen` replaces `_run_once` with `_run_loop`; header clears item title at iteration boundaries, footer shows iteration counter + cumulative cost, log pane preserves history with dividers, completion panel fires once at loop end. Dead `_show_completion_panel` and duplicate cost accumulator removed — `_show_loop_summary_panel` now reads from `_CountingSink._cumulative_cost` only.
- CLI gains `--max-iterations N` (implies `--loop`). `build_and_run` in `ui/wire.py` forwards `loop` + `max_iterations` to both execution paths.
- Fresh `ExecutionContext` per iteration (new `tmp_dir`, `item`/`work_branch` reset). `RalphWorkflow._processed_this_loop` is intentionally preserved across iterations so label-propagation lag doesn't cause re-picks.

## Closes

Closes #16

## Test plan

- [x] `tests/test_loop.py` covers `fresh_iteration_context` + `LoopState` invariants
- [x] `tests/test_headless/test_run_headless_loop.py` covers single-run, loop-until-empty, max-iterations cap, cumulative cost, iteration counter, workflow-instance reuse, StageError aborting the loop, per-iteration banners, final summary presence/absence
- [x] `tests/test_ui/test_run_screen.py` extended for multi-iteration flows, dividers, footer counter, queue-empty exit, max-iterations, Ctrl-C cancellation, StageError error panel, loop completion panel
- [x] `tests/test_cli.py` + `tests/test_ui/test_wire.py` extended to cover `--max-iterations` forwarding and the `--max-iterations N` → `loop=True` implication
- [ ] Manual: `uv run cog ralph --loop --headless` against a 2+ item queue drains cleanly with banners + final summary
- [ ] Manual: `uv run cog ralph --loop --max-iterations 2 --headless` stops after 2 iterations with a larger queue
- [ ] Manual: Ctrl-C mid-iteration exits 130 and finalizes-as-error

---
🤖 Generated by cog (manual finalization — ralph's autonomous finalize did not complete; see issue thread for follow-up).