### PR TITLE
Docker sandbox image: bump Python to 3.12 via python:3.12-slim-bookworm base + versioned LABEL cache-bust (#85)

### DIFF
--- a/src/cog/resources/Dockerfile
+++ b/src/cog/resources/Dockerfile
@@ -1,6 +1,7 @@
-FROM debian:bookworm-slim
+FROM python:3.12-slim-bookworm
 
 LABEL cog.fat-image="true"
+LABEL cog.image-version="2"
 
 # Core system packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -11,8 +12,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     jq \
     ca-certificates \
     gnupg \
-    python3 \
-    python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
 # Node 20 (LTS) via NodeSource

--- a/src/cog/runners/docker_sandbox.py
+++ b/src/cog/runners/docker_sandbox.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 from cog.core.errors import DockerImageBuildError, DockerUnavailableError, SandboxError
 
+_EXPECTED_IMAGE_VERSION = "2"
+
 
 def _read_bundled_dockerfile() -> bytes:
     resource = importlib.resources.files("cog.resources") / "Dockerfile"
@@ -69,7 +71,9 @@ class DockerSandbox:
             self._image,
             "sh",
             "-c",
-            "claude --version && gh --version && jq --version && uv --version",
+            "claude --version && gh --version && jq --version && uv --version "
+            "&& python3 -c 'import sys; assert sys.version_info >= (3, 12), "
+            'f"Python 3.12+ required, got {sys.version_info}"\'',
         )
         await proc.wait()
         if proc.returncode != 0:
@@ -107,12 +111,16 @@ class DockerSandbox:
             "docker",
             "image",
             "inspect",
+            "--format",
+            '{{ index .Config.Labels "cog.image-version" }}',
             self._image,
-            stdout=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.DEVNULL,
         )
-        await proc.wait()
-        return proc.returncode == 0
+        stdout, _ = await proc.communicate()
+        if proc.returncode != 0:
+            return False
+        return stdout.decode().strip() == _EXPECTED_IMAGE_VERSION
 
     async def _run_build(self, dockerfile: str, ctx: str, *, quiet: bool) -> None:
         if quiet:

--- a/tests/test_sandbox/test_docker_sandbox_unit.py
+++ b/tests/test_sandbox/test_docker_sandbox_unit.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from cog.core.errors import DockerImageBuildError, DockerUnavailableError, SandboxError
-from cog.runners.docker_sandbox import DockerSandbox
+from cog.runners.docker_sandbox import _EXPECTED_IMAGE_VERSION, DockerSandbox
 
 _PATCH_DOCKERFILE = "cog.runners.docker_sandbox._read_bundled_dockerfile"
 _FAKE_DOCKERFILE = lambda: b"FROM scratch\n"  # noqa: E731
@@ -43,9 +43,10 @@ def _exec_mock(*procs: FakeProc) -> AsyncMock:
 
 def _standard_build_procs(*, image_exists: bool, build_rc: int = 0) -> list[FakeProc]:
     """Ordered procs for one full _ensure_image_built call."""
+    inspect_stdout = f"{_EXPECTED_IMAGE_VERSION}\n".encode() if image_exists else b""
     return [
         FakeProc(0),  # docker info
-        FakeProc(0 if image_exists else 1),  # docker image inspect
+        FakeProc(0 if image_exists else 1, inspect_stdout),  # docker image inspect
         FakeProc(build_rc),  # docker build
     ]
 
@@ -146,7 +147,10 @@ async def test_cached_build_uses_quiet_mode(
 
     async def tracking_exec(*args: str, **kwargs: Any) -> FakeProc:
         captured.append(args)
-        return FakeProc(0, b'{"t":"x"}')  # image exists → quiet build
+        # image inspect returns matching version label → image exists → quiet build
+        if len(args) > 2 and args[1] == "image" and args[2] == "inspect":
+            return FakeProc(0, f"{_EXPECTED_IMAGE_VERSION}\n".encode())
+        return FakeProc(0, b'{"t":"x"}')
 
     with (
         _patch_which(),
@@ -501,3 +505,50 @@ async def test_docker_build_fail_raises(tmp_path: Path, monkeypatch: pytest.Monk
         sandbox = DockerSandbox()
         with pytest.raises(DockerImageBuildError):
             await sandbox.prepare()
+
+
+# ---------------------------------------------------------------------------
+# _image_exists label check
+# ---------------------------------------------------------------------------
+
+
+async def test_image_exists_returns_true_when_label_matches_expected_version() -> None:
+    with _patch_exec(FakeProc(0, f"{_EXPECTED_IMAGE_VERSION}\n".encode())):
+        sandbox = DockerSandbox()
+        assert await sandbox._image_exists() is True
+
+
+async def test_image_exists_returns_false_when_label_mismatches() -> None:
+    with _patch_exec(FakeProc(0, b"1\n")):
+        sandbox = DockerSandbox()
+        assert await sandbox._image_exists() is False
+
+
+async def test_image_exists_returns_false_when_label_absent() -> None:
+    with _patch_exec(FakeProc(0, b"\n")):
+        sandbox = DockerSandbox()
+        assert await sandbox._image_exists() is False
+
+
+async def test_image_exists_returns_false_when_tag_not_found() -> None:
+    with _patch_exec(FakeProc(1)):
+        sandbox = DockerSandbox()
+        assert await sandbox._image_exists() is False
+
+
+async def test_smoke_test_includes_python_version_check() -> None:
+    captured: list[tuple[str, ...]] = []
+
+    async def tracking_exec(*args: str, **kwargs: Any) -> FakeProc:
+        captured.append(args)
+        return FakeProc(0)
+
+    with patch(
+        "cog.runners.docker_sandbox.asyncio.create_subprocess_exec",
+        new=AsyncMock(side_effect=tracking_exec),
+    ):
+        sandbox = DockerSandbox()
+        await sandbox.smoke_test()
+
+    shell_cmd = captured[0][-1]
+    assert "sys.version_info >= (3, 12)" in shell_cmd


### PR DESCRIPTION
## Summary

Swaps the sandbox Docker base image from `debian:bookworm-slim` (Python 3.11) to `python:3.12-slim-bookworm`, removing the redundant `python3`/`python3-pip` apt packages. Adds `LABEL cog.image-version="2"` to the Dockerfile and rewrites `_image_exists` to check that label via `docker image inspect --format`, so any user with a pre-fix `cog:latest` (no label or wrong version) automatically triggers a rebuild without manual `docker rmi`. Extends `smoke_test` with a `sys.version_info >= (3, 12)` assertion to catch Dockerfile regressions at integration time.

## Key changes

- `src/cog/resources/Dockerfile`: base changed to `python:3.12-slim-bookworm`, added `LABEL cog.image-version="2"`, removed `python3`/`python3-pip` apt lines
- `src/cog/runners/docker_sandbox.py`: added `_EXPECTED_IMAGE_VERSION = "2"` constant; `_image_exists` now reads the label via `--format` + `communicate()` instead of just checking returncode; `smoke_test` shell command extended with Python version assertion
- `tests/test_sandbox/test_docker_sandbox_unit.py`: updated `_standard_build_procs` to return matching label stdout when `image_exists=True`; fixed `test_cached_build_uses_quiet_mode` to return the right inspect stdout; added 5 new tests covering all `_image_exists` label branches and the smoke test command content

## Closes

Closes #85

## Test plan

- [ ] `uv run pytest tests/test_sandbox/test_docker_sandbox_unit.py -v` — all 24 tests pass
- [ ] `uv run ruff check . && uv run ruff format --check .` — exits 0
- [ ] `uv run mypy src` — exits 0
- [ ] Manual: `docker rmi cog:latest || true && cog ralph --item <agent-ready-item> --headless` — one-time visible build fires, proceeds with Python 3.12 available
- [ ] Manual: existing `cog:latest` with no label → label mismatch → quiet rebuild triggered automatically, no manual `docker rmi` needed
- [ ] Manual: `docker run --rm cog:latest python3 --version` reports `Python 3.12.x`
- [ ] Manual: `docker image inspect --format '{{ index .Config.Labels "cog.image-version" }}' cog:latest` prints `2`
- [ ] Manual (with `COG_INTEGRATION_TESTS=1`): `uv run pytest tests/test_sandbox/test_docker_sandbox_integration.py -v` — all three integration tests pass including extended smoke test

---
🤖 Generated by cog. Iteration cost: $1.458
