### PR TITLE
ChatPane + LogPane output UX: tool previews, wrapping, markdown rendering, turn separation (#88)

### DIFF
--- a/src/cog/ui/widgets/_shared.py
+++ b/src/cog/ui/widgets/_shared.py
@@ -1,0 +1,45 @@
+"""Shared rendering helpers for widgets that consume claude stream events."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from cog.core.runner import ToolUseEvent
+
+_TRUNCATE_CAP = 100
+
+
+def tool_preview(event: ToolUseEvent) -> str:
+    """Short human-readable summary of a ToolUseEvent's input.
+
+    Empty string if no useful preview is extractable.
+    """
+    if event.tool == "TodoWrite":
+        todos = event.input.get("todos")
+        if isinstance(todos, list):
+            return f"({len(todos)} items)"
+        return ""
+
+    raw = (
+        event.input.get("command")
+        or event.input.get("file_path")
+        or event.input.get("pattern")
+        or event.input.get("description")
+        or event.input.get("prompt")
+        or event.input.get("query")
+        or _first_string_value(event.input)
+        or ""
+    )
+    if not raw:
+        return ""
+    if len(raw) <= _TRUNCATE_CAP:
+        return raw
+    return raw[: _TRUNCATE_CAP - 1] + "…"
+
+
+def _first_string_value(d: Mapping[str, Any]) -> str:
+    for v in d.values():
+        if isinstance(v, str) and v:
+            return v
+    return ""

--- a/src/cog/ui/widgets/chat_pane.py
+++ b/src/cog/ui/widgets/chat_pane.py
@@ -2,12 +2,16 @@
 
 import asyncio
 
+from rich.console import Group
+from rich.markdown import Markdown
+from rich.text import Text
 from textual.app import ComposeResult
 from textual.events import Key
 from textual.widget import Widget
 from textual.widgets import RichLog, Static, TextArea
 
 from cog.core.runner import AssistantTextEvent, ResultEvent, RunEvent, ToolUseEvent
+from cog.ui.widgets._shared import tool_preview
 
 
 class ChatPaneWidget(Widget):
@@ -37,7 +41,7 @@ class ChatPaneWidget(Widget):
         self._input_future: asyncio.Future[str | None] | None = None
 
     def compose(self) -> ComposeResult:
-        yield RichLog(id="scrollback", highlight=True, markup=True)
+        yield RichLog(id="scrollback", highlight=True, markup=True, wrap=True)
         yield Static("⏳ Thinking…", id="thinking")
         yield TextArea(id="input-area")
 
@@ -50,9 +54,15 @@ class ChatPaneWidget(Widget):
         self.query_one("#thinking", Static).display = False
         self._ensure_future()
 
-    def _append_assistant_message(self, text: str) -> None:
+    def _append_message(self, renderable: object) -> None:
         log = self.query_one("#scrollback", RichLog)
-        log.write(f"[bold blue]Claude:[/bold blue] {text}")
+        log.write("")
+        log.write(renderable)
+        log.scroll_end(animate=False)
+
+    def _append_tool_line(self, markup: str) -> None:
+        log = self.query_one("#scrollback", RichLog)
+        log.write(markup)
         log.scroll_end(animate=False)
 
     def _show_thinking_indicator(self) -> None:
@@ -75,9 +85,12 @@ class ChatPaneWidget(Widget):
         text = area.text.strip()
         area.clear()
         if text:
-            log = self.query_one("#scrollback", RichLog)
-            log.write(f"[bold green]You:[/bold green] {text}")
-            log.scroll_end(animate=False)
+            self._append_message(
+                Group(
+                    Text.from_markup("[bold green]You:[/bold green]"),
+                    Text(text),
+                )
+            )
         future = self._ensure_future()
         if not future.done():
             future.set_result(text)
@@ -89,12 +102,16 @@ class ChatPaneWidget(Widget):
 
     async def emit(self, event: RunEvent) -> None:
         if isinstance(event, AssistantTextEvent):
-            self._append_assistant_message(event.text)
+            self._append_message(
+                Group(
+                    Text.from_markup("[bold blue]Claude:[/bold blue]"),
+                    Markdown(event.text),
+                )
+            )
         elif isinstance(event, ToolUseEvent):
-            preview = event.input.get("command") or event.input.get("file_path") or ""
-            log = self.query_one("#scrollback", RichLog)
-            log.write(f"[dim]🔧 {event.tool}: {preview}[/dim]")
-            log.scroll_end(animate=False)
+            preview = tool_preview(event)
+            suffix = f": {preview}" if preview else ""
+            self._append_tool_line(f"[dim]🔧 {event.tool}{suffix}[/dim]")
         elif isinstance(event, ResultEvent):
             self._hide_thinking_indicator()
 

--- a/src/cog/ui/widgets/log_pane.py
+++ b/src/cog/ui/widgets/log_pane.py
@@ -1,10 +1,13 @@
 """Append-only scrolling log for autonomous workflow stages."""
 
+from rich.console import RenderableType
+from rich.markdown import Markdown
 from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import RichLog
 
 from cog.core.runner import AssistantTextEvent, ResultEvent, RunEvent, ToolUseEvent
+from cog.ui.widgets._shared import tool_preview
 
 
 class LogPaneWidget(Widget):
@@ -25,14 +28,14 @@ class LogPaneWidget(Widget):
         self._pinned = True  # stick to bottom
 
     def compose(self) -> ComposeResult:
-        yield RichLog(id="log", highlight=True, markup=True, auto_scroll=False)
+        yield RichLog(id="log", highlight=True, markup=True, auto_scroll=False, wrap=True)
 
     def _log(self) -> RichLog:
         return self.query_one("#log", RichLog)
 
-    def _append_line(self, text: str) -> None:
+    def _append_line(self, content: str | RenderableType) -> None:
         log = self._log()
-        log.write(text)
+        log.write(content)
         if self._pinned:
             log.scroll_end(animate=False)
 
@@ -42,10 +45,11 @@ class LogPaneWidget(Widget):
 
     async def emit(self, event: RunEvent) -> None:
         if isinstance(event, AssistantTextEvent):
-            self._append_line(event.text)
+            self._append_line(Markdown(event.text))
         elif isinstance(event, ToolUseEvent):
-            preview = event.input.get("command") or event.input.get("file_path") or ""
-            self._append_line(f"🔧 {event.tool}: {preview}")
+            preview = tool_preview(event)
+            suffix = f": {preview}" if preview else ""
+            self._append_line(f"🔧 {event.tool}{suffix}")
         elif isinstance(event, ResultEvent):
             cost = event.result.total_cost_usd
             self._append_line(f"[dim]─── stage complete: ${cost:.3f} ───[/dim]")

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -9,7 +9,7 @@ from textual.widget import Widget
 
 from cog.core.item import Comment, Item
 from cog.core.outcomes import StageResult
-from cog.core.runner import AgentRunner, ResultEvent, RunEvent, RunResult
+from cog.core.runner import AgentRunner, ResultEvent, RunEvent, RunResult, ToolUseEvent
 from cog.core.stage import Stage
 
 _EPOCH = datetime(2024, 1, 1, tzinfo=UTC)
@@ -216,6 +216,10 @@ class FakeItemPicker:
     async def pick(self, items: Sequence[Item]) -> Item | None:
         self.called_with = list(items)
         return self._return_value
+
+
+def make_tool_event(tool: str, **input_kwargs: object) -> ToolUseEvent:
+    return ToolUseEvent(tool=tool, input=input_kwargs)
 
 
 def make_needs_refinement_items(ids: list[int]) -> list[Item]:

--- a/tests/test_ui/test_chat_pane.py
+++ b/tests/test_ui/test_chat_pane.py
@@ -3,11 +3,13 @@
 import asyncio
 from pathlib import Path
 
+import pytest
 from textual.app import App, ComposeResult
 from textual.widgets import RichLog, Static, TextArea
 
 from cog.core.runner import AssistantTextEvent, ResultEvent, RunResult
 from cog.ui.widgets.chat_pane import ChatPaneWidget
+from tests.fakes import make_tool_event
 
 
 def _log_text(log: RichLog) -> str:
@@ -143,3 +145,170 @@ async def test_chat_pane_thinking_indicator_during_emit() -> None:
         await pilot.pause()
         # _hide_thinking_indicator called → still hidden
         assert thinking.display is False
+
+
+# Tool preview tests via emit path
+
+
+@pytest.mark.parametrize(
+    "tool,kwargs,expected_preview",
+    [
+        ("Bash", {"command": "ls -la"}, "ls -la"),
+        ("Read", {"file_path": "/src/main.py"}, "/src/main.py"),
+        ("Write", {"file_path": "/out/result.txt"}, "/out/result.txt"),
+        ("Edit", {"file_path": "/src/foo.py", "old_string": "x", "new_string": "y"}, "/src/foo.py"),
+        ("Glob", {"pattern": "**/*.py"}, "**/*.py"),
+        ("Grep", {"pattern": "def foo"}, "def foo"),
+        ("Agent", {"description": "explore widgets", "prompt": "search"}, "explore widgets"),
+        ("Agent", {"prompt": "search for things"}, "search for things"),
+        ("Task", {"description": "run tests", "prompt": "execute"}, "run tests"),
+        ("ToolSearch", {"query": "select:Read"}, "select:Read"),
+        ("Unknown", {"my_param": "some value"}, "some value"),
+        ("Unknown", {"n": 42}, ""),
+    ],
+)
+async def test_tool_preview_in_chat_pane(tool: str, kwargs: dict, expected_preview: str) -> None:
+    async with _ChatApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(ChatPaneWidget)
+        await widget.emit(make_tool_event(tool, **kwargs))
+        await pilot.pause()
+        content = _log_text(widget.query_one("#scrollback", RichLog))
+        assert tool in content
+        if expected_preview:
+            assert expected_preview in content
+
+
+async def test_tool_preview_todowrite_shows_item_count() -> None:
+    async with _ChatApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(ChatPaneWidget)
+        await widget.emit(make_tool_event("TodoWrite", todos=[{"id": 1}, {"id": 2}]))
+        await pilot.pause()
+        content = _log_text(widget.query_one("#scrollback", RichLog))
+        assert "TodoWrite" in content
+        assert "(2 items)" in content
+
+
+async def test_tool_preview_truncates_at_100_chars_with_ellipsis() -> None:
+    long_cmd = "x" * 101
+    async with _ChatApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(ChatPaneWidget)
+        await widget.emit(make_tool_event("Bash", command=long_cmd))
+        await pilot.pause()
+        content = _log_text(widget.query_one("#scrollback", RichLog))
+        assert "…" in content
+        assert long_cmd not in content
+
+
+async def test_tool_preview_at_exactly_100_chars_is_not_truncated() -> None:
+    exact_cmd = "x" * 100
+    async with _ChatApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(ChatPaneWidget)
+        await widget.emit(make_tool_event("Bash", command=exact_cmd))
+        await pilot.pause()
+        content = _log_text(widget.query_one("#scrollback", RichLog))
+        assert exact_cmd in content
+
+
+async def test_chat_pane_claude_message_renders_via_markdown() -> None:
+    async with _ChatApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(ChatPaneWidget)
+        await widget.emit(AssistantTextEvent(text="**bold text**"))
+        await pilot.pause()
+        content = _log_text(widget.query_one("#scrollback", RichLog))
+        # Markdown strips the asterisks — text appears but markers do not
+        assert "bold text" in content
+        assert "**bold text**" not in content
+
+
+async def test_chat_pane_claude_message_renders_inline_code() -> None:
+    async with _ChatApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(ChatPaneWidget)
+        await widget.emit(AssistantTextEvent(text="Use `foo()` here"))
+        await pilot.pause()
+        content = _log_text(widget.query_one("#scrollback", RichLog))
+        assert "foo()" in content
+
+
+async def test_chat_pane_claude_message_renders_code_block_with_distinct_style() -> None:
+    async with _ChatApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(ChatPaneWidget)
+        await widget.emit(AssistantTextEvent(text="```\nprint('hello')\n```"))
+        await pilot.pause()
+        content = _log_text(widget.query_one("#scrollback", RichLog))
+        assert "print" in content
+        assert "hello" in content
+
+
+async def test_chat_pane_user_message_renders_as_plain_text_not_markdown() -> None:
+    async with _ChatApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(ChatPaneWidget)
+        area = widget.query_one("#input-area", TextArea)
+        area.load_text("**hello**")
+        await pilot.pause()
+        widget._submit()
+        await pilot.pause()
+        content = _log_text(widget.query_one("#scrollback", RichLog))
+        # Plain Text — asterisks preserved as-is
+        assert "**hello**" in content
+
+
+async def test_chat_pane_tool_call_renders_with_dim_style_and_preview() -> None:
+    async with _ChatApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(ChatPaneWidget)
+        await widget.emit(make_tool_event("Bash", command="echo hi"))
+        await pilot.pause()
+        content = _log_text(widget.query_one("#scrollback", RichLog))
+        assert "🔧" in content
+        assert "Bash" in content
+        assert "echo hi" in content
+
+
+async def test_chat_pane_todowrite_renders_count_placeholder_not_full_todos() -> None:
+    async with _ChatApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(ChatPaneWidget)
+        todos = [{"id": i, "content": f"item {i}"} for i in range(5)]
+        await widget.emit(make_tool_event("TodoWrite", todos=todos))
+        await pilot.pause()
+        content = _log_text(widget.query_one("#scrollback", RichLog))
+        assert "TodoWrite" in content
+        assert "(5 items)" in content
+        # Full todo content should NOT be shown
+        assert "item 0" not in content
+
+
+async def test_chat_pane_turn_separator_blank_line_before_each_speaker_message() -> None:
+    async with _ChatApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(ChatPaneWidget)
+        log = widget.query_one("#scrollback", RichLog)
+
+        await widget.emit(AssistantTextEvent(text="First message"))
+        await pilot.pause()
+        await widget.emit(AssistantTextEvent(text="Second message"))
+        await pilot.pause()
+        lines_after_second = list(log.lines)
+
+        # Each message adds a blank line + content, so two messages add more lines
+        # than one message. Blank lines appear in the strip list as empty-text strips.
+        blank_count = sum(1 for s in lines_after_second if s.text == "")
+        assert blank_count >= 2
+
+
+async def test_chat_pane_tool_calls_do_not_get_blank_line_separators() -> None:
+    async with _ChatApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(ChatPaneWidget)
+        log = widget.query_one("#scrollback", RichLog)
+
+        await widget.emit(make_tool_event("Bash", command="ls"))
+        await widget.emit(make_tool_event("Read", file_path="/a.py"))
+        await pilot.pause()
+
+        # Tool lines go through _append_tool_line which writes no blank line
+        blank_count = sum(1 for s in log.lines if s.text == "")
+        assert blank_count == 0
+
+
+async def test_chat_pane_richlog_has_wrap_enabled() -> None:
+    async with _ChatApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(ChatPaneWidget)
+        log = widget.query_one("#scrollback", RichLog)
+        assert log.wrap is True

--- a/tests/test_ui/test_log_pane.py
+++ b/tests/test_ui/test_log_pane.py
@@ -2,11 +2,13 @@
 
 from pathlib import Path
 
+import pytest
 from textual.app import App, ComposeResult
 from textual.widgets import RichLog
 
 from cog.core.runner import AssistantTextEvent, ResultEvent, RunResult, ToolUseEvent
 from cog.ui.widgets.log_pane import LogPaneWidget
+from tests.fakes import make_tool_event
 
 
 def _log_text(log: RichLog) -> str:
@@ -76,3 +78,94 @@ async def test_log_pane_preserves_scroll_when_user_scrolled_up() -> None:
 
         # scroll_y unchanged because _pinned is False → no scroll_end called
         assert log.scroll_y == y_before
+
+
+async def test_log_pane_assistant_message_renders_via_markdown() -> None:
+    async with _LogApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(LogPaneWidget)
+        await widget.emit(AssistantTextEvent(text="**bold text**"))
+        await pilot.pause()
+        content = _log_text(widget.query_one("#log", RichLog))
+        assert "bold text" in content
+        assert "**bold text**" not in content
+
+
+async def test_log_pane_assistant_message_has_no_claude_prefix() -> None:
+    async with _LogApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(LogPaneWidget)
+        await widget.emit(AssistantTextEvent(text="some response"))
+        await pilot.pause()
+        content = _log_text(widget.query_one("#log", RichLog))
+        assert "some response" in content
+        assert "Claude:" not in content
+
+
+async def test_log_pane_tool_call_renders_with_preview() -> None:
+    async with _LogApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(LogPaneWidget)
+        await widget.emit(make_tool_event("Read", file_path="/src/main.py"))
+        await pilot.pause()
+        content = _log_text(widget.query_one("#log", RichLog))
+        assert "🔧" in content
+        assert "Read" in content
+        assert "/src/main.py" in content
+
+
+async def test_log_pane_richlog_has_wrap_enabled() -> None:
+    async with _LogApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(LogPaneWidget)
+        log = widget.query_one("#log", RichLog)
+        assert log.wrap is True
+
+
+async def test_log_pane_todowrite_renders_count_placeholder() -> None:
+    async with _LogApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(LogPaneWidget)
+        await widget.emit(make_tool_event("TodoWrite", todos=[{"id": 1}, {"id": 2}, {"id": 3}]))
+        await pilot.pause()
+        content = _log_text(widget.query_one("#log", RichLog))
+        assert "TodoWrite" in content
+        assert "(3 items)" in content
+
+
+async def test_log_pane_stage_separator_still_renders_on_result_event() -> None:
+    result = RunResult(
+        final_message="done",
+        total_cost_usd=0.123,
+        exit_status=0,
+        stream_json_path=Path("/dev/null"),
+        duration_seconds=5.0,
+    )
+    async with _LogApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(LogPaneWidget)
+        await widget.emit(ResultEvent(result=result))
+        await pilot.pause()
+        content = _log_text(widget.query_one("#log", RichLog))
+        assert "stage complete" in content
+        assert "0.123" in content
+
+
+@pytest.mark.parametrize(
+    "tool,kwargs,expected_in_output",
+    [
+        ("Bash", {"command": "echo hi"}, "echo hi"),
+        ("Read", {"file_path": "/a.py"}, "/a.py"),
+        ("Write", {"file_path": "/b.py"}, "/b.py"),
+        ("Edit", {"file_path": "/c.py"}, "/c.py"),
+        ("Glob", {"pattern": "*.py"}, "*.py"),
+        ("Grep", {"pattern": "def foo"}, "def foo"),
+        ("Agent", {"description": "desc", "prompt": "p"}, "desc"),
+        ("Agent", {"prompt": "fallback"}, "fallback"),
+        ("ToolSearch", {"query": "search"}, "search"),
+        ("TodoWrite", {"todos": [1, 2]}, "(2 items)"),
+    ],
+)
+async def test_log_pane_tool_preview_extraction_matches_chat_pane_for_all_tools(
+    tool: str, kwargs: dict, expected_in_output: str
+) -> None:
+    async with _LogApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(LogPaneWidget)
+        await widget.emit(make_tool_event(tool, **kwargs))
+        await pilot.pause()
+        content = _log_text(widget.query_one("#log", RichLog))
+        assert expected_in_output in content

--- a/tests/test_ui/test_shared.py
+++ b/tests/test_ui/test_shared.py
@@ -1,0 +1,115 @@
+"""Direct unit tests for tool_preview() in isolation."""
+
+import pytest
+
+from cog.ui.widgets._shared import tool_preview
+from tests.fakes import make_tool_event
+
+
+def test_tool_preview_bash_command() -> None:
+    event = make_tool_event("Bash", command="ls -la")
+    assert tool_preview(event) == "ls -la"
+
+
+def test_tool_preview_read_file_path() -> None:
+    event = make_tool_event("Read", file_path="/src/main.py")
+    assert tool_preview(event) == "/src/main.py"
+
+
+def test_tool_preview_write_file_path() -> None:
+    event = make_tool_event("Write", file_path="/out/result.txt")
+    assert tool_preview(event) == "/out/result.txt"
+
+
+def test_tool_preview_edit_file_path() -> None:
+    event = make_tool_event("Edit", file_path="/src/foo.py", old_string="x", new_string="y")
+    assert tool_preview(event) == "/src/foo.py"
+
+
+def test_tool_preview_glob_pattern() -> None:
+    event = make_tool_event("Glob", pattern="**/*.py")
+    assert tool_preview(event) == "**/*.py"
+
+
+def test_tool_preview_grep_pattern() -> None:
+    event = make_tool_event("Grep", pattern="def foo")
+    assert tool_preview(event) == "def foo"
+
+
+def test_tool_preview_agent_prefers_description_over_prompt() -> None:
+    event = make_tool_event("Agent", description="explore widgets", prompt="search for things")
+    assert tool_preview(event) == "explore widgets"
+
+
+def test_tool_preview_agent_falls_back_to_prompt_when_no_description() -> None:
+    event = make_tool_event("Agent", prompt="search for things")
+    assert tool_preview(event) == "search for things"
+
+
+def test_tool_preview_task_prefers_description() -> None:
+    event = make_tool_event("Task", description="run tests", prompt="execute the suite")
+    assert tool_preview(event) == "run tests"
+
+
+def test_tool_preview_toolsearch_query() -> None:
+    event = make_tool_event("ToolSearch", query="select:Read,Edit")
+    assert tool_preview(event) == "select:Read,Edit"
+
+
+def test_tool_preview_todowrite_shows_item_count() -> None:
+    event = make_tool_event("TodoWrite", todos=[{"id": 1}, {"id": 2}, {"id": 3}])
+    assert tool_preview(event) == "(3 items)"
+
+
+def test_tool_preview_todowrite_empty_list() -> None:
+    event = make_tool_event("TodoWrite", todos=[])
+    assert tool_preview(event) == "(0 items)"
+
+
+def test_tool_preview_unknown_tool_uses_first_string_value_fallback() -> None:
+    event = make_tool_event("FutureTool", my_param="some value")
+    assert tool_preview(event) == "some value"
+
+
+def test_tool_preview_unknown_tool_with_only_non_string_values_renders_empty() -> None:
+    event = make_tool_event("FutureTool", count=42, flag=True)
+    assert tool_preview(event) == ""
+
+
+def test_tool_preview_truncates_at_100_chars_with_ellipsis() -> None:
+    long_cmd = "x" * 101
+    event = make_tool_event("Bash", command=long_cmd)
+    result = tool_preview(event)
+    assert len(result) == 100
+    assert result.endswith("…")
+    assert result[:99] == "x" * 99
+
+
+def test_tool_preview_at_exactly_100_chars_is_not_truncated() -> None:
+    exact_cmd = "x" * 100
+    event = make_tool_event("Bash", command=exact_cmd)
+    result = tool_preview(event)
+    assert result == exact_cmd
+    assert len(result) == 100
+
+
+@pytest.mark.parametrize(
+    "tool,kwargs,expected",
+    [
+        ("Bash", {"command": "echo hi"}, "echo hi"),
+        ("Read", {"file_path": "/a.py"}, "/a.py"),
+        ("Write", {"file_path": "/b.py"}, "/b.py"),
+        ("Edit", {"file_path": "/c.py"}, "/c.py"),
+        ("Glob", {"pattern": "*.py"}, "*.py"),
+        ("Grep", {"pattern": "foo"}, "foo"),
+        ("Agent", {"description": "desc", "prompt": "p"}, "desc"),
+        ("Agent", {"prompt": "fallback"}, "fallback"),
+        ("ToolSearch", {"query": "search"}, "search"),
+        ("TodoWrite", {"todos": [1, 2]}, "(2 items)"),
+        ("Unknown", {"my_key": "my_value"}, "my_value"),
+        ("Unknown", {"n": 1}, ""),
+    ],
+)
+def test_tool_preview_parametrized(tool: str, kwargs: dict, expected: str) -> None:
+    event = make_tool_event(tool, **kwargs)
+    assert tool_preview(event) == expected


### PR DESCRIPTION
## Summary

Implements the full rendering UX overhaul for `ChatPaneWidget` and `LogPaneWidget` as specified in issue #88. A new shared `tool_preview()` helper in `_shared.py` extracts human-readable previews from any `ToolUseEvent` via an explicit key-lookup chain (`command` → `file_path` → `pattern` → `description` → `prompt` → `query` → first string value), with special-case count display for `TodoWrite` and 100-char truncation. Both widgets now render assistant text via Rich `Markdown`, display tool previews for all known tools, and use `wrap=True` on their `RichLog`. `ChatPaneWidget` additionally adds blank-line turn separators before each speaker message (Claude and You) while keeping tool lines flush.

## Key changes

- `src/cog/ui/widgets/_shared.py` (new): `tool_preview()` + `_first_string_value()` helpers
- `src/cog/ui/widgets/chat_pane.py`: `emit` uses `Markdown` + `Group` for Claude, `Text` for user, `tool_preview` for tools; adds `_append_message`/`_append_tool_line` helpers; `wrap=True` on RichLog
- `src/cog/ui/widgets/log_pane.py`: `emit` uses `Markdown` for assistant text, `tool_preview` for tools; `_append_line` accepts `RenderableType`; `wrap=True` on RichLog
- `tests/fakes.py`: adds `make_tool_event(tool, **kwargs)` factory; imports `ToolUseEvent`
- `tests/test_ui/test_shared.py` (new): 20 direct unit tests of `tool_preview()` including parametrized coverage
- `tests/test_ui/test_chat_pane.py`: extended with 20+ tests covering all tool shapes, markdown rendering, plain-text user messages, turn separators, and wrap flag
- `tests/test_ui/test_log_pane.py`: extended with markdown rendering, no-prefix check, wrap flag, stage separator regression, and parametrized tool-preview parity test

## Closes

Closes #88

## Test plan

- [ ] `uv run pytest` — 751 passed, 3 skipped (docker integration, expected)
- [ ] `uv run mypy src` — clean
- [ ] `uv run ruff check . && uv run ruff format --check .` — clean
- [ ] Manual `cog refine`: tool-call lines show preview for Bash (`command`), Read/Write/Edit (`file_path`), Glob/Grep (`pattern`), Agent/Task (`description` preferred, `prompt` fallback), ToolSearch (`query`); TodoWrite shows `(N items)`
- [ ] Claude messages render with bold, inline code, and fenced code blocks formatted by Rich Markdown
- [ ] User messages with `**asterisks**` appear as literal asterisks, not bold
- [ ] Blank line visible between each Claude turn and each You turn; consecutive tool calls are flush with no gaps
- [ ] Long lines wrap instead of clipping at the right edge (both panes)
- [ ] `cog ralph --loop --headless` unaffected (no widget changes to headless path)
- [ ] `─── stage complete: $X.XXX ───` still fires on ResultEvent in LogPane

---
🤖 Generated by cog. Iteration cost: $1.373
