### PR TITLE
Refine interactive interview loop: ChatPane multi-turn with claude + transcript capture (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,30 @@ Options for `cog refine`:
     --item N              Skip selection; run on issue number N
     --project-dir PATH    Project directory (default: cwd)
 
+### Refine interview
+
+`cog refine` runs a multi-turn interview in the Textual chat pane. Claude
+asks one question at a time; the user replies until Claude has enough context
+and emits `<<interview-complete>>`, or the user ends early.
+
+Keyboard bindings in the chat pane:
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Submit reply (empty string is a valid reply) |
+| `Shift+Enter` | Insert newline |
+| `Escape` / `Ctrl+D` | End interview early |
+
+Environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `COG_REFINE_INTERVIEW_MODEL` | `claude-sonnet-4-6` | Claude model used for each interview turn |
+
+When the user ends early via `Escape`/`Ctrl+D`, the interview transcript is
+preserved and the rewrite pass (landing in #19) produces a best-effort rewrite
+from the partial conversation.
+
 ## Telemetry
 
 Each run appends one JSON line to `<state-dir>/runs.jsonl` (default: `~/.local/share/cog/runs.jsonl`).
@@ -32,7 +56,7 @@ Key fields:
 |-------|------|-------------|
 | `ts` | string | ISO-8601 UTC timestamp |
 | `outcome` | string | `success`, `error`, `no-op`, `push-failed`, `deferred-by-blocker` |
-| `stages` | array | Per-stage entry with `stage`, `duration_s`, `cost_usd`, `exit_status`, `commits` |
+| `stages` | array | Per-stage entry with `stage`, `duration_s`, `cost_usd`, `exit_status`, `commits`; for `cog refine` the first entry is `"interview"` |
 | `total_cost_usd` | float | Sum of stage costs |
 | `duration_seconds` | float | Wall time across all stages |
 | `error` | string\|null | `"stage 'X' failed \| cause=RunnerStalledError: ..."` on failure |

--- a/src/cog/core/sinks.py
+++ b/src/cog/core/sinks.py
@@ -16,7 +16,9 @@ class RunEventSink(Protocol):
 class UserInputProvider(Protocol):
     """Solicits a line of text from the user (interactive workflows only)."""
 
-    async def prompt(self) -> str: ...
+    async def prompt(self) -> str | None:
+        """Return user's reply (str, possibly empty), or None if they ended early."""
+        ...
 
 
 class ItemPicker(Protocol):

--- a/src/cog/prompts/claude/refine/interview.md
+++ b/src/cog/prompts/claude/refine/interview.md
@@ -1,0 +1,50 @@
+# Refine: interactive interview
+
+You are interviewing the user to gather enough context to rewrite a
+tracked item so another agent can implement it autonomously.
+
+## Your goal
+
+Resolve every decision that would block implementation:
+- Architecture choices (where code lives, which abstraction to use)
+- Behavior specifics (edge cases, error paths, default values)
+- Scope boundaries (what's in, what's out, what's deferred)
+- Testing strategy
+
+When all questions are answered, output the token `<<interview-complete>>`
+on its own line. The wrapper will then invoke a rewrite pass to produce
+the final item body.
+
+## Style
+
+- Ask ONE question per turn.
+- Always provide a recommended answer with reasoning. The user agrees,
+  pushes back, or picks an alternative — but they never start from a blank
+  page.
+- Be concise. A user who agrees with your recommendation should be able
+  to reply with one word.
+- Walk the decision tree top-down: foundational choices first, leaf
+  decisions last.
+- Explore the codebase before guessing. Use Bash/Read/Grep tools freely
+  to read existing code, check current conventions, find related files.
+
+## What NOT to do
+
+- Don't ask compound questions. One thing at a time.
+- Don't proceed based on assumptions; if you're uncertain, ask.
+- Don't police the original item scope. If adjacent work surfaces and
+  it makes sense to do together, fold it in — don't flag it as "scope
+  creep."
+- Don't repeat context already established earlier in the conversation.
+
+## Exit condition
+
+When you have enough context to produce a clear problem statement,
+explicit scope (with sub-sections if multiple concerns), non-goals,
+and related items, output:
+
+```
+<<interview-complete>>
+```
+
+on its own line. The wrapper picks up from there.

--- a/src/cog/telemetry.py
+++ b/src/cog/telemetry.py
@@ -3,6 +3,7 @@ import fcntl
 import json
 import os
 import sys
+from collections.abc import Sequence
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -63,12 +64,15 @@ class TelemetryRecord:
         item: Item,
         outcome: TelemetryOutcome,
         results: list[StageResult],
+        extra_stages: Sequence["StageTelemetry"] = (),
         branch: str | None = None,
         pr_url: str | None = None,
         duration_seconds: float,
         error: str | None = None,
         cause_class: str | None = None,
     ) -> "TelemetryRecord":
+        result_stages = tuple(StageTelemetry.from_stage_result(r) for r in results)
+        all_stages = tuple(extra_stages) + result_stages
         return cls(
             ts=datetime.now(UTC).isoformat(),
             cog_version=cog_version,
@@ -79,8 +83,8 @@ class TelemetryRecord:
             branch=branch,
             pr_url=pr_url,
             duration_seconds=duration_seconds,
-            stages=tuple(StageTelemetry.from_stage_result(r) for r in results),
-            total_cost_usd=sum(r.cost_usd for r in results),
+            stages=all_stages,
+            total_cost_usd=sum(r.cost_usd for r in results) + sum(s.cost_usd for s in extra_stages),
             error=error,
             cause_class=cause_class,
         )

--- a/src/cog/ui/widgets/chat_pane.py
+++ b/src/cog/ui/widgets/chat_pane.py
@@ -7,7 +7,7 @@ from textual.events import Key
 from textual.widget import Widget
 from textual.widgets import RichLog, Static, TextArea
 
-from cog.core.runner import AssistantTextEvent, ResultEvent, RunEvent
+from cog.core.runner import AssistantTextEvent, ResultEvent, RunEvent, ToolUseEvent
 
 
 class ChatPaneWidget(Widget):
@@ -73,12 +73,11 @@ class ChatPaneWidget(Widget):
     def _submit(self) -> None:
         area = self.query_one("#input-area", TextArea)
         text = area.text.strip()
-        if not text:
-            return
         area.clear()
-        log = self.query_one("#scrollback", RichLog)
-        log.write(f"[bold green]You:[/bold green] {text}")
-        log.scroll_end(animate=False)
+        if text:
+            log = self.query_one("#scrollback", RichLog)
+            log.write(f"[bold green]You:[/bold green] {text}")
+            log.scroll_end(animate=False)
         future = self._ensure_future()
         if not future.done():
             future.set_result(text)
@@ -91,6 +90,11 @@ class ChatPaneWidget(Widget):
     async def emit(self, event: RunEvent) -> None:
         if isinstance(event, AssistantTextEvent):
             self._append_assistant_message(event.text)
+        elif isinstance(event, ToolUseEvent):
+            preview = event.input.get("command") or event.input.get("file_path") or ""
+            log = self.query_one("#scrollback", RichLog)
+            log.write(f"[dim]🔧 {event.tool}: {preview}[/dim]")
+            log.scroll_end(animate=False)
         elif isinstance(event, ResultEvent):
             self._hide_thinking_indicator()
 

--- a/src/cog/ui/widgets/chat_pane.py
+++ b/src/cog/ui/widgets/chat_pane.py
@@ -34,14 +34,14 @@ class ChatPaneWidget(Widget):
 
     def __init__(self, *args: object, **kwargs: object) -> None:
         super().__init__(*args, **kwargs)  # type: ignore[arg-type]
-        self._input_future: asyncio.Future[str] | None = None
+        self._input_future: asyncio.Future[str | None] | None = None
 
     def compose(self) -> ComposeResult:
         yield RichLog(id="scrollback", highlight=True, markup=True)
         yield Static("⏳ Thinking…", id="thinking")
         yield TextArea(id="input-area")
 
-    def _ensure_future(self) -> asyncio.Future[str]:
+    def _ensure_future(self) -> asyncio.Future[str | None]:
         if self._input_future is None or self._input_future.done():
             self._input_future = asyncio.get_running_loop().create_future()
         return self._input_future
@@ -65,6 +65,9 @@ class ChatPaneWidget(Widget):
         if event.key == "enter":
             event.stop()
             self._submit()
+        elif event.key in ("escape", "ctrl+d"):
+            event.stop()
+            self._end_interview()
         # shift+enter inserts newline — TextArea handles this by default
 
     def _submit(self) -> None:
@@ -80,17 +83,24 @@ class ChatPaneWidget(Widget):
         if not future.done():
             future.set_result(text)
 
+    def _end_interview(self) -> None:
+        future = self._ensure_future()
+        if not future.done():
+            future.set_result(None)
+
     async def emit(self, event: RunEvent) -> None:
         if isinstance(event, AssistantTextEvent):
             self._append_assistant_message(event.text)
         elif isinstance(event, ResultEvent):
             self._hide_thinking_indicator()
 
-    async def prompt(self) -> str:
-        """Block until the user submits a message via Enter."""
+    async def prompt(self) -> str | None:
+        """Block until the user submits a message via Enter (str, possibly empty),
+        or ends the interview via Escape / Ctrl+D (None)."""
         self._hide_thinking_indicator()
         future = self._ensure_future()
-        text = await future
+        result = await future
         self._input_future = None
-        self._show_thinking_indicator()
-        return text
+        if result is not None:
+            self._show_thinking_indicator()
+        return result

--- a/src/cog/workflows/refine.py
+++ b/src/cog/workflows/refine.py
@@ -1,3 +1,11 @@
+from __future__ import annotations
+
+import os
+import sys
+import time
+from dataclasses import dataclass
+from enum import Enum
+from importlib.resources import files
 from typing import ClassVar
 
 from cog.checks import REFINE_CHECKS
@@ -5,11 +13,30 @@ from cog.core.context import ExecutionContext
 from cog.core.errors import WorkflowError
 from cog.core.item import Item
 from cog.core.outcomes import Outcome, StageResult
-from cog.core.runner import AgentRunner
+from cog.core.runner import AgentRunner, ResultEvent
 from cog.core.stage import Stage
 from cog.core.tracker import IssueTracker
 from cog.core.workflow import Workflow
+from cog.state_paths import project_slug
+from cog.telemetry import StageTelemetry, TelemetryRecord
 from cog.ui.widgets.chat_pane import ChatPaneWidget
+
+_INTERVIEW_COMPLETE = "<<interview-complete>>"
+
+
+class InterviewEnd(Enum):
+    NOT_ENDED = "not-ended"
+    SENTINEL = "sentinel"
+    USER = "user"
+
+
+@dataclass(frozen=True)
+class InterviewTurn:
+    assistant_message: str
+    user_message: str | None
+    cost_usd: float
+    duration_seconds: float
+    end: InterviewEnd = InterviewEnd.NOT_ENDED
 
 
 class RefineWorkflow(Workflow):
@@ -23,6 +50,7 @@ class RefineWorkflow(Workflow):
     def __init__(self, runner: AgentRunner, tracker: IssueTracker, **kwargs: object) -> None:
         self._runner = runner
         self._tracker = tracker
+        self._transcripts: dict[str, list[InterviewTurn]] = {}
 
     async def select_item(self, ctx: ExecutionContext) -> Item | None:
         items = await self._tracker.list_by_label("needs-refinement", assignee="@me")
@@ -37,8 +65,134 @@ class RefineWorkflow(Workflow):
             )
         return await ctx.item_picker.pick(items)
 
+    async def pre_stages(self, ctx: ExecutionContext) -> None:
+        assert ctx.item is not None, "refine pre_stages requires ctx.item"
+        assert ctx.event_sink is not None, "refine interview requires an event sink"
+        assert ctx.input_provider is not None, "refine interview requires an input provider"
+        transcript = await self._run_interview(ctx)
+        self._transcripts[ctx.item.item_id] = transcript
+
     def stages(self, ctx: ExecutionContext) -> list[Stage]:
-        raise NotImplementedError("refine stages land with #18 (interview)")
+        raise NotImplementedError("rewrite stage lands with #19")
 
     async def classify_outcome(self, ctx: ExecutionContext, results: list[StageResult]) -> Outcome:
-        raise NotImplementedError("refine classify_outcome lands with #19 (rewrite)")
+        raise NotImplementedError("refine classify_outcome lands with #19")
+
+    async def finalize_error(
+        self, ctx: ExecutionContext, error: Exception, results: list[StageResult]
+    ) -> None:
+        item_ref = ctx.item.item_id if ctx.item else "?"
+        print(
+            f"refine: interview failed on #{item_ref}: {type(error).__name__}: {error}",
+            file=sys.stderr,
+        )
+        if ctx.item is None or ctx.telemetry is None:
+            return
+        transcript = self._transcripts.get(ctx.item.item_id, [])
+        if not transcript:
+            return
+        model = os.environ.get("COG_REFINE_INTERVIEW_MODEL", "claude-sonnet-4-6")
+        interview_stage = self._interview_telemetry_stage(transcript, model)
+        record = TelemetryRecord.build(
+            project=project_slug(ctx.project_dir),
+            workflow=self.name,
+            item=ctx.item,
+            outcome="error",
+            results=[],
+            extra_stages=(interview_stage,),
+            duration_seconds=sum(t.duration_seconds for t in transcript),
+            error=str(error),
+        )
+        await ctx.telemetry.write(record)
+
+    def _build_preamble(self, item: Item) -> str:
+        skill = (
+            files("cog.prompts.claude.refine").joinpath("interview.md").read_text(encoding="utf-8")
+        )
+        parts = [skill, "\n## Item to refine\n", f"Issue #{item.item_id}: {item.title}"]
+        parts.append(f"\n### Body\n\n{item.body}\n")
+        if item.comments:
+            parts.append("\n### Comments\n")
+            for c in item.comments:
+                parts.append(f"\n**{c.author}** ({c.created_at.isoformat()}):\n{c.body}\n")
+        return "\n".join(parts)
+
+    def _build_turn_prompt(self, preamble: str, transcript: list[InterviewTurn]) -> str:
+        parts = [preamble]
+        if transcript:
+            parts.append("\n## Conversation so far\n")
+            for turn in transcript:
+                parts.append(f"\n### You:\n{turn.assistant_message}\n")
+                if turn.user_message is not None:
+                    parts.append(f"\n### User:\n{turn.user_message}\n")
+        parts.append(
+            f"\n## Your turn\n\nAsk your next question, or if you have all the "
+            f"information you need to rewrite the item body, output the token "
+            f"`{_INTERVIEW_COMPLETE}` on its own line."
+        )
+        return "\n".join(parts)
+
+    def _interview_telemetry_stage(
+        self, transcript: list[InterviewTurn], model: str
+    ) -> StageTelemetry:
+        return StageTelemetry(
+            stage="interview",
+            model=model,
+            duration_s=sum(t.duration_seconds for t in transcript),
+            cost_usd=sum(t.cost_usd for t in transcript),
+            exit_status=0,
+            commits=0,
+        )
+
+    async def _run_interview(self, ctx: ExecutionContext) -> list[InterviewTurn]:
+        assert ctx.event_sink is not None, "refine interview requires an event sink"
+        assert ctx.input_provider is not None, "refine interview requires an input provider"
+        assert ctx.item is not None
+        transcript: list[InterviewTurn] = []
+        preamble = self._build_preamble(ctx.item)
+        model = os.environ.get("COG_REFINE_INTERVIEW_MODEL", "claude-sonnet-4-6")
+        while True:
+            prompt = self._build_turn_prompt(preamble, transcript)
+            start = time.monotonic()
+            total_cost = 0.0
+            final_message = ""
+            async for event in self._runner.stream(prompt, model=model):
+                if isinstance(event, ResultEvent):
+                    total_cost = event.result.total_cost_usd
+                    final_message = event.result.final_message
+                    continue
+                await ctx.event_sink.emit(event)
+            duration = time.monotonic() - start
+            if _INTERVIEW_COMPLETE in final_message:
+                cleaned = final_message.replace(_INTERVIEW_COMPLETE, "").strip()
+                transcript.append(
+                    InterviewTurn(
+                        assistant_message=cleaned,
+                        user_message=None,
+                        cost_usd=total_cost,
+                        duration_seconds=duration,
+                        end=InterviewEnd.SENTINEL,
+                    )
+                )
+                return transcript
+            user_reply = await ctx.input_provider.prompt()
+            if user_reply is None:
+                transcript.append(
+                    InterviewTurn(
+                        assistant_message=final_message,
+                        user_message=None,
+                        cost_usd=total_cost,
+                        duration_seconds=duration,
+                        end=InterviewEnd.USER,
+                    )
+                )
+                return transcript
+            transcript.append(
+                InterviewTurn(
+                    assistant_message=final_message,
+                    user_message=user_reply,
+                    cost_usd=total_cost,
+                    duration_seconds=duration,
+                    end=InterviewEnd.NOT_ENDED,
+                )
+            )

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator, Iterator, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -229,6 +229,49 @@ def make_needs_refinement_items(ids: list[int]) -> list[Item]:
         )
         for idx, i in enumerate(ids)
     ]
+
+
+class ScriptedInterviewRunner(AgentRunner):
+    """Each stream() call yields one AssistantTextEvent + ResultEvent from the scripted list.
+
+    Cycles through responses per turn.
+    """
+
+    def __init__(self, responses: list[tuple[str, float]]) -> None:
+        self._responses = responses
+        self._iter: Iterator[tuple[str, float]] = iter([])
+        self._call_count = 0
+
+    async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+        from cog.core.runner import AssistantTextEvent
+
+        message, cost = self._responses[self._call_count % len(self._responses)]
+        self._call_count += 1
+        yield AssistantTextEvent(text=message)
+        yield ResultEvent(
+            result=RunResult(
+                final_message=message,
+                total_cost_usd=cost,
+                exit_status=0,
+                stream_json_path=Path("/dev/null"),
+                duration_seconds=0.0,
+            )
+        )
+
+
+class ScriptedInputProvider:
+    """Each prompt() call returns the next value from the list; None simulates early-end."""
+
+    def __init__(self, replies: list[str | None]) -> None:
+        self._replies = list(replies)
+        self._index = 0
+
+    async def prompt(self) -> str | None:
+        if self._index >= len(self._replies):
+            raise AssertionError("ScriptedInputProvider ran out of replies")
+        reply = self._replies[self._index]
+        self._index += 1
+        return reply
 
 
 class FakeSubprocessRegistry:

--- a/tests/test_telemetry_record.py
+++ b/tests/test_telemetry_record.py
@@ -264,6 +264,55 @@ def test_telemetry_record_json_includes_cause_class():
     assert "RunnerTimeoutError" in line
 
 
+def test_build_accepts_extra_stages_kwarg():
+    item = _make_item()
+    interview_stage = StageTelemetry(
+        stage="interview",
+        model="claude-sonnet-4-6",
+        duration_s=5.0,
+        cost_usd=0.10,
+        exit_status=0,
+        commits=0,
+    )
+    record = TelemetryRecord.build(
+        project="p",
+        workflow="refine",
+        item=item,
+        outcome="error",
+        results=[],
+        extra_stages=(interview_stage,),
+        duration_seconds=5.0,
+    )
+    assert len(record.stages) == 1
+    assert record.stages[0].stage == "interview"
+    assert abs(record.total_cost_usd - 0.10) < 1e-9
+
+
+def test_build_extra_stages_prepended_before_result_stages():
+    item = _make_item()
+    interview_stage = StageTelemetry(
+        stage="interview",
+        model="claude-sonnet-4-6",
+        duration_s=2.0,
+        cost_usd=0.05,
+        exit_status=0,
+        commits=0,
+    )
+    result = _make_stage_result("build", cost_usd=0.10)
+    record = TelemetryRecord.build(
+        project="p",
+        workflow="refine",
+        item=item,
+        outcome="success",
+        results=[result],
+        extra_stages=(interview_stage,),
+        duration_seconds=10.0,
+    )
+    assert record.stages[0].stage == "interview"
+    assert record.stages[1].stage == "build"
+    assert abs(record.total_cost_usd - 0.15) < 1e-9
+
+
 def test_telemetry_record_backward_compat_missing_cause_class():
     # Old JSONL lines without cause_class should parse correctly
     # when cause_class defaults to None

--- a/tests/test_ui/test_chat_pane.py
+++ b/tests/test_ui/test_chat_pane.py
@@ -70,6 +70,60 @@ async def test_chat_pane_shift_enter_inserts_newline() -> None:
         assert not future.done()
 
 
+async def test_chat_pane_prompt_returns_str_on_enter() -> None:
+    async with _ChatApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(ChatPaneWidget)
+        area = widget.query_one("#input-area", TextArea)
+        area.load_text("hello")
+        await pilot.pause()
+
+        async def _submit_after_delay() -> None:
+            await asyncio.sleep(0.05)
+            widget._submit()
+
+        pilot.app.run_worker(_submit_after_delay())
+        result = await widget.prompt()
+        assert result == "hello"
+
+
+async def test_chat_pane_prompt_returns_none_on_escape() -> None:
+    async with _ChatApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(ChatPaneWidget)
+
+        async def _escape_after_delay() -> None:
+            await asyncio.sleep(0.05)
+            widget._end_interview()
+
+        pilot.app.run_worker(_escape_after_delay())
+        result = await widget.prompt()
+        assert result is None
+
+
+async def test_chat_pane_prompt_returns_none_on_ctrl_d() -> None:
+    async with _ChatApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(ChatPaneWidget)
+
+        async def _end_after_delay() -> None:
+            await asyncio.sleep(0.05)
+            widget._end_interview()
+
+        pilot.app.run_worker(_end_after_delay())
+        result = await widget.prompt()
+        assert result is None
+
+
+async def test_chat_pane_prompt_submit_clears_textarea_for_next_turn() -> None:
+    async with _ChatApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(ChatPaneWidget)
+        area = widget.query_one("#input-area", TextArea)
+        area.load_text("first message")
+        await pilot.pause()
+        widget._submit()
+        await pilot.pause()
+        # after submit, textarea should be cleared
+        assert area.text == ""
+
+
 async def test_chat_pane_thinking_indicator_during_emit() -> None:
     async with _ChatApp().run_test(headless=True) as pilot:
         widget = pilot.app.query_one(ChatPaneWidget)

--- a/tests/test_workflows/test_refine_integration.py
+++ b/tests/test_workflows/test_refine_integration.py
@@ -1,4 +1,4 @@
-"""Minimal integration test: select_item wire-up through StageExecutor pre-#18."""
+"""Integration tests for RefineWorkflow."""
 
 from unittest.mock import AsyncMock
 
@@ -7,8 +7,17 @@ import pytest
 from cog.core.context import ExecutionContext
 from cog.core.tracker import IssueTracker
 from cog.core.workflow import StageExecutor
-from cog.workflows.refine import RefineWorkflow
-from tests.fakes import FakeItemPicker, InMemoryStateCache, make_needs_refinement_items
+from cog.workflows.refine import InterviewEnd, RefineWorkflow
+from tests.fakes import (
+    FakeItemPicker,
+    InMemoryStateCache,
+    RecordingEventSink,
+    ScriptedInputProvider,
+    ScriptedInterviewRunner,
+    make_needs_refinement_items,
+)
+
+_SENTINEL = "<<interview-complete>>"
 
 
 async def test_refine_select_then_executor_exits_cleanly_when_stages_not_implemented(tmp_path):
@@ -26,9 +35,45 @@ async def test_refine_select_then_executor_exits_cleanly_when_stages_not_impleme
 
     wf = RefineWorkflow(runner=AsyncMock(), tracker=tracker)
 
-    # With a single item, select_item auto-selects, then stages() raises NotImplementedError
-    # StageExecutor wraps that in StageError via finalize_error
-    with pytest.raises(NotImplementedError):
+    # With a single item, select_item auto-selects, then pre_stages (interview)
+    # has no event_sink/input_provider → raises AssertionError
+    with pytest.raises((NotImplementedError, AssertionError)):
         await StageExecutor().run(wf, ctx)
 
     assert ctx.item == items[0]
+
+
+@pytest.mark.asyncio
+async def test_refine_interview_end_to_end_with_scripted_runner(tmp_path):
+    """Full pre_stages run through ScriptedInterviewRunner + ScriptedInputProvider."""
+    responses = [
+        ("First question?", 0.01),
+        (f"All set! {_SENTINEL}", 0.02),
+    ]
+    runner = ScriptedInterviewRunner(responses)
+    tracker = AsyncMock(spec=IssueTracker)
+    items = make_needs_refinement_items([42])
+    tracker.list_by_label.return_value = items
+
+    sink = RecordingEventSink()
+    provider = ScriptedInputProvider(["my answer"])
+
+    ctx = ExecutionContext(
+        project_dir=tmp_path,
+        tmp_dir=tmp_path / "tmp",
+        state_cache=InMemoryStateCache(),
+        headless=False,
+        item=items[0],
+        event_sink=sink,
+        input_provider=provider,
+    )
+
+    wf = RefineWorkflow(runner=runner, tracker=tracker)
+    await wf.pre_stages(ctx)
+
+    transcript = wf._transcripts[items[0].item_id]
+    assert len(transcript) == 2
+    assert transcript[0].end == InterviewEnd.NOT_ENDED
+    assert transcript[0].user_message == "my answer"
+    assert transcript[1].end == InterviewEnd.SENTINEL
+    assert _SENTINEL not in transcript[1].assistant_message

--- a/tests/test_workflows/test_refine_interview.py
+++ b/tests/test_workflows/test_refine_interview.py
@@ -1,0 +1,505 @@
+"""Tests for RefineWorkflow interview loop."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cog.core.context import ExecutionContext
+from cog.core.item import Comment, Item
+from cog.core.runner import AssistantTextEvent, ResultEvent
+from cog.workflows.refine import (
+    _INTERVIEW_COMPLETE,
+    InterviewEnd,
+    InterviewTurn,
+    RefineWorkflow,
+)
+from tests.fakes import (
+    InMemoryStateCache,
+    RecordingEventSink,
+    ScriptedInputProvider,
+    ScriptedInterviewRunner,
+    make_item,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_workflow(responses: list[tuple[str, float]]) -> RefineWorkflow:
+    runner = ScriptedInterviewRunner(responses)
+    tracker = AsyncMock()
+    return RefineWorkflow(runner=runner, tracker=tracker)
+
+
+def _make_ctx(
+    *,
+    item: Item | None = None,
+    sink: RecordingEventSink | None = None,
+    provider: ScriptedInputProvider | None = None,
+    tmp_path: Path,
+) -> ExecutionContext:
+    return ExecutionContext(
+        project_dir=tmp_path,
+        tmp_dir=tmp_path / "tmp",
+        state_cache=InMemoryStateCache(),
+        headless=False,
+        item=item,
+        event_sink=sink,
+        input_provider=provider,
+    )
+
+
+def _make_item_with_comments() -> Item:
+    return make_item(
+        item_id="5",
+        title="Add caching",
+        body="We need caching.",
+        comments=(
+            Comment(
+                author="alice",
+                body="Good idea",
+                created_at=datetime(2024, 1, 2, tzinfo=UTC),
+            ),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prompt assembly
+# ---------------------------------------------------------------------------
+
+
+def test_load_interview_prompt_reads_package_data():
+    from importlib.resources import files
+
+    text = files("cog.prompts.claude.refine").joinpath("interview.md").read_text(encoding="utf-8")
+    assert "<<interview-complete>>" in text
+    assert "Ask ONE question" in text
+
+
+def test_preamble_includes_interview_prompt_plus_item_details():
+    wf = _make_workflow([("hello", 0.0)])
+    item = make_item(item_id="3", title="My issue", body="Some body")
+    preamble = wf._build_preamble(item)
+    assert "<<interview-complete>>" in preamble
+    assert "Issue #3: My issue" in preamble
+    assert "Some body" in preamble
+
+
+def test_preamble_omits_comments_when_empty():
+    wf = _make_workflow([("hello", 0.0)])
+    item = make_item(item_id="1", title="T", body="B")
+    preamble = wf._build_preamble(item)
+    assert "### Comments" not in preamble
+
+
+def test_preamble_includes_comments_when_present():
+    wf = _make_workflow([("hello", 0.0)])
+    item = _make_item_with_comments()
+    preamble = wf._build_preamble(item)
+    assert "### Comments" in preamble
+    assert "alice" in preamble
+    assert "Good idea" in preamble
+
+
+def test_turn_prompt_first_turn_has_no_conversation_section():
+    wf = _make_workflow([("hello", 0.0)])
+    item = make_item(item_id="1", title="T", body="B")
+    preamble = wf._build_preamble(item)
+    prompt = wf._build_turn_prompt(preamble, [])
+    assert "## Conversation so far" not in prompt
+
+
+def test_turn_prompt_subsequent_turns_include_transcript():
+    wf = _make_workflow([("hello", 0.0)])
+    item = make_item(item_id="1", title="T", body="B")
+    preamble = wf._build_preamble(item)
+    transcript = [
+        InterviewTurn(
+            assistant_message="What approach?",
+            user_message="Use option A",
+            cost_usd=0.01,
+            duration_seconds=1.0,
+        )
+    ]
+    prompt = wf._build_turn_prompt(preamble, transcript)
+    assert "## Conversation so far" in prompt
+    assert "What approach?" in prompt
+    assert "Use option A" in prompt
+
+
+def test_turn_prompt_always_ends_with_sentinel_instruction():
+    wf = _make_workflow([("hello", 0.0)])
+    item = make_item(item_id="1", title="T", body="B")
+    preamble = wf._build_preamble(item)
+    prompt = wf._build_turn_prompt(preamble, [])
+    assert _INTERVIEW_COMPLETE in prompt
+
+
+# ---------------------------------------------------------------------------
+# Loop — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_interview_single_turn_sentinel(tmp_path):
+    sentinel_msg = f"Great, I have what I need. {_INTERVIEW_COMPLETE}"
+    wf = _make_workflow([(sentinel_msg, 0.05)])
+    item = make_item(item_id="1", title="T", body="B")
+    sink = RecordingEventSink()
+    provider = ScriptedInputProvider([])  # should not be called
+    ctx = _make_ctx(item=item, sink=sink, provider=provider, tmp_path=tmp_path)
+    transcript = await wf._run_interview(ctx)
+    assert len(transcript) == 1
+    assert transcript[0].end == InterviewEnd.SENTINEL
+
+
+@pytest.mark.asyncio
+async def test_interview_multi_turn_sentinel(tmp_path):
+    wf = _make_workflow(
+        [
+            ("First question?", 0.01),
+            ("Second question?", 0.01),
+            (f"All done. {_INTERVIEW_COMPLETE}", 0.01),
+        ]
+    )
+    item = make_item(item_id="1", title="T", body="B")
+    sink = RecordingEventSink()
+    provider = ScriptedInputProvider(["answer1", "answer2"])
+    ctx = _make_ctx(item=item, sink=sink, provider=provider, tmp_path=tmp_path)
+    transcript = await wf._run_interview(ctx)
+    assert len(transcript) == 3
+    assert transcript[0].end == InterviewEnd.NOT_ENDED
+    assert transcript[1].end == InterviewEnd.NOT_ENDED
+    assert transcript[2].end == InterviewEnd.SENTINEL
+
+
+@pytest.mark.asyncio
+async def test_interview_sentinel_stripped_from_assistant_message(tmp_path):
+    raw = f"Good to go! {_INTERVIEW_COMPLETE} Extra text after."
+    wf = _make_workflow([(raw, 0.0)])
+    item = make_item(item_id="1", title="T", body="B")
+    sink = RecordingEventSink()
+    provider = ScriptedInputProvider([])
+    ctx = _make_ctx(item=item, sink=sink, provider=provider, tmp_path=tmp_path)
+    transcript = await wf._run_interview(ctx)
+    assert _INTERVIEW_COMPLETE not in transcript[0].assistant_message
+
+
+# ---------------------------------------------------------------------------
+# Loop — user early-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_interview_user_ends_via_none_prompt(tmp_path):
+    wf = _make_workflow([("Question?", 0.02)])
+    item = make_item(item_id="1", title="T", body="B")
+    sink = RecordingEventSink()
+    provider = ScriptedInputProvider([None])
+    ctx = _make_ctx(item=item, sink=sink, provider=provider, tmp_path=tmp_path)
+    transcript = await wf._run_interview(ctx)
+    assert len(transcript) == 1
+    assert transcript[0].end == InterviewEnd.USER
+    assert transcript[0].user_message is None
+
+
+@pytest.mark.asyncio
+async def test_interview_user_end_preserves_assistant_message_as_is(tmp_path):
+    wf = _make_workflow([("What do you need?", 0.0)])
+    item = make_item(item_id="1", title="T", body="B")
+    sink = RecordingEventSink()
+    provider = ScriptedInputProvider([None])
+    ctx = _make_ctx(item=item, sink=sink, provider=provider, tmp_path=tmp_path)
+    transcript = await wf._run_interview(ctx)
+    assert transcript[0].assistant_message == "What do you need?"
+
+
+# ---------------------------------------------------------------------------
+# Loop — cost & duration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_interview_cost_sums_across_turns(tmp_path):
+    wf = _make_workflow(
+        [
+            ("Question?", 0.10),
+            (f"Done. {_INTERVIEW_COMPLETE}", 0.20),
+        ]
+    )
+    item = make_item(item_id="1", title="T", body="B")
+    sink = RecordingEventSink()
+    provider = ScriptedInputProvider(["reply"])
+    ctx = _make_ctx(item=item, sink=sink, provider=provider, tmp_path=tmp_path)
+    transcript = await wf._run_interview(ctx)
+    total = sum(t.cost_usd for t in transcript)
+    assert abs(total - 0.30) < 1e-9
+
+
+@pytest.mark.asyncio
+async def test_interview_duration_sums_across_turns(tmp_path):
+    wf = _make_workflow(
+        [
+            ("Q1?", 0.0),
+            (f"Done. {_INTERVIEW_COMPLETE}", 0.0),
+        ]
+    )
+    item = make_item(item_id="1", title="T", body="B")
+    sink = RecordingEventSink()
+    provider = ScriptedInputProvider(["reply"])
+    ctx = _make_ctx(item=item, sink=sink, provider=provider, tmp_path=tmp_path)
+    transcript = await wf._run_interview(ctx)
+    total_duration = sum(t.duration_seconds for t in transcript)
+    assert total_duration >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# Loop — event forwarding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_interview_forwards_assistant_events_to_sink(tmp_path):
+    sentinel_msg = f"hello {_INTERVIEW_COMPLETE}"
+    wf = _make_workflow([(sentinel_msg, 0.0)])
+    item = make_item(item_id="1", title="T", body="B")
+    sink = RecordingEventSink()
+    provider = ScriptedInputProvider([])
+    ctx = _make_ctx(item=item, sink=sink, provider=provider, tmp_path=tmp_path)
+    await wf._run_interview(ctx)
+    assert any(isinstance(e, AssistantTextEvent) for e in sink.events)
+
+
+@pytest.mark.asyncio
+async def test_interview_does_not_forward_result_events(tmp_path):
+    sentinel_msg = f"done {_INTERVIEW_COMPLETE}"
+    wf = _make_workflow([(sentinel_msg, 0.0)])
+    item = make_item(item_id="1", title="T", body="B")
+    sink = RecordingEventSink()
+    provider = ScriptedInputProvider([])
+    ctx = _make_ctx(item=item, sink=sink, provider=provider, tmp_path=tmp_path)
+    await wf._run_interview(ctx)
+    assert not any(isinstance(e, ResultEvent) for e in sink.events)
+
+
+# ---------------------------------------------------------------------------
+# Loop — failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_interview_raises_when_event_sink_missing(tmp_path):
+    wf = _make_workflow([("Q?", 0.0)])
+    item = make_item(item_id="1", title="T", body="B")
+    ctx = _make_ctx(item=item, sink=None, provider=ScriptedInputProvider([]), tmp_path=tmp_path)
+    with pytest.raises(AssertionError, match="event sink"):
+        await wf._run_interview(ctx)
+
+
+@pytest.mark.asyncio
+async def test_interview_raises_when_input_provider_missing(tmp_path):
+    wf = _make_workflow([("Q?", 0.0)])
+    item = make_item(item_id="1", title="T", body="B")
+    ctx = _make_ctx(item=item, sink=RecordingEventSink(), provider=None, tmp_path=tmp_path)
+    with pytest.raises(AssertionError, match="input provider"):
+        await wf._run_interview(ctx)
+
+
+@pytest.mark.asyncio
+async def test_interview_runner_exception_propagates(tmp_path):
+    from tests.fakes import FailingRunner
+
+    wf = RefineWorkflow(runner=FailingRunner(RuntimeError("boom")), tracker=AsyncMock())
+    item = make_item(item_id="1", title="T", body="B")
+    sink = RecordingEventSink()
+    provider = ScriptedInputProvider([])
+    ctx = _make_ctx(item=item, sink=sink, provider=provider, tmp_path=tmp_path)
+    with pytest.raises(RuntimeError, match="boom"):
+        await wf._run_interview(ctx)
+
+
+@pytest.mark.asyncio
+async def test_interview_no_result_event_emitted_raises(tmp_path):
+    """Runner that never emits ResultEvent should cause _run_interview to loop
+    with empty final_message, not crash — but with no sentinel and no user input
+    it would loop forever. Verify empty final_message with user-end works."""
+    from collections.abc import AsyncIterator
+
+    from cog.core.runner import AgentRunner, RunEvent
+
+    class NoResultRunner(AgentRunner):
+        async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+            # yields nothing (no ResultEvent → final_message stays "")
+            return
+            yield  # type: ignore[misc]
+
+    wf = RefineWorkflow(runner=NoResultRunner(), tracker=AsyncMock())
+    item = make_item(item_id="1", title="T", body="B")
+    sink = RecordingEventSink()
+    provider = ScriptedInputProvider([None])  # user ends on first turn
+    ctx = _make_ctx(item=item, sink=sink, provider=provider, tmp_path=tmp_path)
+    transcript = await wf._run_interview(ctx)
+    assert transcript[0].end == InterviewEnd.USER
+    assert transcript[0].assistant_message == ""
+
+
+# ---------------------------------------------------------------------------
+# pre_stages
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pre_stages_stores_transcript_by_item_id(tmp_path):
+    sentinel_msg = f"All good. {_INTERVIEW_COMPLETE}"
+    wf = _make_workflow([(sentinel_msg, 0.0)])
+    item = make_item(item_id="42", title="T", body="B")
+    sink = RecordingEventSink()
+    provider = ScriptedInputProvider([])
+    ctx = _make_ctx(item=item, sink=sink, provider=provider, tmp_path=tmp_path)
+    await wf.pre_stages(ctx)
+    assert "42" in wf._transcripts
+    assert len(wf._transcripts["42"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_pre_stages_raises_when_item_not_set(tmp_path):
+    wf = _make_workflow([("Q?", 0.0)])
+    ctx = _make_ctx(
+        item=None,
+        sink=RecordingEventSink(),
+        provider=ScriptedInputProvider([]),
+        tmp_path=tmp_path,
+    )
+    with pytest.raises(AssertionError, match="ctx.item"):
+        await wf.pre_stages(ctx)
+
+
+@pytest.mark.asyncio
+async def test_pre_stages_propagates_interview_failure(tmp_path):
+    from tests.fakes import FailingRunner
+
+    wf = RefineWorkflow(runner=FailingRunner(ValueError("oops")), tracker=AsyncMock())
+    item = make_item(item_id="1", title="T", body="B")
+    ctx = _make_ctx(
+        item=item,
+        sink=RecordingEventSink(),
+        provider=ScriptedInputProvider([]),
+        tmp_path=tmp_path,
+    )
+    with pytest.raises(ValueError, match="oops"):
+        await wf.pre_stages(ctx)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic telemetry stage
+# ---------------------------------------------------------------------------
+
+
+def test_interview_telemetry_stage_shape():
+    wf = _make_workflow([("Q?", 0.0)])
+    transcript = [
+        InterviewTurn(
+            assistant_message="Q1?", user_message="A1", cost_usd=0.10, duration_seconds=2.0
+        ),
+        InterviewTurn(
+            assistant_message="Done",
+            user_message=None,
+            cost_usd=0.05,
+            duration_seconds=1.5,
+            end=InterviewEnd.SENTINEL,
+        ),
+    ]
+    stage = wf._interview_telemetry_stage(transcript, "claude-sonnet-4-6")
+    assert stage.stage == "interview"
+    assert stage.model == "claude-sonnet-4-6"
+    assert abs(stage.duration_s - 3.5) < 1e-9
+    assert abs(stage.cost_usd - 0.15) < 1e-9
+    assert stage.exit_status == 0
+    assert stage.commits == 0
+
+
+def test_interview_telemetry_stage_empty_transcript_returns_zeros():
+    wf = _make_workflow([("Q?", 0.0)])
+    stage = wf._interview_telemetry_stage([], "claude-sonnet-4-6")
+    assert stage.duration_s == 0.0
+    assert stage.cost_usd == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Minimal finalize_error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_finalize_error_writes_stderr_warning_with_item_id(tmp_path, capsys):
+    wf = _make_workflow([("Q?", 0.0)])
+    item = make_item(item_id="7", title="T", body="B")
+    ctx = _make_ctx(
+        item=item,
+        sink=RecordingEventSink(),
+        provider=ScriptedInputProvider([]),
+        tmp_path=tmp_path,
+    )
+    await wf.finalize_error(ctx, RuntimeError("bad"), [])
+    captured = capsys.readouterr()
+    assert "#7" in captured.err
+    assert "RuntimeError" in captured.err
+    assert "bad" in captured.err
+
+
+@pytest.mark.asyncio
+async def test_finalize_error_writes_partial_telemetry_when_transcript_exists(tmp_path):
+    wf = _make_workflow([("Q?", 0.0)])
+    item = make_item(item_id="8", title="T", body="B")
+    # Pre-populate a transcript
+    wf._transcripts["8"] = [
+        InterviewTurn(assistant_message="Q?", user_message="A", cost_usd=0.05, duration_seconds=1.0)
+    ]
+    fake_writer = AsyncMock()
+    ctx = ExecutionContext(
+        project_dir=tmp_path,
+        tmp_dir=tmp_path / "tmp",
+        state_cache=InMemoryStateCache(),
+        headless=False,
+        item=item,
+        telemetry=fake_writer,
+    )
+    await wf.finalize_error(ctx, RuntimeError("x"), [])
+    fake_writer.write.assert_called_once()
+    record = fake_writer.write.call_args[0][0]
+    assert record.workflow == "refine"
+    assert record.outcome == "error"
+    # interview stage should be in stages tuple
+    assert any(s.stage == "interview" for s in record.stages)
+
+
+@pytest.mark.asyncio
+async def test_finalize_error_skips_telemetry_when_transcript_empty(tmp_path):
+    wf = _make_workflow([("Q?", 0.0)])
+    item = make_item(item_id="9", title="T", body="B")
+    fake_writer = AsyncMock()
+    ctx = ExecutionContext(
+        project_dir=tmp_path,
+        tmp_dir=tmp_path / "tmp",
+        state_cache=InMemoryStateCache(),
+        headless=False,
+        item=item,
+        telemetry=fake_writer,
+    )
+    await wf.finalize_error(ctx, RuntimeError("x"), [])
+    fake_writer.write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_finalize_error_tolerates_missing_telemetry_writer(tmp_path, capsys):
+    wf = _make_workflow([("Q?", 0.0)])
+    item = make_item(item_id="10", title="T", body="B")
+    ctx = _make_ctx(item=item, sink=None, provider=None, tmp_path=tmp_path)
+    # Should not raise even with no telemetry writer
+    await wf.finalize_error(ctx, RuntimeError("x"), [])
+    captured = capsys.readouterr()
+    assert "#10" in captured.err


### PR DESCRIPTION
## Summary

Implements the full multi-turn interview loop for `RefineWorkflow` (#18). Claude runs a back-and-forth conversation with the user via `ChatPaneWidget`, accumulating an `InterviewTurn` transcript per turn. The loop detects a `<<interview-complete>>` sentinel to end naturally, or records `InterviewEnd.USER` when the user presses Escape/Ctrl+D. Transcripts are stored by item ID so the rewrite stage (#19) can consume them. The `stages()` method raises `NotImplementedError` as specified until #19 lands.

## Key changes

- `src/cog/prompts/claude/refine/__init__.py` (new): package init for prompt namespace
- `src/cog/prompts/claude/refine/interview.md` (new): cog-owned interview system prompt, tracker-agnostic
- `src/cog/workflows/refine.py`: adds `InterviewEnd`, `InterviewTurn`, `_INTERVIEW_COMPLETE`, `pre_stages`, `_run_interview`, `_build_preamble`, `_build_turn_prompt`, `_interview_telemetry_stage`, minimal `finalize_error`
- `src/cog/ui/widgets/chat_pane.py`: `prompt()` returns `str | None`; adds `_end_interview()` called on Escape/Ctrl+D
- `src/cog/core/sinks.py`: `UserInputProvider.prompt()` widened to `str | None`
- `src/cog/telemetry.py`: `TelemetryRecord.build()` gains `extra_stages` kwarg, prepended before result stages; cost sums both
- `tests/fakes.py`: `ScriptedInterviewRunner` + `ScriptedInputProvider` fakes
- `tests/test_workflows/test_refine_interview.py` (new): 29 tests covering prompt assembly, loop happy path, user early-end, cost/duration, event forwarding, failures, pre_stages, telemetry stage, and finalize_error
- `tests/test_ui/test_chat_pane.py`: extended with Enter→str, Escape→None, Ctrl+D→None, submit-clears-textarea tests
- `tests/test_telemetry_record.py`: two new tests for `extra_stages` kwarg and ordering
- `tests/test_workflows/test_refine_integration.py`: updated + new end-to-end test with scripted runner/provider

## Closes

Closes #18

## Test plan

- [ ] `uv run pytest tests/test_workflows/test_refine_interview.py` — 29 tests pass
- [ ] `uv run pytest` full suite — 585 passed, 3 skipped (docker integration)
- [ ] `ruff check .` + `ruff format --check .` — clean
- [ ] `mypy src` — only 3 pre-existing errors (log_pane unused ignore, chat_pane unused ignore, picker no-any-return); no new errors
- [ ] Manual: `cog refine --item <N>` on a `needs-refinement` item — ChatPane opens, Claude asks first question, user can reply, multi-turn proceeds, on `<<interview-complete>>` control returns to pre_stages (then hits `NotImplementedError` from `stages()` — expected pre-#19)
- [ ] Manual: pressing Escape mid-interview ends with `end=InterviewEnd.USER` in transcript
- [ ] Manual: `COG_REFINE_INTERVIEW_MODEL=claude-haiku-4-5-20251001 cog refine` uses the override model
- [ ] Manual: `workflow._transcripts[item.item_id]` accessible after interview completes
- [ ] Verify `StageTelemetry` with `stage="interview"` appears first in `TelemetryRecord.stages` when `extra_stages` is passed

---
🤖 Generated by cog. Iteration cost: $4.509
