### PR TITLE
Ralph build prompt: tighten Key changes (conceptual) and Test plan (consumer-perspective + no CI items) (#82)

### DIFF
--- a/src/cog/prompts/claude/ralph/build.md
+++ b/src/cog/prompts/claude/ralph/build.md
@@ -88,28 +88,53 @@ preserved.
 
 ### Key changes
 
-Bullet list of the files you touched, with a brief note per file. Not
-a changelog of every line edit — highlight the interesting ones. Note
-files that are new (`(new)`) or that got structural changes.
+3-7 bullets summarizing the *conceptual* changes a reviewer should notice —
+new abstractions, architectural shifts, behavioral changes, structural
+moves. NOT a file-by-file changelog; mention a file only when the change
+hinges on the specific file (e.g., a new module, or a structural rework).
+
+A single conceptual change may touch 5 files; list it as one bullet.
+Minor edits (docstring tweaks, test name fixes, import reshuffles) don't
+belong here — they're visible in the diff.
 
 Example:
 ```
 ### Key changes
 
-- `src/cog/loop.py` (new): `LoopState` + `fresh_iteration_context` primitives
-- `src/cog/headless.py`: `run_headless` now loops until queue drained
-- `src/cog/ui/screens/run.py`: `_run_loop` replaces `_run_once`
-- `src/cog/cli.py`: new `--max-iterations` flag; implies `--loop`
+- New `LoopState` + `fresh_iteration_context` primitives in `cog/loop.py`;
+  shared across headless and Textual call sites
+- `run_headless` and `RunScreen._run_loop` both iterate through the same
+  primitives until the queue drains, the cap is hit, or a stage errors
+- CLI gains `--max-iterations N`, which implies `--loop`
 ```
 
 ### Test plan
 
-Manual verification steps for a reviewer. Be thorough: list every
-meaningful thing to check, not just the happy path. Include edge cases,
-error states, responsive/layout checks if UI, accessibility concerns,
-and anything else that matters for this specific change. Don't pad
-with generic items like "review the diff"; every item should be
-concrete and specific to what you changed.
+Manual verification steps written from the perspective of someone using
+what you built. Match the shape of the test plan to the change type:
+
+- **UI / app code** → exercise the user-facing flow (navigate, click,
+  observe states).
+- **CLI / tooling** → run the commands, inspect outputs, try error paths.
+- **Data migration / script** → run it, then use database queries or
+  file inspection to confirm the data changed correctly.
+- **API / library** → call the public surface, observe returns and
+  side effects.
+- **Config / infrastructure** → exercise the configured system, not the
+  config file itself.
+
+List every meaningful behavior to check for THIS change — edge cases,
+error states, UX concerns. Don't pad with generic items like "review
+the diff."
+
+**Do not include tool-execution items that CI runs automatically**:
+- Test runners (e.g. `pytest`, `jest`, `go test`, `cargo test`)
+- Type checkers (e.g. `mypy`, `tsc`, `flow`)
+- Linters / formatters (e.g. `ruff`, `eslint`, `prettier`)
+- Package / build steps (e.g. `python -m build`, `npm run build`)
+
+These run on every PR; listing them adds noise. The project's CLAUDE.md
+is the authority on which commands are CI-gated.
 
 Example format:
 ```

--- a/tests/test_workflows/test_ralph_prompts.py
+++ b/tests/test_workflows/test_ralph_prompts.py
@@ -139,3 +139,76 @@ def test_build_prompt_keeps_test_plan_instruction():
 def test_build_prompt_final_message_format_mentions_wrapper_extraction():
     content = _load_prompt("build")
     assert "wrapper extracts" in content
+
+
+def _key_changes_section(content: str) -> str:
+    match = re.search(
+        r"### Key changes\n(.*?)(?=\n### Test plan\b)", content, re.DOTALL
+    )
+    assert match, "### Key changes section not found in build.md"
+    return match.group(1)
+
+
+def _test_plan_section(content: str) -> str:
+    match = re.search(
+        r"### Test plan\n(.*?)(?=\n## |\Z)", content, re.DOTALL
+    )
+    assert match, "### Test plan section not found in build.md"
+    return match.group(1)
+
+
+def test_build_prompt_key_changes_has_bullet_cap_guidance():
+    content = _load_prompt("build")
+    assert "3-7 bullets" in _key_changes_section(content)
+
+
+def test_build_prompt_key_changes_mentions_conceptual_not_file_by_file():
+    content = _load_prompt("build")
+    key_changes = _key_changes_section(content)
+    assert "conceptual" in key_changes
+    assert "files you touched" not in content
+
+
+def test_build_prompt_key_changes_example_has_three_to_seven_bullets():
+    content = _load_prompt("build")
+    key_changes = _key_changes_section(content)
+    example_match = re.search(r"```\n### Key changes\n(.*?)```", key_changes, re.DOTALL)
+    assert example_match, "No example block found in Key changes section"
+    bullets = re.findall(r"^- ", example_match.group(1), re.MULTILINE)
+    assert 3 <= len(bullets) <= 7, f"Example has {len(bullets)} bullets, expected 3-7"
+
+
+def test_build_prompt_test_plan_has_perspective_framing():
+    content = _load_prompt("build")
+    assert "from the perspective" in _test_plan_section(content)
+
+
+def test_build_prompt_test_plan_lists_change_type_categories():
+    content = _load_prompt("build")
+    test_plan = _test_plan_section(content)
+    for category in (
+        "UI / app code",
+        "CLI / tooling",
+        "Data migration / script",
+        "API / library",
+        "Config / infrastructure",
+    ):
+        assert category in test_plan, f"Missing category: {category}"
+
+
+def test_build_prompt_test_plan_excludes_ci_items_block():
+    content = _load_prompt("build")
+    assert "Do not include tool-execution items that CI runs automatically" in _test_plan_section(content)
+
+
+def test_build_prompt_test_plan_ci_exclusion_is_multi_ecosystem():
+    content = _load_prompt("build")
+    test_plan = _test_plan_section(content)
+    for tool in ("pytest", "jest", "tsc", "eslint"):
+        assert tool in test_plan, f"Missing multi-ecosystem CI tool example: {tool}"
+
+
+def test_build_prompt_test_plan_defers_to_claude_md():
+    content = _load_prompt("build")
+    test_plan = _test_plan_section(content)
+    assert "CLAUDE.md" in test_plan

--- a/tests/test_workflows/test_ralph_prompts.py
+++ b/tests/test_workflows/test_ralph_prompts.py
@@ -142,17 +142,13 @@ def test_build_prompt_final_message_format_mentions_wrapper_extraction():
 
 
 def _key_changes_section(content: str) -> str:
-    match = re.search(
-        r"### Key changes\n(.*?)(?=\n### Test plan\b)", content, re.DOTALL
-    )
+    match = re.search(r"### Key changes\n(.*?)(?=\n### Test plan\b)", content, re.DOTALL)
     assert match, "### Key changes section not found in build.md"
     return match.group(1)
 
 
 def _test_plan_section(content: str) -> str:
-    match = re.search(
-        r"### Test plan\n(.*?)(?=\n## |\Z)", content, re.DOTALL
-    )
+    match = re.search(r"### Test plan\n(.*?)(?=\n## |\Z)", content, re.DOTALL)
     assert match, "### Test plan section not found in build.md"
     return match.group(1)
 
@@ -198,7 +194,8 @@ def test_build_prompt_test_plan_lists_change_type_categories():
 
 def test_build_prompt_test_plan_excludes_ci_items_block():
     content = _load_prompt("build")
-    assert "Do not include tool-execution items that CI runs automatically" in _test_plan_section(content)
+    test_plan = _test_plan_section(content)
+    assert "Do not include tool-execution items that CI runs automatically" in test_plan
 
 
 def test_build_prompt_test_plan_ci_exclusion_is_multi_ecosystem():


### PR DESCRIPTION
## Summary

Rewrites the `### Key changes` and `### Test plan` subsections of `src/cog/prompts/claude/ralph/build.md` to reduce noise in generated PR bodies. Key changes now demands 3-7 conceptual bullets (not a file-by-file enumeration), and Test plan now leads with consumer-perspective framing, shape-matched categories per change type, and an explicit CI-exclusion block that covers multiple ecosystems.

## Key changes

- `src/cog/prompts/claude/ralph/build.md`: `### Key changes` rewritten with 3-7 bullet cap, conceptual framing, and updated example; `### Test plan` rewritten with perspective-first framing, five change-type categories, and a category-based CI-exclusion block that defers to CLAUDE.md as authority
- `tests/test_workflows/test_ralph_prompts.py`: 8 new regression tests pinning the new guidance language; two private helpers (`_key_changes_section`, `_test_plan_section`) extract the relevant markdown sections for assertion

## Closes

Closes #82

## Test plan

- [ ] Read `build.md` end to end — verify the three final-message subsections (`Summary`, `Key changes`, `Test plan`) read coherently together
- [ ] Confirm `### Key changes` no longer says "files you touched" and now says "conceptual" and "3-7 bullets"
- [ ] Confirm `### Test plan` mentions "from the perspective", lists all five change-type categories, includes the CI-exclusion block with multi-ecosystem examples, and references CLAUDE.md
- [ ] On the next ralph run: observe that Key changes has ≤7 bullets describing concepts, not files; Test plan has no `pytest`/`mypy`/`ruff` lines

---
🤖 Generated by cog. Iteration cost: $1.020
