### PR TITLE
Drop clean_tree + default_branch from workflow preflight (low-friction startup)

### DIFF
--- a/src/cog/checks.py
+++ b/src/cog/checks.py
@@ -335,8 +335,14 @@ ALL_CHECKS: tuple[PreflightCheck, ...] = (
     CheckClaudeAuth(),
 )
 
-# Reusable subsets — workflow issues (#12, #18) will use these
-RALPH_CHECKS: tuple[PreflightCheck, ...] = ALL_CHECKS
-REFINE_CHECKS: tuple[PreflightCheck, ...] = tuple(
+# Workflow preflight — excludes git-state checks (clean_tree, default_branch).
+# Those are redundant at startup: RalphWorkflow.pre_stages does
+# `checkout default → fetch → merge-ff → create work branch` and git itself
+# will fail cleanly if the tree isn't checkout-able at that moment. Preempting
+# before the user has even picked an item is friction without coverage.
+# `cog doctor` still surfaces git-state via ALL_CHECKS for diagnostic use.
+_WORKFLOW_CHECKS: tuple[PreflightCheck, ...] = tuple(
     c for c in ALL_CHECKS if c.name not in ("clean_tree", "default_branch")
 )
+RALPH_CHECKS: tuple[PreflightCheck, ...] = _WORKFLOW_CHECKS
+REFINE_CHECKS: tuple[PreflightCheck, ...] = _WORKFLOW_CHECKS

--- a/tests/test_workflows/test_ralph_lifecycle.py
+++ b/tests/test_workflows/test_ralph_lifecycle.py
@@ -49,6 +49,25 @@ def test_class_attributes():
     assert RalphWorkflow.preflight_checks is RALPH_CHECKS
 
 
+def test_ralph_checks_exclude_git_state_so_startup_is_low_friction():
+    # Intent pin: pre_stages does checkout+fetch+merge-ff+create-branch and
+    # git will fail cleanly if the tree isn't checkout-able at that point.
+    # Preempting clean_tree / default_branch at startup is redundant and
+    # adds friction — particularly when resuming an existing cog/N-* branch
+    # where the user is by definition NOT on default.
+    names = {c.name for c in RALPH_CHECKS}
+    assert "clean_tree" not in names
+    assert "default_branch" not in names
+
+
+def test_refine_checks_exclude_git_state_same_as_ralph():
+    from cog.checks import REFINE_CHECKS
+
+    names = {c.name for c in REFINE_CHECKS}
+    assert "clean_tree" not in names
+    assert "default_branch" not in names
+
+
 def test_content_widget_cls_is_log_pane_widget():
     from cog.ui.widgets.log_pane import LogPaneWidget
 


### PR DESCRIPTION
## Summary

Both ralph and refine previously ran `CheckCleanTree` and `CheckDefaultBranch` as error-level preflights at startup. For refine this is irrelevant (no git ops). For ralph it's redundant (pre_stages does `checkout default → fetch → merge-ff → create work branch`; git fails cleanly if the tree isn't checkout-able). And for #51's resume path, the user is by definition NOT on default when resuming an existing `cog/N-*` branch — forcing them back before even selecting an item is friction.

`cog doctor` keeps running `ALL_CHECKS` so the diagnostic set is unchanged; nothing about `cog doctor`'s behavior shifts.

## Key changes

- `src/cog/checks.py`: factor `_WORKFLOW_CHECKS = ALL_CHECKS - (clean_tree, default_branch)`; both `RALPH_CHECKS` and `REFINE_CHECKS` now point at it. (`REFINE_CHECKS` was already excluding these two; ralph just catches up.)
- `tests/test_workflows/test_ralph_lifecycle.py`: regression tests pinning the intent that neither bundle includes the git-state checks.

## Closes

No issue — direct response to user feedback during dogfooding. Follows on from #51 (resume path makes startup git-state checks actively harmful).

## Test plan

- [ ] Run `cog ralph` while on a non-default branch with uncommitted changes → preflight modal no longer blocks; ralph proceeds to picker. Assuming the target branch is either new (pre_stages creates it) or existing (#51 resume path), the iteration runs.
- [ ] Run `cog ralph` while on main with a dirty tree → pre_stages' `git checkout default` succeeds if the dirty changes don't conflict, or fails with a raw git error message (acceptable — fails at the point of actual conflict, not preemptively).
- [ ] Run `cog doctor` → still shows all original checks including clean_tree and default_branch; diagnostic surface unchanged.

---
🤖 Hand-authored in response to user feedback; not a ralph iteration.