### PR TITLE
ClaudeCliRunner: drain stderr concurrently to prevent pipe-fill deadlock

### DIFF
--- a/src/cog/runners/claude_cli.py
+++ b/src/cog/runners/claude_cli.py
@@ -91,6 +91,13 @@ class ClaudeCliRunner(AgentRunner):
 
         proc = await asyncio.create_subprocess_exec(*argv, env=env, stdout=PIPE, stderr=PIPE)
         assert proc.stdout is not None  # guaranteed by stdout=PIPE
+        # Drain stderr concurrently so the pipe buffer (~64KB on Linux) can't fill and
+        # block claude's stderr writes — which would cascade into stdout stalling and
+        # trip RunnerStalledError (#48). Real stderr content is discarded in this
+        # minimal drain; #44 layers on capture-for-diagnostics.
+        stderr_drain: asyncio.Task[bytes] | None = (
+            asyncio.create_task(proc.stderr.read()) if proc.stderr is not None else None
+        )
         start = time.monotonic()
 
         final_text = ""
@@ -166,6 +173,13 @@ class ClaudeCliRunner(AgentRunner):
         finally:
             if not _waited:
                 await proc.wait()
+            if stderr_drain is not None and not stderr_drain.done():
+                stderr_drain.cancel()
+            if stderr_drain is not None:
+                try:
+                    await stderr_drain
+                except (asyncio.CancelledError, Exception):
+                    pass
 
         duration = time.monotonic() - start
         cost = float(result_record.get("total_cost_usd", 0.0)) if result_record else 0.0

--- a/tests/test_runners/helpers.py
+++ b/tests/test_runners/helpers.py
@@ -14,6 +14,7 @@ class FakeProcess:
 
     def __init__(self, stdout: Any, returncode: int = 0) -> None:
         self.stdout = stdout
+        self.stderr = None  # ClaudeCliRunner guards against None stderr for mocks.
         self.returncode = returncode
         self.terminated = False
         self.killed = False

--- a/tests/test_runners/test_claude_cli_stderr_drain.py
+++ b/tests/test_runners/test_claude_cli_stderr_drain.py
@@ -1,0 +1,94 @@
+"""Regression tests for the concurrent stderr drain in ClaudeCliRunner.
+
+Without a drain, a subprocess that writes more than ~64KB to stderr fills
+the OS pipe buffer, blocks on the next write, and stalls stdout — which
+manifests as RunnerStalledError (#48). These tests use a real subprocess
+(python3 -c) because the pipe-fill dynamics can't be simulated with mocks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from cog.core.runner import ResultEvent, RunEvent
+from cog.runners.claude_cli import ClaudeCliRunner
+from tests.test_runners.helpers import RecordingSandbox
+
+
+class _RealSubprocessSandbox(RecordingSandbox):
+    """Sandbox that replaces `claude ...` with a python one-liner inline so we
+    hit asyncio's real subprocess machinery."""
+
+    def __init__(self, python_snippet: str) -> None:
+        super().__init__()
+        self._snippet = python_snippet
+
+    def wrap_argv(self, argv):  # type: ignore[override]
+        # Ignore the simulated claude argv entirely; invoke python3 -c <snippet>.
+        return ["python3", "-c", self._snippet]
+
+
+async def _collect(stream) -> list[RunEvent]:
+    return [event async for event in stream]
+
+
+@pytest.mark.asyncio
+async def test_runner_does_not_hang_on_large_stderr_output():
+    # Script that writes 200KB to stderr (well above typical 64KB pipe
+    # buffer), then a minimal valid stream-json result line, then exits.
+    # Without stderr drain, the stderr write blocks at ~64KB and the runner
+    # trips its 120s inactivity timeout instead of completing promptly.
+    snippet = (
+        "import sys, json\n"
+        "sys.stderr.write('x' * 200_000)\n"
+        "sys.stderr.flush()\n"
+        "print(json.dumps({'type': 'result', 'total_cost_usd': 0.0, 'exit_status': 0}))\n"
+        "sys.stdout.flush()\n"
+    )
+    sandbox = _RealSubprocessSandbox(snippet)
+    runner = ClaudeCliRunner(sandbox)
+
+    # Bound the test: if the drain regresses and the process blocks, this
+    # wait_for fires long before the runner's own 120s inactivity timer.
+    events = await asyncio.wait_for(_collect(runner.stream("ignored", model="m")), timeout=10.0)
+
+    assert any(isinstance(e, ResultEvent) for e in events)
+
+
+@pytest.mark.asyncio
+async def test_runner_completes_normally_when_stderr_is_small():
+    # Baseline: small stderr, normal flow. Guards against regressions where
+    # the drain accidentally blocks completion (e.g., infinite await).
+    snippet = (
+        "import sys, json\n"
+        "sys.stderr.write('small stderr')\n"
+        "sys.stderr.flush()\n"
+        "print(json.dumps({'type': 'result', 'total_cost_usd': 0.01, 'exit_status': 0}))\n"
+        "sys.stdout.flush()\n"
+    )
+    sandbox = _RealSubprocessSandbox(snippet)
+    runner = ClaudeCliRunner(sandbox)
+
+    events = await asyncio.wait_for(_collect(runner.stream("ignored", model="m")), timeout=10.0)
+
+    results = [e for e in events if isinstance(e, ResultEvent)]
+    assert len(results) == 1
+    assert results[0].result.total_cost_usd == 0.01
+
+
+@pytest.mark.asyncio
+async def test_drain_tolerates_fake_proc_without_stderr():
+    # Regression guard for the `proc.stderr is not None` check: the existing
+    # FakeProcess helpers leave stderr=None, and the drain must not AttributeError.
+    from tests.test_runners.helpers import fixture_proc, patch_exec
+
+    proc = fixture_proc("happy.jsonl")
+    sandbox = RecordingSandbox()
+    runner = ClaudeCliRunner(sandbox)
+
+    with patch_exec(proc):
+        events = await _collect(runner.stream("ignored", model="m"))
+
+    assert any(isinstance(e, ResultEvent) for e in events)


### PR DESCRIPTION
## Summary

Cog's `ClaudeCliRunner` spawns claude with `stderr=PIPE` but never reads `proc.stderr`. When claude writes more than ~64KB to stderr (typical Linux pipe buffer), the next stderr write blocks — which cascades into stdout stalling and trips `RunnerStalledError` after 120s of no activity (#48's safety net). Observed pattern: `Read: /work/tests/fakes.py` mid-build, then silence until the stall timer fires.

Bash ralph avoids this by redirecting stderr to a file. Interactive Claude Code avoids it via terminal-backed stderr (large effective buffering). Cog is the only consumer that uses a pipe-with-no-reader, which is why the hangs appear only in cog.

The minimal fix: spawn `asyncio.create_task(proc.stderr.read())` alongside the stdout streaming loop. Captured content is discarded in this PR — #44 layers on capture-for-diagnostics on top of this.

## Key changes

- `ClaudeCliRunner.stream`: spawn a concurrent `stderr_drain` task after the subprocess is created; cancel + await in the `finally` block so it can't leak. Guarded by `proc.stderr is not None` so existing mocks stay valid.
- `tests/test_runners/helpers.py::FakeProcess`: adds `stderr = None` attribute to match the new guard.
- `tests/test_runners/test_claude_cli_stderr_drain.py` (new): regression tests using real subprocesses — 200KB to stderr + minimal stream-json result; completes under 10s instead of the 120s stall. Also covers the baseline small-stderr case and the FakeProcess mock compatibility.

## Closes

Addresses the hang class; does NOT close #44 (richer diagnostics + `RunnerAbortedError` + `stderr_tail` on `RunResult`), which can still ship on top.

## Test plan

- [ ] Run `cog ralph --headless --loop` against a project where claude historically stalls on a Read (e.g., the one where #80's stall was observed). Iteration completes without tripping `RunnerStalledError`.
- [ ] Observe telemetry for a normal-length iteration — no new entries for `RunnerStalledError` originating in pipe-fill scenarios.
- [ ] If a real hang occurs, verify `runs.jsonl` still shows `RunnerStalledError` with a meaningful `last_event_summary` — the 120s safety net still fires for genuinely-hung claude processes (it's just no longer triggered by stderr-pipe pressure).

---
🤖 Hand-authored. See #44 for the layered diagnostics work that builds on this minimal drain.