### PR TITLE
Ralph workflow: resume from existing branch + agent-failed label + --restart flag (#51)

### DIFF
--- a/src/cog/cli.py
+++ b/src/cog/cli.py
@@ -38,6 +38,11 @@ def ralph(
         help="Stop after N iterations (implies --loop).",
     ),
     headless: bool = typer.Option(False, "--headless", help="Bypass Textual; log to stderr."),
+    restart: bool = typer.Option(
+        False,
+        "--restart",
+        help="Delete and recreate any existing cog/N-* branch instead of resuming.",
+    ),
     project_dir: Path | None = typer.Option(None, "--project-dir"),  # noqa: B008
 ) -> None:
     """Autonomous agent: picks next agent-ready issue, runs build/review/document, opens PR."""
@@ -55,6 +60,7 @@ def ralph(
                 loop=loop,
                 max_iterations=max_iterations,
                 headless=headless,
+                restart=restart,
             )
         )
     except KeyboardInterrupt:

--- a/src/cog/git.py
+++ b/src/cog/git.py
@@ -59,6 +59,20 @@ async def create_branch(project_dir: Path, name: str, start_point: str = "HEAD")
     await _run(["git", "checkout", "-b", name, start_point], project_dir)
 
 
+async def branch_exists(project_dir: Path, name: str) -> bool:
+    """`git rev-parse --verify refs/heads/<name>` → True if branch exists locally."""
+    try:
+        await _run(["git", "rev-parse", "--verify", f"refs/heads/{name}"], project_dir)
+        return True
+    except GitError:
+        return False
+
+
+async def delete_branch(project_dir: Path, name: str) -> None:
+    """`git branch -D <name>` — force delete (branch may not be merged)."""
+    await _run(["git", "branch", "-D", name], project_dir)
+
+
 async def log_short_shas(project_dir: Path, revision_range: str) -> list[str]:
     """`git log --format=%h --no-merges <range>` → list of short SHAs (oldest-first empty ok)."""
     result = await _run(

--- a/src/cog/telemetry.py
+++ b/src/cog/telemetry.py
@@ -54,6 +54,7 @@ class TelemetryRecord:
     total_cost_usd: float
     error: str | None
     cause_class: str | None = None
+    resumed: bool = False
 
     @classmethod
     def build(
@@ -70,6 +71,7 @@ class TelemetryRecord:
         duration_seconds: float,
         error: str | None = None,
         cause_class: str | None = None,
+        resumed: bool = False,
     ) -> "TelemetryRecord":
         result_stages = tuple(StageTelemetry.from_stage_result(r) for r in results)
         all_stages = tuple(extra_stages) + result_stages
@@ -87,6 +89,7 @@ class TelemetryRecord:
             total_cost_usd=sum(r.cost_usd for r in results) + sum(s.cost_usd for s in extra_stages),
             error=error,
             cause_class=cause_class,
+            resumed=resumed,
         )
 
 

--- a/src/cog/ui/wire.py
+++ b/src/cog/ui/wire.py
@@ -24,6 +24,7 @@ async def build_and_run(
     loop: bool,
     headless: bool,
     max_iterations: int | None = None,
+    restart: bool = False,
 ) -> int:
     # 1. Preflight
     results: list[PreflightResult] = await run_checks(workflow_cls.preflight_checks, project_dir)
@@ -53,7 +54,7 @@ async def build_and_run(
         await cache.recover_from_remote(tracker, host, workflow_cls.queue_label)
     telemetry = TelemetryWriter(state_dir)
 
-    workflow = workflow_cls(runner=runner, tracker=tracker, host=host)  # type: ignore[call-arg]
+    workflow = workflow_cls(runner=runner, tracker=tracker, host=host, restart=restart)  # type: ignore[call-arg]
 
     tmp_dir = Path(tempfile.mkdtemp(prefix="cog-"))
     ctx = ExecutionContext(

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -99,11 +99,15 @@ class RalphWorkflow(Workflow):
         runner: AgentRunner,
         tracker: IssueTracker,
         host: GitHost | None = None,
+        *,
+        restart: bool = False,
     ) -> None:
         self._runner = runner
         self._tracker = tracker
         self._host = host
+        self._restart = restart
         self._processed_this_loop: set[tuple[str, str]] = set()
+        self._resumed_this_iteration: dict[str, bool] = {}
 
     async def select_item(self, ctx: ExecutionContext) -> Item | None:
         items = await self._tracker.list_by_label("agent-ready", assignee="@me")
@@ -178,8 +182,21 @@ class RalphWorkflow(Workflow):
         await git.fetch_origin(ctx.project_dir)
         await git.merge_ff_only(ctx.project_dir, f"origin/{default}")
         work_branch = f"cog/{ctx.item.item_id}-{_slugify(ctx.item.title)}"
-        await git.create_branch(ctx.project_dir, work_branch, start_point="HEAD")
+
+        resumed = False
+        if await git.branch_exists(ctx.project_dir, work_branch):
+            ahead = await git.commits_between(ctx.project_dir, default, work_branch)
+            if ahead == 0 or self._restart:
+                await git.delete_branch(ctx.project_dir, work_branch)
+                await git.create_branch(ctx.project_dir, work_branch, start_point="HEAD")
+            else:
+                await git.checkout_branch(ctx.project_dir, work_branch)
+                resumed = True
+        else:
+            await git.create_branch(ctx.project_dir, work_branch, start_point="HEAD")
+
         ctx.work_branch = work_branch
+        self._resumed_this_iteration[ctx.item.item_id] = resumed
 
     def stages(self, ctx: ExecutionContext) -> list[Stage]:
         return [
@@ -235,6 +252,10 @@ class RalphWorkflow(Workflow):
 
         await self._tracker.comment(ctx.item, f"🤖 Cog opened a PR for this: {pr.url}")
         await self._tracker.remove_label(ctx.item, "agent-ready")
+        try:
+            await self._tracker.remove_label(ctx.item, "agent-failed")
+        except TrackerError:
+            pass
         ctx.state_cache.mark_processed(ctx.item, "success")
         ctx.state_cache.save()
         await self._write_telemetry(ctx, results, "success", pr_url=pr.url)
@@ -263,6 +284,10 @@ class RalphWorkflow(Workflow):
         )
         await self._tracker.add_label(ctx.item, "agent-abandoned")
         await self._tracker.remove_label(ctx.item, "agent-ready")
+        try:
+            await self._tracker.remove_label(ctx.item, "agent-failed")
+        except TrackerError:
+            pass
         ctx.state_cache.mark_processed(ctx.item, "no-op")
         ctx.state_cache.save()
         await self._write_telemetry(ctx, results, "no-op")
@@ -295,8 +320,14 @@ class RalphWorkflow(Workflow):
                 f"warning: failed to comment error on #{ctx.item.item_id}",
                 file=sys.stderr,
             )
-        # KEEP agent-ready label — user fixes infra, ralph retries next run.
+        # KEEP agent-ready label — item stays eligible for resume.
         # Don't mark processed — item stays eligible.
+        await self._tracker.ensure_label(
+            "agent-failed",
+            color="d93f0b",
+            description="Cog attempted this and hit an error; retry is still eligible",
+        )
+        await self._tracker.add_label(ctx.item, "agent-failed")
         await self._write_telemetry(ctx, results, "error", error=error)
         await self.write_report(ctx, results, "error", error=error)
 
@@ -414,12 +445,14 @@ class RalphWorkflow(Workflow):
                 f"warning: failed to comment push-fail on #{ctx.item.item_id}",
                 file=sys.stderr,
             )
-        try:
-            await self._tracker.remove_label(ctx.item, "agent-ready")
-        except Exception:
-            pass
-        # Don't mark processed — local commits exist; next run either reuses the
-        # branch (v1.1 orphan-resume) or fails cleanly on create_branch (v1).
+        # KEEP agent-ready — next run will resume + retry push.
+        # Don't mark processed — local commits exist; resume path handles it.
+        await self._tracker.ensure_label(
+            "agent-failed",
+            color="d93f0b",
+            description="Cog attempted this and hit an error; retry is still eligible",
+        )
+        await self._tracker.add_label(ctx.item, "agent-failed")
         await self._write_telemetry(ctx, results, "push-failed", error=error)
         await self.write_report(ctx, results, "error", error=error)
 
@@ -440,6 +473,7 @@ class RalphWorkflow(Workflow):
                 cause_class = type(error.cause).__name__
         if ctx.telemetry is None:
             return
+        resumed = self._resumed_this_iteration.get(ctx.item.item_id, False)  # type: ignore[union-attr]
         record = TelemetryRecord.build(
             project=project_slug(ctx.project_dir),
             workflow=self.name,
@@ -451,5 +485,6 @@ class RalphWorkflow(Workflow):
             duration_seconds=sum(r.duration_seconds for r in results),
             error=error_str,
             cause_class=cause_class,
+            resumed=resumed,
         )
         await ctx.telemetry.write(record)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -162,6 +162,36 @@ def test_cog_ralph_keyboard_interrupt_exits_130(monkeypatch, tmp_path):
     assert "aborted." in result.output or "aborted." in (result.stderr or "")
 
 
+# --- ralph --restart flag ---
+
+
+def test_cog_ralph_restart_flag_forwards_to_build_and_run(monkeypatch, tmp_path):
+    calls: list[dict] = []
+
+    async def fake_build_and_run(*args: Any, **kwargs: Any) -> int:
+        calls.append({"args": args, **kwargs})
+        return 0
+
+    monkeypatch.setattr("cog.cli.build_and_run", fake_build_and_run)
+    result = runner.invoke(app, ["ralph", "--project-dir", str(tmp_path), "--restart"])
+    assert result.exit_code == 0
+    assert len(calls) == 1
+    assert calls[0]["restart"] is True
+
+
+def test_cog_ralph_without_restart_defaults_to_false(monkeypatch, tmp_path):
+    calls: list[dict] = []
+
+    async def fake_build_and_run(*args: Any, **kwargs: Any) -> int:
+        calls.append({"args": args, **kwargs})
+        return 0
+
+    monkeypatch.setattr("cog.cli.build_and_run", fake_build_and_run)
+    result = runner.invoke(app, ["ralph", "--project-dir", str(tmp_path)])
+    assert result.exit_code == 0
+    assert calls[0]["restart"] is False
+
+
 # --- refine subcommand ---
 
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -7,12 +7,14 @@ import pytest
 
 from cog.core.errors import GitError
 from cog.git import (
+    branch_exists,
     checkout_branch,
     commits_between,
     create_branch,
     current_branch,
     current_head_sha,
     default_branch,
+    delete_branch,
     fetch_origin,
     merge_ff_only,
 )
@@ -157,3 +159,34 @@ async def test_create_branch_raises_when_exists(tmp_path: Path) -> None:
     with _patch_exec(registry):
         with pytest.raises(GitError):
             await create_branch(tmp_path, "cog/42-my-branch")
+
+
+async def test_branch_exists_returns_true_when_present(tmp_path: Path) -> None:
+    registry = FakeSubprocessRegistry()
+    registry.expect(
+        ("git", "rev-parse", "--verify", "refs/heads/cog/42-my-branch"),
+        stdout=b"abc1234\n",
+    )
+    with _patch_exec(registry):
+        result = await branch_exists(tmp_path, "cog/42-my-branch")
+    assert result is True
+
+
+async def test_branch_exists_returns_false_when_absent(tmp_path: Path) -> None:
+    registry = FakeSubprocessRegistry()
+    registry.expect(
+        ("git", "rev-parse", "--verify", "refs/heads/cog/42-my-branch"),
+        returncode=128,
+        stderr=b"fatal: Needed a single revision\n",
+    )
+    with _patch_exec(registry):
+        result = await branch_exists(tmp_path, "cog/42-my-branch")
+    assert result is False
+
+
+async def test_delete_branch_removes_branch(tmp_path: Path) -> None:
+    registry = FakeSubprocessRegistry()
+    registry.expect(("git", "branch", "-D", "cog/42-my-branch"), stdout=b"")
+    with _patch_exec(registry):
+        await delete_branch(tmp_path, "cog/42-my-branch")
+    assert ("git", "branch", "-D", "cog/42-my-branch") in registry.calls

--- a/tests/test_telemetry_record.py
+++ b/tests/test_telemetry_record.py
@@ -332,3 +332,49 @@ def test_telemetry_record_backward_compat_missing_cause_class():
     # Re-constructing from dict without cause_class uses the default
     reconstructed = TelemetryRecord(**{**d, "stages": tuple(d["stages"])})  # type: ignore[arg-type]
     assert reconstructed.cause_class is None
+
+
+def test_telemetry_record_resumed_defaults_to_false():
+    record = TelemetryRecord.build(
+        project="p",
+        workflow="w",
+        item=_make_item(),
+        outcome="success",
+        results=[],
+        duration_seconds=1.0,
+    )
+    assert record.resumed is False
+
+
+def test_telemetry_record_resumed_field_serializes_to_json():
+    import dataclasses
+    import json
+
+    record = TelemetryRecord.build(
+        project="p",
+        workflow="w",
+        item=_make_item(),
+        outcome="success",
+        results=[],
+        duration_seconds=1.0,
+        resumed=True,
+    )
+    d = dataclasses.asdict(record)
+    line = json.dumps(d)
+    parsed = json.loads(line)
+    assert parsed["resumed"] is True
+
+
+def test_telemetry_record_old_jsonl_without_resumed_field_parses_with_default():
+    record = TelemetryRecord.build(
+        project="p",
+        workflow="w",
+        item=_make_item(),
+        outcome="success",
+        results=[],
+        duration_seconds=1.0,
+    )
+    d = dataclasses.asdict(record)
+    d.pop("resumed", None)
+    reconstructed = TelemetryRecord(**{**d, "stages": tuple(d["stages"])})  # type: ignore[arg-type]
+    assert reconstructed.resumed is False

--- a/tests/test_ui/test_wire.py
+++ b/tests/test_ui/test_wire.py
@@ -386,3 +386,37 @@ async def test_build_run_screen_sets_ctx_app_for_textual_workflows(tmp_path: Pat
         await run_textual(wf, ctx, loop=False, tracker=None)
 
     assert ctx.app is not None
+
+
+async def test_build_and_run_forwards_restart_to_workflow_constructor(tmp_path: Path) -> None:
+    from cog.ui.wire import build_and_run
+
+    captured_workflow: list = []
+
+    async def _run_headless(workflow, ctx, *, loop, max_iterations=None):
+        captured_workflow.append(workflow)
+        return 0
+
+    patches = _patched_wire_context(tmp_path)
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patches[5],
+        patches[6],
+        patches[7],
+        patch("cog.ui.wire.run_headless", _run_headless),
+    ):
+        await build_and_run(
+            _FakeWorkflow,  # type: ignore[arg-type]
+            tmp_path,
+            item_id=None,
+            loop=False,
+            headless=True,
+            restart=True,
+        )
+
+    assert len(captured_workflow) == 1
+    assert captured_workflow[0]._kwargs.get("restart") is True

--- a/tests/test_workflows/test_ralph_finalization.py
+++ b/tests/test_workflows/test_ralph_finalization.py
@@ -422,7 +422,8 @@ async def test_finalize_success_removes_agent_ready_label(tmp_path: Path) -> Non
     wf = _make_wf(tracker=tracker)
     ctx = _make_ctx(tmp_path)
     await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
-    tracker.remove_label.assert_awaited_once_with(ctx.item, "agent-ready")
+    removed_labels = [c.args[1] for c in tracker.remove_label.call_args_list]
+    assert "agent-ready" in removed_labels
 
 
 async def test_finalize_success_marks_processed_in_state_cache(tmp_path: Path) -> None:
@@ -519,13 +520,15 @@ async def test_push_failed_does_not_call_push_or_create_pr(tmp_path: Path) -> No
     host.create_pr.assert_not_awaited()
 
 
-async def test_push_failed_removes_agent_ready_label(tmp_path: Path) -> None:
+async def test_push_failed_does_not_remove_agent_ready_label(tmp_path: Path) -> None:
+    """Push-failed now keeps agent-ready so the item stays eligible for resume."""
     tracker = _make_tracker()
     host = _make_host(push_error=HostError("fail"))
     wf = _make_wf(tracker=tracker, host=host)
     ctx = _make_ctx(tmp_path)
     await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
-    tracker.remove_label.assert_awaited_once_with(ctx.item, "agent-ready")
+    removed_labels = [c.args[1] for c in tracker.remove_label.call_args_list]
+    assert "agent-ready" not in removed_labels
 
 
 async def test_push_failed_does_not_mark_processed_in_state_cache(tmp_path: Path) -> None:
@@ -592,7 +595,8 @@ async def test_finalize_noop_removes_agent_ready_label(tmp_path: Path) -> None:
     wf = _make_wf(tracker=tracker)
     ctx = _make_ctx(tmp_path)
     await wf.finalize_noop(ctx, [make_stage_result("build")])
-    tracker.remove_label.assert_awaited_once_with(ctx.item, "agent-ready")
+    removed_labels = [c.args[1] for c in tracker.remove_label.call_args_list]
+    assert "agent-ready" in removed_labels
 
 
 async def test_finalize_noop_comments_with_build_stage_explanation(tmp_path: Path) -> None:
@@ -822,7 +826,8 @@ async def test_full_iteration_end_to_end_success(tmp_path: Path) -> None:
     host.push_branch.assert_awaited_once_with("cog/42-fix")
     host.create_pr.assert_awaited_once()
     tracker.comment.assert_awaited_once()
-    tracker.remove_label.assert_awaited_once_with(ctx.item, "agent-ready")
+    removed_labels = [c.args[1] for c in tracker.remove_label.call_args_list]
+    assert "agent-ready" in removed_labels
     assert cache.is_processed(ctx.item)
 
 
@@ -872,9 +877,11 @@ async def test_full_iteration_end_to_end_noop(tmp_path: Path) -> None:
     await StageExecutor().run(wf, ctx)
 
     host.push_branch.assert_not_awaited()
-    tracker.ensure_label.assert_awaited_once()
-    tracker.add_label.assert_awaited_once_with(ctx.item, "agent-abandoned")
-    tracker.remove_label.assert_awaited_once_with(ctx.item, "agent-ready")
+    tracker.ensure_label.assert_awaited()
+    add_labels = [c.args[1] for c in tracker.add_label.call_args_list]
+    assert "agent-abandoned" in add_labels
+    removed_labels = [c.args[1] for c in tracker.remove_label.call_args_list]
+    assert "agent-ready" in removed_labels
     assert cache.is_processed(ctx.item)
 
 

--- a/tests/test_workflows/test_ralph_pre_stages.py
+++ b/tests/test_workflows/test_ralph_pre_stages.py
@@ -54,6 +54,7 @@ async def test_pre_stages_git_operations_in_order() -> None:
         patch("cog.workflows.ralph.git.checkout_branch", new=_checkout),
         patch("cog.workflows.ralph.git.fetch_origin", new=_fetch),
         patch("cog.workflows.ralph.git.merge_ff_only", new=_merge),
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=False)),
         patch("cog.workflows.ralph.git.create_branch", new=_create),
     ):
         await wf.pre_stages(ctx)
@@ -77,6 +78,7 @@ async def test_pre_stages_sets_ctx_work_branch() -> None:
         patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
         patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
         patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=False)),
         patch("cog.workflows.ralph.git.create_branch", AsyncMock()),
     ):
         await wf.pre_stages(ctx)
@@ -94,6 +96,7 @@ async def test_pre_stages_branch_name_format() -> None:
         patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
         patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
         patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=False)),
         patch("cog.workflows.ralph.git.create_branch", AsyncMock()) as mock_create,
     ):
         await wf.pre_stages(ctx)
@@ -116,6 +119,7 @@ async def test_pre_stages_propagates_git_error_from_fetch() -> None:
             AsyncMock(side_effect=GitError("fetch failed")),
         ),
         patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=False)),
         patch("cog.workflows.ralph.git.create_branch", AsyncMock()),
     ):
         with pytest.raises(GitError, match="fetch failed"):
@@ -132,6 +136,7 @@ async def test_pre_stages_propagates_git_error_from_merge() -> None:
         patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
         patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
         patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock(side_effect=GitError("not ff"))),
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=False)),
         patch("cog.workflows.ralph.git.create_branch", AsyncMock()),
     ):
         with pytest.raises(GitError, match="not ff"):
@@ -148,6 +153,7 @@ async def test_pre_stages_propagates_git_error_from_create_branch() -> None:
         patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
         patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
         patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=False)),
         patch(
             "cog.workflows.ralph.git.create_branch",
             AsyncMock(side_effect=GitError("branch already exists")),

--- a/tests/test_workflows/test_ralph_resume.py
+++ b/tests/test_workflows/test_ralph_resume.py
@@ -1,0 +1,442 @@
+"""Tests for RalphWorkflow resume / restart / agent-failed label logic."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cog.core.context import ExecutionContext
+from cog.core.errors import HostError, TrackerError
+from cog.core.host import GitHost, PullRequest
+from cog.core.tracker import IssueTracker
+from cog.workflows.ralph import RalphWorkflow
+from tests.fakes import InMemoryStateCache, make_item, make_stage_result
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_workflow(*, restart: bool = False) -> RalphWorkflow:
+    return RalphWorkflow(
+        runner=AsyncMock(),
+        tracker=AsyncMock(spec=IssueTracker),
+        restart=restart,
+    )
+
+
+def _make_ctx(item=None) -> ExecutionContext:
+    ctx = ExecutionContext(
+        project_dir=Path("/fake/project"),
+        tmp_dir=Path("/tmp"),
+        state_cache=InMemoryStateCache(),
+        headless=True,
+    )
+    ctx.item = item
+    return ctx
+
+
+def _make_tracker() -> AsyncMock:
+    tracker = AsyncMock(spec=IssueTracker)
+    tracker.comment.return_value = None
+    tracker.add_label.return_value = None
+    tracker.remove_label.return_value = None
+    tracker.ensure_label.return_value = None
+    return tracker
+
+
+def _make_host(*, pr: PullRequest | None = None) -> AsyncMock:
+    host = AsyncMock(spec=GitHost)
+    host.push_branch.return_value = None
+    host.get_pr_for_branch.return_value = pr
+    host.create_pr.return_value = PullRequest(
+        number=1,
+        url="https://github.com/org/repo/pull/1",
+        state="open",
+        body="",
+        head_branch="cog/42-fix",
+    )
+    host.update_pr.return_value = None
+    return host
+
+
+def _make_wf_with_tracker_host(tracker=None, host=None, *, restart: bool = False) -> RalphWorkflow:
+    from tests.fakes import EchoRunner
+
+    return RalphWorkflow(
+        runner=EchoRunner(),
+        tracker=tracker or _make_tracker(),
+        host=host or _make_host(),
+        restart=restart,
+    )
+
+
+# ---------------------------------------------------------------------------
+# pre_stages branch-state logic
+# ---------------------------------------------------------------------------
+
+
+async def test_pre_stages_creates_branch_when_none_exists() -> None:
+    item = make_item(item_id="42", title="Fix the bug")
+    ctx = _make_ctx(item)
+    wf = _make_workflow()
+    create_mock = AsyncMock()
+
+    with (
+        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
+        patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
+        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
+        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=False)),
+        patch("cog.workflows.ralph.git.create_branch", create_mock),
+    ):
+        await wf.pre_stages(ctx)
+
+    create_mock.assert_awaited_once_with(
+        Path("/fake/project"), "cog/42-fix-the-bug", start_point="HEAD"
+    )
+    assert ctx.work_branch == "cog/42-fix-the-bug"
+
+
+async def test_pre_stages_silently_deletes_stale_empty_branch_and_recreates() -> None:
+    item = make_item(item_id="42", title="Fix the bug")
+    ctx = _make_ctx(item)
+    wf = _make_workflow()
+    delete_mock = AsyncMock()
+    create_mock = AsyncMock()
+
+    with (
+        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
+        patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
+        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
+        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=True)),
+        patch("cog.workflows.ralph.git.commits_between", AsyncMock(return_value=0)),
+        patch("cog.workflows.ralph.git.delete_branch", delete_mock),
+        patch("cog.workflows.ralph.git.create_branch", create_mock),
+    ):
+        await wf.pre_stages(ctx)
+
+    delete_mock.assert_awaited_once()
+    create_mock.assert_awaited_once()
+
+
+async def test_pre_stages_resumes_existing_branch_with_commits() -> None:
+    item = make_item(item_id="42", title="Fix the bug")
+    ctx = _make_ctx(item)
+    wf = _make_workflow()
+    checkout_calls: list[str] = []
+
+    async def _checkout(project_dir, branch):
+        checkout_calls.append(branch)
+
+    with (
+        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
+        patch("cog.workflows.ralph.git.checkout_branch", _checkout),
+        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
+        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=True)),
+        patch("cog.workflows.ralph.git.commits_between", AsyncMock(return_value=3)),
+        patch("cog.workflows.ralph.git.create_branch", AsyncMock()) as create_mock,
+        patch("cog.workflows.ralph.git.delete_branch", AsyncMock()) as delete_mock,
+    ):
+        await wf.pre_stages(ctx)
+
+    # Should have checked out work branch (not created or deleted)
+    assert "cog/42-fix-the-bug" in checkout_calls
+    create_mock.assert_not_awaited()
+    delete_mock.assert_not_awaited()
+
+
+async def test_pre_stages_sets_resumed_flag_on_resume() -> None:
+    item = make_item(item_id="42", title="Fix the bug")
+    ctx = _make_ctx(item)
+    wf = _make_workflow()
+
+    with (
+        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
+        patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
+        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
+        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=True)),
+        patch("cog.workflows.ralph.git.commits_between", AsyncMock(return_value=2)),
+        patch("cog.workflows.ralph.git.create_branch", AsyncMock()),
+        patch("cog.workflows.ralph.git.delete_branch", AsyncMock()),
+    ):
+        await wf.pre_stages(ctx)
+
+    assert wf._resumed_this_iteration.get("42") is True
+
+
+async def test_pre_stages_clears_resumed_flag_on_fresh_create() -> None:
+    item = make_item(item_id="42", title="Fix the bug")
+    ctx = _make_ctx(item)
+    wf = _make_workflow()
+
+    with (
+        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
+        patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
+        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
+        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=False)),
+        patch("cog.workflows.ralph.git.create_branch", AsyncMock()),
+    ):
+        await wf.pre_stages(ctx)
+
+    assert wf._resumed_this_iteration.get("42") is False
+
+
+async def test_pre_stages_honors_restart_flag_deletes_and_recreates() -> None:
+    item = make_item(item_id="42", title="Fix the bug")
+    ctx = _make_ctx(item)
+    wf = _make_workflow(restart=True)
+    delete_mock = AsyncMock()
+    create_mock = AsyncMock()
+
+    with (
+        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
+        patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
+        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
+        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=True)),
+        patch("cog.workflows.ralph.git.commits_between", AsyncMock(return_value=5)),
+        patch("cog.workflows.ralph.git.delete_branch", delete_mock),
+        patch("cog.workflows.ralph.git.create_branch", create_mock),
+    ):
+        await wf.pre_stages(ctx)
+
+    delete_mock.assert_awaited_once()
+    create_mock.assert_awaited_once()
+
+
+async def test_pre_stages_restart_flag_forces_delete_even_on_empty_branch_noop() -> None:
+    # --restart on a 0-commits branch still deletes + recreates (same as default, just explicit)
+    item = make_item(item_id="42", title="Fix the bug")
+    ctx = _make_ctx(item)
+    wf = _make_workflow(restart=True)
+    delete_mock = AsyncMock()
+    create_mock = AsyncMock()
+
+    with (
+        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
+        patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
+        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
+        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=True)),
+        patch("cog.workflows.ralph.git.commits_between", AsyncMock(return_value=0)),
+        patch("cog.workflows.ralph.git.delete_branch", delete_mock),
+        patch("cog.workflows.ralph.git.create_branch", create_mock),
+    ):
+        await wf.pre_stages(ctx)
+
+    delete_mock.assert_awaited_once()
+    create_mock.assert_awaited_once()
+
+
+async def test_pre_stages_with_restart_does_not_set_resumed_flag() -> None:
+    item = make_item(item_id="42", title="Fix the bug")
+    ctx = _make_ctx(item)
+    wf = _make_workflow(restart=True)
+
+    with (
+        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
+        patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
+        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
+        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=True)),
+        patch("cog.workflows.ralph.git.commits_between", AsyncMock(return_value=3)),
+        patch("cog.workflows.ralph.git.delete_branch", AsyncMock()),
+        patch("cog.workflows.ralph.git.create_branch", AsyncMock()),
+    ):
+        await wf.pre_stages(ctx)
+
+    assert wf._resumed_this_iteration.get("42") is False
+
+
+# ---------------------------------------------------------------------------
+# Label lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _writable_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+
+
+def _make_ctx_with_tmp(tmp_path: Path, *, item_id: str = "42") -> ExecutionContext:
+    return ExecutionContext(
+        project_dir=tmp_path,
+        tmp_dir=tmp_path,
+        state_cache=InMemoryStateCache(),
+        headless=True,
+        item=make_item(item_id=item_id, title="Fix the bug"),
+        work_branch="cog/42-fix-the-bug",
+    )
+
+
+async def test_finalize_error_keeps_agent_ready_and_adds_agent_failed(tmp_path: Path) -> None:
+    tracker = _make_tracker()
+    wf = _make_wf_with_tracker_host(tracker=tracker)
+    ctx = _make_ctx_with_tmp(tmp_path)
+    await wf.finalize_error(ctx, RuntimeError("boom"), [])
+
+    remove_calls = [c.args[1] for c in tracker.remove_label.call_args_list]
+    assert "agent-ready" not in remove_calls
+    tracker.add_label.assert_awaited()
+    add_calls = [c.args[1] for c in tracker.add_label.call_args_list]
+    assert "agent-failed" in add_calls
+
+
+async def test_handle_push_failed_keeps_agent_ready_and_adds_agent_failed(tmp_path: Path) -> None:
+    tracker = _make_tracker()
+    host = _make_host()
+    host.push_branch.side_effect = HostError("push failed")
+    wf = _make_wf_with_tracker_host(tracker=tracker, host=host)
+    ctx = _make_ctx_with_tmp(tmp_path)
+    await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
+
+    remove_calls = [c.args[1] for c in tracker.remove_label.call_args_list]
+    assert "agent-ready" not in remove_calls
+    add_calls = [c.args[1] for c in tracker.add_label.call_args_list]
+    assert "agent-failed" in add_calls
+
+
+async def test_finalize_success_removes_agent_failed_label(tmp_path: Path) -> None:
+    tracker = _make_tracker()
+    wf = _make_wf_with_tracker_host(tracker=tracker)
+    ctx = _make_ctx_with_tmp(tmp_path)
+    await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
+
+    remove_calls = [c.args[1] for c in tracker.remove_label.call_args_list]
+    assert "agent-failed" in remove_calls
+
+
+async def test_finalize_noop_removes_agent_failed_label(tmp_path: Path) -> None:
+    tracker = _make_tracker()
+    wf = _make_wf_with_tracker_host(tracker=tracker)
+    ctx = _make_ctx_with_tmp(tmp_path)
+    await wf.finalize_noop(ctx, [make_stage_result("build")])
+
+    remove_calls = [c.args[1] for c in tracker.remove_label.call_args_list]
+    assert "agent-failed" in remove_calls
+
+
+async def test_finalize_error_tolerates_missing_agent_failed_label_on_first_error(
+    tmp_path: Path,
+) -> None:
+    tracker = _make_tracker()
+    tracker.remove_label.side_effect = TrackerError("label not found")
+    wf = _make_wf_with_tracker_host(tracker=tracker)
+    ctx = _make_ctx_with_tmp(tmp_path)
+    # finalize_error doesn't remove agent-failed, so TrackerError from remove_label
+    # only fires in finalize_success/noop. Simulate it there:
+    tracker.remove_label.side_effect = None  # reset
+    tracker.add_label.side_effect = None
+    # Should not raise even if ensure_label or add_label has issues
+    await wf.finalize_error(ctx, RuntimeError("err"), [])
+
+
+async def test_finalize_success_tolerates_missing_agent_failed_label(tmp_path: Path) -> None:
+    """remove_label('agent-failed') wrapped in try/except TrackerError."""
+    tracker = _make_tracker()
+
+    def _remove_side_effect(item, label):
+        if label == "agent-failed":
+            raise TrackerError("label not present")
+
+    tracker.remove_label.side_effect = _remove_side_effect
+    wf = _make_wf_with_tracker_host(tracker=tracker)
+    ctx = _make_ctx_with_tmp(tmp_path)
+    # Should not raise
+    await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
+
+
+async def test_finalize_noop_tolerates_missing_agent_failed_label(tmp_path: Path) -> None:
+    tracker = _make_tracker()
+
+    def _remove_side_effect(item, label):
+        if label == "agent-failed":
+            raise TrackerError("label not present")
+
+    tracker.remove_label.side_effect = _remove_side_effect
+    wf = _make_wf_with_tracker_host(tracker=tracker)
+    ctx = _make_ctx_with_tmp(tmp_path)
+    await wf.finalize_noop(ctx, [make_stage_result("build")])
+
+
+# ---------------------------------------------------------------------------
+# Telemetry passthrough
+# ---------------------------------------------------------------------------
+
+
+def _make_tel() -> AsyncMock:
+    tel = AsyncMock()
+    tel.write.return_value = None
+    return tel
+
+
+async def test_write_telemetry_passes_resumed_true_when_branch_was_resumed(
+    tmp_path: Path,
+) -> None:
+    tel = _make_tel()
+    wf = _make_wf_with_tracker_host()
+    ctx = _make_ctx_with_tmp(tmp_path)
+    ctx.telemetry = tel
+    wf._resumed_this_iteration["42"] = True
+    await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
+    record = tel.write.call_args.args[0]
+    assert record.resumed is True
+
+
+async def test_write_telemetry_passes_resumed_false_when_branch_was_fresh(
+    tmp_path: Path,
+) -> None:
+    tel = _make_tel()
+    wf = _make_wf_with_tracker_host()
+    ctx = _make_ctx_with_tmp(tmp_path)
+    ctx.telemetry = tel
+    wf._resumed_this_iteration["42"] = False
+    await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
+    record = tel.write.call_args.args[0]
+    assert record.resumed is False
+
+
+async def test_write_telemetry_passes_resumed_true_on_error_when_resumed(
+    tmp_path: Path,
+) -> None:
+    tel = _make_tel()
+    wf = _make_wf_with_tracker_host()
+    ctx = _make_ctx_with_tmp(tmp_path)
+    ctx.telemetry = tel
+    wf._resumed_this_iteration["42"] = True
+    await wf.finalize_error(ctx, RuntimeError("err"), [])
+    record = tel.write.call_args.args[0]
+    assert record.resumed is True
+
+
+# ---------------------------------------------------------------------------
+# PR idempotency on resume
+# ---------------------------------------------------------------------------
+
+
+async def test_resume_then_success_updates_existing_pr_via_get_pr_for_branch(
+    tmp_path: Path,
+) -> None:
+    existing_pr = PullRequest(
+        number=7,
+        url="https://github.com/org/repo/pull/7",
+        state="open",
+        body="",
+        head_branch="cog/42-fix-the-bug",
+    )
+    host = _make_host(pr=existing_pr)
+    tracker = _make_tracker()
+    wf = _make_wf_with_tracker_host(tracker=tracker, host=host)
+    wf._resumed_this_iteration["42"] = True
+    ctx = _make_ctx_with_tmp(tmp_path)
+    await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
+
+    host.create_pr.assert_not_awaited()
+    host.update_pr.assert_awaited_once_with(7, body=host.update_pr.call_args.kwargs["body"])


### PR DESCRIPTION
## Summary

Completes #51's autonomous-recovery path. Ralph iterations that errored, stalled (#48), or push-failed used to leave the work branch on disk and the next `cog ralph` run would fail loud at `pre_stages` with `branch already exists`. This PR adds a resume path, a new `agent-failed` signal label, and a `--restart` override — so loop mode keeps going across failures without manual intervention.

## Key changes

- **Three-state `pre_stages` logic** in `RalphWorkflow`: if the work branch doesn't exist, create it (unchanged); if it exists with 0 commits ahead of default, silently delete + recreate (stale-empty); if it has commits, resume on the existing branch — or delete + recreate under `--restart`. Tracks `_resumed_this_iteration` per item so telemetry reflects the branch state.
- **`agent-failed` additive label lifecycle**: applied by `finalize_error` and `_handle_push_failed` (both now keep `agent-ready` so resume picks the item up automatically), cleared by `finalize_success` and `finalize_noop`. Behavior change from #14: push-fail no longer strips `agent-ready` — the human handoff is replaced by autonomous retry through the resume path.
- **`resumed: bool` telemetry field**: orthogonal to `outcome` so a run's outcome and its fresh-vs-resumed status are independent. Backwards-compatible default `False` — old JSONL entries parse cleanly.
- **`--restart` CLI flag**: opt-in override to nuke and recreate the branch instead of resuming. Threads through `cli.py` → `build_and_run` → `RalphWorkflow(restart=True)`. No `--resume` flag; resume is the default.
- **Two new git helpers** in `src/cog/git.py`: `branch_exists(project_dir, name)` via `git rev-parse --verify`, and `delete_branch(project_dir, name)` via `git branch -D`. Used by the three-state `pre_stages` branch.

## Closes

Closes #51

## Test plan

- [ ] With a prior iteration on `cog/<N>-*` that errored mid-build (local commits exist), run `cog ralph --item <N>`; verify it resumes on the existing branch, runs stages, and `resumed=true` appears in the corresponding `runs.jsonl` entry.
- [ ] Same setup, but run `cog ralph --item <N> --restart`; verify the branch is deleted and recreated fresh, and `resumed=false` in telemetry.
- [ ] Create a local branch `cog/<N>-<slug>` with zero commits ahead of main (`git branch cog/<N>-<slug> main`); run `cog ralph --item <N>`; verify the stale-empty branch is silently deleted + recreated, iteration runs normally.
- [ ] Trigger a push failure (e.g., lose network mid-push); verify the comment lands on the item, `agent-ready` stays, `agent-failed` is applied, and re-running `cog ralph` picks the same item up and re-attempts the push via resume.
- [ ] After a successful iteration on a previously-failed item, verify `agent-failed` is removed from the item's labels.
- [ ] After a no-op iteration on a previously-failed item, verify `agent-failed` is also removed (so we never end up with both `agent-abandoned` and `agent-failed`).
- [ ] Inspect a resumed iteration's telemetry: existing PR updated via `get_pr_for_branch` rather than duplicated.

---
🤖 Generated manually after a ralph iteration committed but did not write telemetry; PR body rewritten from the actual diff against the refined #51 spec.