### PR TITLE
Ralph workflow: wait for CI after PR creation, abandon on failure (part 1 of 2) (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Key fields:
 | Field | Type | Description |
 |-------|------|-------------|
 | `ts` | string | ISO-8601 UTC timestamp |
-| `outcome` | string | `success`, `error`, `no-op`, `push-failed`, `deferred-by-blocker`, `rebase-conflict` |
+| `outcome` | string | `success`, `error`, `no-op`, `push-failed`, `deferred-by-blocker`, `rebase-conflict`, `ci-failed` |
 | `stages` | array | Per-stage entry with `stage`, `duration_s`, `cost_usd`, `exit_status`, `commits`; for `cog refine` the first entry is `"interview"` |
 | `total_cost_usd` | float | Sum of stage costs |
 | `duration_seconds` | float | Wall time across all stages |

--- a/src/cog/core/errors.py
+++ b/src/cog/core/errors.py
@@ -85,3 +85,19 @@ class RebaseUnresolvedError(Exception):
         super().__init__(
             f"Rebase could not be completed by claude. Analysis: {final_message[:200]}"
         )
+
+
+class CiError(Exception):
+    """Base for CI-related failures."""
+
+
+class CiChecksFailedError(CiError):
+    def __init__(self, failing: tuple[str, ...]) -> None:
+        self.failing = failing
+        super().__init__(f"CI checks failed: {', '.join(failing)}")
+
+
+class CiTimeoutError(CiError):
+    def __init__(self, timeout_seconds: float) -> None:
+        self.timeout_seconds = timeout_seconds
+        super().__init__(f"CI did not resolve within {timeout_seconds:.0f}s")

--- a/src/cog/core/host.py
+++ b/src/cog/core/host.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import Literal
 
 from cog.core.item import Item
 
@@ -11,6 +12,31 @@ class PullRequest:
     state: str  # "open" | "closed" | "merged"
     body: str
     head_branch: str
+
+
+@dataclass(frozen=True)
+class CheckRun:
+    name: str
+    state: Literal["pending", "passed", "failed", "skipped"]
+    link: str
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class PrChecks:
+    runs: tuple[CheckRun, ...]
+
+    @property
+    def pending(self) -> bool:
+        return any(r.state == "pending" for r in self.runs)
+
+    @property
+    def failed(self) -> tuple[CheckRun, ...]:
+        return tuple(r for r in self.runs if r.state == "failed")
+
+    @property
+    def all_passed(self) -> bool:
+        return not self.pending and not self.failed
 
 
 class GitHost(ABC):
@@ -31,3 +57,9 @@ class GitHost(ABC):
 
     @abstractmethod
     async def get_open_prs_mentioning_item(self, item: Item) -> list[PullRequest]: ...
+
+    @abstractmethod
+    async def get_pr_checks(self, number: int) -> PrChecks: ...
+
+    @abstractmethod
+    async def comment_on_pr(self, number: int, body: str) -> None: ...

--- a/src/cog/core/runner.py
+++ b/src/cog/core/runner.py
@@ -43,7 +43,14 @@ class StageEndEvent:
     exit_status: int
 
 
-RunEvent = AssistantTextEvent | ToolUseEvent | ResultEvent | StageStartEvent | StageEndEvent
+@dataclass(frozen=True)
+class StatusEvent:
+    message: str
+
+
+RunEvent = (
+    AssistantTextEvent | ToolUseEvent | ResultEvent | StageStartEvent | StageEndEvent | StatusEvent
+)
 
 
 class AgentRunner(ABC):

--- a/src/cog/headless.py
+++ b/src/cog/headless.py
@@ -8,6 +8,7 @@ from cog.core.runner import (
     RunEvent,
     StageEndEvent,
     StageStartEvent,
+    StatusEvent,
     ToolUseEvent,
 )
 from cog.core.workflow import StageExecutor, Workflow
@@ -31,6 +32,8 @@ class StderrEventSink:
         elif isinstance(event, AssistantTextEvent):
             for line in event.text.splitlines():
                 sys.stderr.write(f"  {line}\n")
+        elif isinstance(event, StatusEvent):
+            sys.stderr.write(f"-- {event.message}\n")
         # ResultEvent is internal to runner; StageEndEvent carries the data.
         # Any other event type (future additions) is silently dropped.
         sys.stderr.flush()

--- a/src/cog/hosts/github.py
+++ b/src/cog/hosts/github.py
@@ -2,11 +2,24 @@ import asyncio
 import json
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from cog.core.errors import HostError
-from cog.core.host import GitHost, PullRequest
+from cog.core.host import CheckRun, GitHost, PrChecks, PullRequest
 from cog.core.item import Item
+
+_GH_STATE_MAP: dict[str, Literal["pending", "passed", "failed", "skipped"]] = {
+    "SUCCESS": "passed",
+    "FAILURE": "failed",
+    "PENDING": "pending",
+    "QUEUED": "pending",
+    "IN_PROGRESS": "pending",
+    "SKIPPED": "skipped",
+}
+
+
+def _map_gh_state(raw: str) -> Literal["pending", "passed", "failed", "skipped"]:
+    return _GH_STATE_MAP.get(raw.upper(), "pending")
 
 
 class GitHubGitHost(GitHost):
@@ -52,6 +65,27 @@ class GitHubGitHost(GitHost):
     async def get_pr_body(self, number: int) -> str:
         data = await self._gh_json(["pr", "view", str(number), "--json", "body"])
         return data["body"] or ""
+
+    async def get_pr_checks(self, number: int) -> PrChecks:
+        stdout = await self._gh_json(
+            ["pr", "checks", str(number), "--json", "name,state,link,description"]
+        )
+        runs = tuple(
+            CheckRun(
+                name=r["name"],
+                state=_map_gh_state(r["state"]),
+                link=r.get("link", ""),
+                description=r.get("description", ""),
+            )
+            for r in stdout
+        )
+        return PrChecks(runs=runs)
+
+    async def comment_on_pr(self, number: int, body: str) -> None:
+        await self._gh_run(
+            ["pr", "comment", str(number), "--body-file", "-"],
+            stdin=body.encode("utf-8"),
+        )
 
     async def get_open_prs_mentioning_item(self, item: Item) -> list[PullRequest]:
         query = f'"Closes #{item.item_id}" OR "Fixes #{item.item_id}" OR "Resolves #{item.item_id}"'

--- a/src/cog/telemetry.py
+++ b/src/cog/telemetry.py
@@ -20,6 +20,7 @@ TelemetryOutcome = Literal[
     "push-failed",
     "deferred-by-blocker",
     "rebase-conflict",
+    "ci-failed",
 ]
 
 

--- a/src/cog/ui/widgets/chat_pane.py
+++ b/src/cog/ui/widgets/chat_pane.py
@@ -10,7 +10,7 @@ from textual.events import Key
 from textual.widget import Widget
 from textual.widgets import RichLog, Static, TextArea
 
-from cog.core.runner import AssistantTextEvent, ResultEvent, RunEvent, ToolUseEvent
+from cog.core.runner import AssistantTextEvent, ResultEvent, RunEvent, StatusEvent, ToolUseEvent
 from cog.ui.widgets._shared import tool_preview
 
 
@@ -114,6 +114,8 @@ class ChatPaneWidget(Widget):
             self._append_tool_line(f"[dim]🔧 {event.tool}{suffix}[/dim]")
         elif isinstance(event, ResultEvent):
             self._hide_thinking_indicator()
+        elif isinstance(event, StatusEvent):
+            self._append_tool_line(f"[dim]{event.message}[/dim]")
 
     async def prompt(self) -> str | None:
         """Block until the user submits a message via Enter (str, possibly empty),

--- a/src/cog/ui/widgets/log_pane.py
+++ b/src/cog/ui/widgets/log_pane.py
@@ -6,7 +6,7 @@ from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import RichLog
 
-from cog.core.runner import AssistantTextEvent, ResultEvent, RunEvent, ToolUseEvent
+from cog.core.runner import AssistantTextEvent, ResultEvent, RunEvent, StatusEvent, ToolUseEvent
 from cog.ui.widgets._shared import tool_preview
 
 
@@ -53,3 +53,5 @@ class LogPaneWidget(Widget):
         elif isinstance(event, ResultEvent):
             cost = event.result.total_cost_usd
             self._append_line(f"[dim]─── stage complete: ${cost:.3f} ───[/dim]")
+        elif isinstance(event, StatusEvent):
+            self._append_line(f"[dim]{event.message}[/dim]")

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -297,9 +297,7 @@ class RalphWorkflow(Workflow):
         if checks.all_passed:
             await self._mark_ci_success(ctx, results, pr)
         else:
-            error = CiChecksFailedError(
-                failing=tuple(r.name for r in checks.failed)
-            )
+            error = CiChecksFailedError(failing=tuple(r.name for r in checks.failed))
             await self._handle_ci_failure(ctx, results, pr, checks, error)
 
     async def _wait_for_ci(self, ctx: ExecutionContext, pr: PullRequest) -> PrChecks:

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import re
 import sys
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from importlib.resources import files
@@ -14,11 +16,19 @@ from typing import ClassVar, Literal
 import cog.git as git
 from cog.checks import RALPH_CHECKS
 from cog.core.context import ExecutionContext
-from cog.core.errors import GitError, HostError, RebaseUnresolvedError, StageError, TrackerError
-from cog.core.host import GitHost
+from cog.core.errors import (
+    CiChecksFailedError,
+    CiTimeoutError,
+    GitError,
+    HostError,
+    RebaseUnresolvedError,
+    StageError,
+    TrackerError,
+)
+from cog.core.host import GitHost, PrChecks, PullRequest
 from cog.core.item import Item
 from cog.core.outcomes import Outcome, StageResult
-from cog.core.runner import AgentRunner
+from cog.core.runner import AgentRunner, StatusEvent
 from cog.core.stage import Stage
 from cog.core.tracker import IssueTracker
 from cog.core.workflow import StageExecutor, Workflow
@@ -31,6 +41,18 @@ from cog.ui.widgets.log_pane import LogPaneWidget
 class RebaseOutcome:
     status: Literal["clean", "conflict"]
     final_message: str = ""  # claude's analysis on conflict; empty on clean
+
+
+def _parse_float_env(key: str, default: float) -> float:
+    try:
+        return float(os.environ[key])
+    except (KeyError, ValueError):
+        return default
+
+
+_POLL_INTERVAL = _parse_float_env("COG_CI_POLL_INTERVAL_SECONDS", 15.0)
+_CI_TIMEOUT = _parse_float_env("COG_CI_TIMEOUT_SECONDS", 1800.0)
+_HEARTBEAT_INTERVAL = 60.0
 
 
 _PRIORITY_RE = re.compile(r"^p(\d+)$")
@@ -265,15 +287,129 @@ class RalphWorkflow(Workflow):
             pr = existing
 
         await self._tracker.comment(ctx.item, f"🤖 Cog opened a PR for this: {pr.url}")
-        await self._tracker.remove_label(ctx.item, "agent-ready")
+
+        ci_error: CiChecksFailedError | CiTimeoutError | None = None
         try:
-            await self._tracker.remove_label(ctx.item, "agent-failed")
+            checks = await self._wait_for_ci(ctx, pr)
+        except TimeoutError:
+            ci_error = CiTimeoutError(timeout_seconds=_CI_TIMEOUT)
+            checks = None
+        except asyncio.CancelledError:
+            raise
+
+        if ci_error is None and checks is not None and checks.all_passed:
+            await self._mark_ci_success(ctx, results, pr)
+        else:
+            effective_error = ci_error or CiChecksFailedError(
+                failing=tuple(r.name for r in (checks.failed if checks else ()))
+            )
+            await self._handle_ci_failure(ctx, results, pr, checks, effective_error)
+
+    async def _wait_for_ci(self, ctx: ExecutionContext, pr: PullRequest) -> PrChecks:
+        poll_interval = _parse_float_env("COG_CI_POLL_INTERVAL_SECONDS", _POLL_INTERVAL)
+        ci_timeout = _parse_float_env("COG_CI_TIMEOUT_SECONDS", _CI_TIMEOUT)
+        await self._emit(ctx, StatusEvent(message=f"⏳ Waiting for CI on PR #{pr.number}..."))
+
+        started = time.monotonic()
+        last_heartbeat = started
+        checks: PrChecks | None = None
+
+        async with asyncio.timeout(ci_timeout):
+            while True:
+                checks = await self._host.get_pr_checks(pr.number)  # type: ignore[union-attr]
+                if not checks.pending:
+                    break
+
+                now = time.monotonic()
+                if now - last_heartbeat >= _HEARTBEAT_INTERVAL:
+                    passed = sum(1 for r in checks.runs if r.state == "passed")
+                    total = len(checks.runs)
+                    pending = sum(1 for r in checks.runs if r.state == "pending")
+                    elapsed_m = int((now - started) / 60)
+                    await self._emit(
+                        ctx,
+                        StatusEvent(
+                            message=(
+                                f"⏳ CI: {passed}/{total} passed, "
+                                f"{pending} pending ({elapsed_m}m elapsed)"
+                            )
+                        ),
+                    )
+                    last_heartbeat = now
+
+                await asyncio.sleep(poll_interval)
+
+        assert checks is not None
+        if checks.all_passed:
+            await self._emit(ctx, StatusEvent(message="✓ All CI checks passed"))
+        else:
+            failed_names = ", ".join(r.name for r in checks.failed)
+            await self._emit(ctx, StatusEvent(message=f"✗ CI failed: {failed_names}"))
+        return checks
+
+    @staticmethod
+    async def _emit(ctx: ExecutionContext, event: StatusEvent) -> None:
+        if ctx.event_sink is not None:
+            await ctx.event_sink.emit(event)
+
+    async def _mark_ci_success(
+        self,
+        ctx: ExecutionContext,
+        results: list[StageResult],
+        pr: PullRequest,
+    ) -> None:
+        await self._tracker.remove_label(ctx.item, "agent-ready")  # type: ignore[arg-type]
+        try:
+            await self._tracker.remove_label(ctx.item, "agent-failed")  # type: ignore[arg-type]
         except TrackerError:
             pass
-        ctx.state_cache.mark_processed(ctx.item, "success")
+        ctx.state_cache.mark_processed(ctx.item, "success")  # type: ignore[arg-type]
         ctx.state_cache.save()
         await self._write_telemetry(ctx, results, "success", pr_url=pr.url)
         await self.write_report(ctx, results, "success", error=None)
+
+    async def _handle_ci_failure(
+        self,
+        ctx: ExecutionContext,
+        results: list[StageResult],
+        pr: PullRequest,
+        checks: PrChecks | None,
+        error: CiChecksFailedError | CiTimeoutError,
+    ) -> None:
+        assert ctx.item is not None
+        assert self._host is not None
+
+        lines = ["🤖 Cog: CI failed on this PR. See:"]
+        if checks is not None:
+            for r in checks.failed:
+                lines.append(f"- **{r.name}**: {r.link}")
+        await self._host.comment_on_pr(pr.number, "\n".join(lines))
+
+        await self._tracker.comment(
+            ctx.item,
+            f"🤖 Cog opened PR #{pr.number} but CI failed. "
+            f"See the PR for failing checks. `agent-failed` applied.",
+        )
+
+        await self._tracker.ensure_label(
+            "agent-failed",
+            color="d93f0b",
+            description="Cog attempted this and hit an error; retry is still eligible",
+        )
+        await self._tracker.add_label(ctx.item, "agent-failed")
+        await self._tracker.remove_label(ctx.item, "agent-ready")
+
+        ctx.state_cache.mark_processed(ctx.item, "ci-failed")
+        ctx.state_cache.save()
+        await self._write_telemetry(
+            ctx,
+            results,
+            "ci-failed",
+            pr_url=pr.url,
+            error=error,
+            cause_class=type(error).__name__,
+        )
+        await self.write_report(ctx, results, "error", error=error)
 
     async def finalize_noop(
         self,
@@ -561,7 +697,11 @@ class RalphWorkflow(Workflow):
         resolved_cause_class = cause_class
         if error is not None:
             error_str = str(error)
-            if cause_class is None and isinstance(error, StageError) and error.cause is not None:
+            if (
+                resolved_cause_class is None
+                and isinstance(error, StageError)
+                and error.cause is not None
+            ):
                 resolved_cause_class = type(error.cause).__name__
         if ctx.telemetry is None:
             return

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -50,8 +50,8 @@ def _parse_float_env(key: str, default: float) -> float:
         return default
 
 
-_POLL_INTERVAL = _parse_float_env("COG_CI_POLL_INTERVAL_SECONDS", 15.0)
-_CI_TIMEOUT = _parse_float_env("COG_CI_TIMEOUT_SECONDS", 1800.0)
+_DEFAULT_POLL_INTERVAL = 15.0
+_DEFAULT_CI_TIMEOUT = 1800.0
 _HEARTBEAT_INTERVAL = 60.0
 
 
@@ -288,56 +288,56 @@ class RalphWorkflow(Workflow):
 
         await self._tracker.comment(ctx.item, f"🤖 Cog opened a PR for this: {pr.url}")
 
-        ci_error: CiChecksFailedError | CiTimeoutError | None = None
         try:
             checks = await self._wait_for_ci(ctx, pr)
-        except TimeoutError:
-            ci_error = CiTimeoutError(timeout_seconds=_CI_TIMEOUT)
-            checks = None
-        except asyncio.CancelledError:
-            raise
+        except CiTimeoutError as e:
+            await self._handle_ci_failure(ctx, results, pr, None, e)
+            return
 
-        if ci_error is None and checks is not None and checks.all_passed:
+        if checks.all_passed:
             await self._mark_ci_success(ctx, results, pr)
         else:
-            effective_error = ci_error or CiChecksFailedError(
-                failing=tuple(r.name for r in (checks.failed if checks else ()))
+            error = CiChecksFailedError(
+                failing=tuple(r.name for r in checks.failed)
             )
-            await self._handle_ci_failure(ctx, results, pr, checks, effective_error)
+            await self._handle_ci_failure(ctx, results, pr, checks, error)
 
     async def _wait_for_ci(self, ctx: ExecutionContext, pr: PullRequest) -> PrChecks:
-        poll_interval = _parse_float_env("COG_CI_POLL_INTERVAL_SECONDS", _POLL_INTERVAL)
-        ci_timeout = _parse_float_env("COG_CI_TIMEOUT_SECONDS", _CI_TIMEOUT)
+        poll_interval = _parse_float_env("COG_CI_POLL_INTERVAL_SECONDS", _DEFAULT_POLL_INTERVAL)
+        ci_timeout = _parse_float_env("COG_CI_TIMEOUT_SECONDS", _DEFAULT_CI_TIMEOUT)
         await self._emit(ctx, StatusEvent(message=f"⏳ Waiting for CI on PR #{pr.number}..."))
 
         started = time.monotonic()
         last_heartbeat = started
         checks: PrChecks | None = None
 
-        async with asyncio.timeout(ci_timeout):
-            while True:
-                checks = await self._host.get_pr_checks(pr.number)  # type: ignore[union-attr]
-                if not checks.pending:
-                    break
+        try:
+            async with asyncio.timeout(ci_timeout):
+                while True:
+                    checks = await self._host.get_pr_checks(pr.number)  # type: ignore[union-attr]
+                    if not checks.pending:
+                        break
 
-                now = time.monotonic()
-                if now - last_heartbeat >= _HEARTBEAT_INTERVAL:
-                    passed = sum(1 for r in checks.runs if r.state == "passed")
-                    total = len(checks.runs)
-                    pending = sum(1 for r in checks.runs if r.state == "pending")
-                    elapsed_m = int((now - started) / 60)
-                    await self._emit(
-                        ctx,
-                        StatusEvent(
-                            message=(
-                                f"⏳ CI: {passed}/{total} passed, "
-                                f"{pending} pending ({elapsed_m}m elapsed)"
-                            )
-                        ),
-                    )
-                    last_heartbeat = now
+                    now = time.monotonic()
+                    if now - last_heartbeat >= _HEARTBEAT_INTERVAL:
+                        passed = sum(1 for r in checks.runs if r.state == "passed")
+                        total = len(checks.runs)
+                        pending = sum(1 for r in checks.runs if r.state == "pending")
+                        elapsed_m = int((now - started) / 60)
+                        await self._emit(
+                            ctx,
+                            StatusEvent(
+                                message=(
+                                    f"⏳ CI: {passed}/{total} passed, "
+                                    f"{pending} pending ({elapsed_m}m elapsed)"
+                                )
+                            ),
+                        )
+                        last_heartbeat = now
 
-                await asyncio.sleep(poll_interval)
+                    await asyncio.sleep(poll_interval)
+        except TimeoutError:
+            raise CiTimeoutError(timeout_seconds=ci_timeout) from None
 
         assert checks is not None
         if checks.all_passed:

--- a/tests/test_core/test_runner_events.py
+++ b/tests/test_core/test_runner_events.py
@@ -1,0 +1,55 @@
+"""Tests for runner event types, including StatusEvent."""
+
+from cog.core.runner import (
+    AssistantTextEvent,
+    ResultEvent,
+    RunEvent,
+    StageEndEvent,
+    StageStartEvent,
+    StatusEvent,
+    ToolUseEvent,
+)
+
+
+def test_status_event_shape() -> None:
+    event = StatusEvent(message="⏳ Waiting for CI on PR #42...")
+    assert event.message == "⏳ Waiting for CI on PR #42..."
+
+
+def test_status_event_is_frozen() -> None:
+    event = StatusEvent(message="hello")
+    try:
+        event.message = "changed"  # type: ignore[misc]
+        raise AssertionError("should have raised")
+    except (AttributeError, TypeError):
+        pass
+
+
+def test_run_event_union_accepts_status_event() -> None:
+    # Verify StatusEvent is part of RunEvent at runtime via isinstance checks
+    event: RunEvent = StatusEvent(message="test")
+    assert isinstance(event, StatusEvent)
+
+
+def test_run_event_union_still_accepts_all_prior_types() -> None:
+    from pathlib import Path
+
+    from cog.core.runner import RunResult
+
+    events: list[RunEvent] = [
+        AssistantTextEvent(text="hi"),
+        ToolUseEvent(tool="Bash", input={"command": "ls"}),
+        ResultEvent(
+            result=RunResult(
+                final_message="done",
+                total_cost_usd=0.0,
+                exit_status=0,
+                stream_json_path=Path("/dev/null"),
+                duration_seconds=0.0,
+            )
+        ),
+        StageStartEvent(stage_name="build", model="m"),
+        StageEndEvent(stage_name="build", cost_usd=0.0, exit_status=0),
+        StatusEvent(message="status"),
+    ]
+    assert len(events) == 6

--- a/tests/test_headless/test_stderr_sink.py
+++ b/tests/test_headless/test_stderr_sink.py
@@ -89,3 +89,12 @@ async def test_flush_called_after_each_emit(sink):
         mock_stderr.write = lambda s: None
         await sink.emit(StageStartEvent(stage_name="x", model="m"))
         mock_stderr.flush.assert_called()
+
+
+async def test_stderr_sink_renders_status_event_to_stderr_with_dim_prefix(sink, capsys):
+    from cog.core.runner import StatusEvent
+
+    await sink.emit(StatusEvent(message="⏳ Waiting for CI on PR #42..."))
+    captured = capsys.readouterr()
+    assert "⏳ Waiting for CI on PR #42..." in captured.err
+    assert captured.err.startswith("--")

--- a/tests/test_hosts/test_github_checks.py
+++ b/tests/test_hosts/test_github_checks.py
@@ -1,0 +1,161 @@
+"""Tests for GitHubGitHost.get_pr_checks and comment_on_pr."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cog.core.errors import HostError
+from cog.hosts.github import GitHubGitHost
+from tests.fakes import FakeSubprocessRegistry
+
+_CHECKS_ARGV = ("gh", "pr", "checks", "42", "--json", "name,state,link,description")
+
+
+def _checks_json(runs: list[dict]) -> bytes:
+    return json.dumps(runs).encode()
+
+
+@pytest.mark.parametrize(
+    "gh_state,expected",
+    [
+        ("SUCCESS", "passed"),
+        ("FAILURE", "failed"),
+        ("PENDING", "pending"),
+        ("QUEUED", "pending"),
+        ("IN_PROGRESS", "pending"),
+        ("SKIPPED", "skipped"),
+    ],
+)
+async def test_get_pr_checks_maps_gh_states_to_our_literals(
+    gh_state: str,
+    expected: str,
+    registry: FakeSubprocessRegistry,
+    project_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = [{"name": "ci", "state": gh_state, "link": "https://example.com", "description": ""}]
+    registry.expect(_CHECKS_ARGV, stdout=_checks_json(payload))
+    monkeypatch.setattr("asyncio.create_subprocess_exec", registry.create_subprocess_exec)
+    host = GitHubGitHost(project_dir)
+    checks = await host.get_pr_checks(42)
+    assert len(checks.runs) == 1
+    assert checks.runs[0].state == expected
+
+
+async def test_get_pr_checks_unknown_state_maps_to_pending(
+    registry: FakeSubprocessRegistry,
+    project_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = [{"name": "ci", "state": "UNKNOWN_STATE", "link": "", "description": ""}]
+    registry.expect(_CHECKS_ARGV, stdout=_checks_json(payload))
+    monkeypatch.setattr("asyncio.create_subprocess_exec", registry.create_subprocess_exec)
+    host = GitHubGitHost(project_dir)
+    checks = await host.get_pr_checks(42)
+    assert checks.runs[0].state == "pending"
+
+
+async def test_get_pr_checks_empty_runs_returns_all_passed_true(
+    registry: FakeSubprocessRegistry,
+    project_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry.expect(_CHECKS_ARGV, stdout=b"[]")
+    monkeypatch.setattr("asyncio.create_subprocess_exec", registry.create_subprocess_exec)
+    host = GitHubGitHost(project_dir)
+    checks = await host.get_pr_checks(42)
+    assert checks.all_passed is True
+    assert checks.pending is False
+    assert checks.failed == ()
+
+
+async def test_get_pr_checks_all_passed_when_mix_of_passed_and_skipped(
+    registry: FakeSubprocessRegistry,
+    project_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = [
+        {"name": "lint", "state": "SUCCESS", "link": "https://a.com", "description": ""},
+        {"name": "docs", "state": "SKIPPED", "link": "https://b.com", "description": ""},
+    ]
+    registry.expect(_CHECKS_ARGV, stdout=_checks_json(payload))
+    monkeypatch.setattr("asyncio.create_subprocess_exec", registry.create_subprocess_exec)
+    host = GitHubGitHost(project_dir)
+    checks = await host.get_pr_checks(42)
+    assert checks.all_passed is True
+    assert checks.failed == ()
+
+
+async def test_get_pr_checks_failed_returns_subset_with_links(
+    registry: FakeSubprocessRegistry,
+    project_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = [
+        {"name": "lint", "state": "SUCCESS", "link": "https://pass.com", "description": ""},
+        {"name": "tests", "state": "FAILURE", "link": "https://fail.com", "description": ""},
+    ]
+    registry.expect(_CHECKS_ARGV, stdout=_checks_json(payload))
+    monkeypatch.setattr("asyncio.create_subprocess_exec", registry.create_subprocess_exec)
+    host = GitHubGitHost(project_dir)
+    checks = await host.get_pr_checks(42)
+    assert len(checks.failed) == 1
+    assert checks.failed[0].name == "tests"
+    assert checks.failed[0].link == "https://fail.com"
+
+
+async def test_get_pr_checks_pending_detection(
+    registry: FakeSubprocessRegistry,
+    project_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = [
+        {"name": "build", "state": "SUCCESS", "link": "", "description": ""},
+        {"name": "deploy", "state": "QUEUED", "link": "", "description": ""},
+    ]
+    registry.expect(_CHECKS_ARGV, stdout=_checks_json(payload))
+    monkeypatch.setattr("asyncio.create_subprocess_exec", registry.create_subprocess_exec)
+    host = GitHubGitHost(project_dir)
+    checks = await host.get_pr_checks(42)
+    assert checks.pending is True
+    assert checks.all_passed is False
+
+
+async def test_get_pr_checks_raises_host_error_on_gh_failure(
+    registry: FakeSubprocessRegistry,
+    project_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry.expect(_CHECKS_ARGV, returncode=1, stderr=b"gh: not found")
+    monkeypatch.setattr("asyncio.create_subprocess_exec", registry.create_subprocess_exec)
+    host = GitHubGitHost(project_dir)
+    with pytest.raises(HostError):
+        await host.get_pr_checks(42)
+
+
+async def test_comment_on_pr_sends_correct_argv(
+    registry: FakeSubprocessRegistry,
+    project_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    argv = ("gh", "pr", "comment", "7", "--body-file", "-")
+    proc = registry.expect(argv)
+    monkeypatch.setattr("asyncio.create_subprocess_exec", registry.create_subprocess_exec)
+    host = GitHubGitHost(project_dir)
+    await host.comment_on_pr(7, "hello from cog")
+    assert argv in registry.calls
+    assert proc.received_stdin == b"hello from cog"
+
+
+async def test_comment_on_pr_raises_host_error_on_failure(
+    registry: FakeSubprocessRegistry,
+    project_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    argv = ("gh", "pr", "comment", "7", "--body-file", "-")
+    registry.expect(argv, returncode=1, stderr=b"error")
+    monkeypatch.setattr("asyncio.create_subprocess_exec", registry.create_subprocess_exec)
+    host = GitHubGitHost(project_dir)
+    with pytest.raises(HostError):
+        await host.comment_on_pr(7, "body")

--- a/tests/test_ui/test_chat_pane.py
+++ b/tests/test_ui/test_chat_pane.py
@@ -312,3 +312,14 @@ async def test_chat_pane_richlog_has_wrap_enabled() -> None:
         widget = pilot.app.query_one(ChatPaneWidget)
         log = widget.query_one("#scrollback", RichLog)
         assert log.wrap is True
+
+
+async def test_chat_pane_renders_status_event_as_dim_line() -> None:
+    from cog.core.runner import StatusEvent
+
+    async with _ChatApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(ChatPaneWidget)
+        await widget.emit(StatusEvent(message="⏳ Waiting for CI on PR #42..."))
+        await pilot.pause()
+        content = _log_text(widget.query_one("#scrollback", RichLog))
+        assert "⏳ Waiting for CI on PR #42..." in content

--- a/tests/test_ui/test_log_pane.py
+++ b/tests/test_ui/test_log_pane.py
@@ -145,6 +145,17 @@ async def test_log_pane_stage_separator_still_renders_on_result_event() -> None:
         assert "0.123" in content
 
 
+async def test_log_pane_renders_status_event_as_dim_line() -> None:
+    from cog.core.runner import StatusEvent
+
+    async with _LogApp().run_test(headless=True) as pilot:
+        widget = pilot.app.query_one(LogPaneWidget)
+        await widget.emit(StatusEvent(message="⏳ Waiting for CI on PR #42..."))
+        await pilot.pause()
+        content = _log_text(widget.query_one("#log", RichLog))
+        assert "⏳ Waiting for CI on PR #42..." in content
+
+
 @pytest.mark.parametrize(
     "tool,kwargs,expected_in_output",
     [

--- a/tests/test_workflows/test_ralph_ci_wait.py
+++ b/tests/test_workflows/test_ralph_ci_wait.py
@@ -117,6 +117,17 @@ def _writable_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
 
 
+@pytest.fixture(autouse=True)
+def _patch_rebase_before_push(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch _rebase_before_push to return clean so finalize_success tests don't hit git."""
+    from cog.workflows.ralph import RebaseOutcome
+
+    async def _noop(self: object, ctx: object) -> RebaseOutcome:
+        return RebaseOutcome(status="clean")
+
+    monkeypatch.setattr(RalphWorkflow, "_rebase_before_push", _noop)
+
+
 # ---------------------------------------------------------------------------
 # PrChecks dataclass predicates (unit tests)
 # ---------------------------------------------------------------------------

--- a/tests/test_workflows/test_ralph_ci_wait.py
+++ b/tests/test_workflows/test_ralph_ci_wait.py
@@ -1,0 +1,537 @@
+"""Tests for RalphWorkflow CI-wait loop and finalize CI-gate behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cog.core.context import ExecutionContext
+from cog.core.host import CheckRun, GitHost, PrChecks, PullRequest
+from cog.core.runner import StatusEvent
+from cog.core.tracker import IssueTracker
+from cog.workflows.ralph import RalphWorkflow
+from tests.fakes import InMemoryStateCache, RecordingEventSink, make_item, make_stage_result
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pr(number: int = 42, url: str = "https://github.com/org/repo/pull/42") -> PullRequest:
+    return PullRequest(number=number, url=url, state="open", body="", head_branch="cog/42-fix")
+
+
+def _passed_checks(*names: str) -> PrChecks:
+    runs = tuple(CheckRun(name=n, state="passed", link=f"https://ci.example/{n}") for n in names)
+    return PrChecks(runs=runs)
+
+
+def _pending_checks(*names: str) -> PrChecks:
+    runs = tuple(CheckRun(name=n, state="pending", link="") for n in names)
+    return PrChecks(runs=runs)
+
+
+def _failed_checks(*names: str) -> PrChecks:
+    runs = tuple(CheckRun(name=n, state="failed", link=f"https://ci.example/{n}") for n in names)
+    return PrChecks(runs=runs)
+
+
+def _make_host(
+    *,
+    pr: PullRequest | None = None,
+    push_error: Exception | None = None,
+    checks_sequence: list[PrChecks] | None = None,
+) -> AsyncMock:
+    host = AsyncMock(spec=GitHost)
+    if push_error:
+        host.push_branch.side_effect = push_error
+    else:
+        host.push_branch.return_value = None
+    host.get_pr_for_branch.return_value = pr
+    host.create_pr.return_value = _make_pr()
+    host.update_pr.return_value = None
+    host.comment_on_pr.return_value = None
+    if checks_sequence:
+        host.get_pr_checks.side_effect = checks_sequence
+    else:
+        host.get_pr_checks.return_value = _passed_checks("ci")
+    return host
+
+
+def _make_tracker() -> AsyncMock:
+    tracker = AsyncMock(spec=IssueTracker)
+    tracker.comment.return_value = None
+    tracker.add_label.return_value = None
+    tracker.remove_label.return_value = None
+    tracker.ensure_label.return_value = None
+    return tracker
+
+
+def _make_telemetry() -> AsyncMock:
+    tel = AsyncMock()
+    tel.write.return_value = None
+    return tel
+
+
+def _make_ctx(
+    tmp_path: Path,
+    *,
+    item_id: str = "42",
+    work_branch: str = "cog/42-fix",
+    telemetry: Any = None,
+    event_sink: Any = None,
+) -> ExecutionContext:
+    sink = event_sink or RecordingEventSink()
+    return ExecutionContext(
+        project_dir=tmp_path,
+        tmp_dir=tmp_path,
+        state_cache=InMemoryStateCache(),
+        headless=True,
+        item=make_item(item_id=item_id, title="Fix the bug"),
+        work_branch=work_branch,
+        telemetry=telemetry,
+        event_sink=sink,
+    )
+
+
+def _make_wf(
+    tracker: AsyncMock | None = None,
+    host: AsyncMock | None = None,
+) -> RalphWorkflow:
+    from tests.fakes import EchoRunner
+
+    return RalphWorkflow(
+        runner=EchoRunner(),
+        tracker=tracker or _make_tracker(),
+        host=host or _make_host(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _writable_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+
+
+# ---------------------------------------------------------------------------
+# PrChecks dataclass predicates (unit tests)
+# ---------------------------------------------------------------------------
+
+
+def test_pr_checks_all_passed_empty() -> None:
+    assert PrChecks(runs=()).all_passed is True
+
+
+def test_pr_checks_all_passed_with_passed_and_skipped() -> None:
+    runs = (
+        CheckRun(name="ci", state="passed", link=""),
+        CheckRun(name="docs", state="skipped", link=""),
+    )
+    checks = PrChecks(runs=runs)
+    assert checks.all_passed is True
+    assert checks.pending is False
+    assert checks.failed == ()
+
+
+def test_pr_checks_pending_when_any_pending() -> None:
+    runs = (
+        CheckRun(name="ci", state="passed", link=""),
+        CheckRun(name="deploy", state="pending", link=""),
+    )
+    checks = PrChecks(runs=runs)
+    assert checks.pending is True
+    assert checks.all_passed is False
+
+
+def test_pr_checks_failed_subset() -> None:
+    runs = (
+        CheckRun(name="ci", state="passed", link="https://pass"),
+        CheckRun(name="lint", state="failed", link="https://fail"),
+    )
+    checks = PrChecks(runs=runs)
+    assert len(checks.failed) == 1
+    assert checks.failed[0].name == "lint"
+
+
+# ---------------------------------------------------------------------------
+# _wait_for_ci: basic behavior
+# ---------------------------------------------------------------------------
+
+
+async def test_wait_emits_start_event_immediately(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.001")
+    monkeypatch.setenv("COG_CI_TIMEOUT_SECONDS", "10")
+    sink = RecordingEventSink()
+    host = _make_host(checks_sequence=[_passed_checks("ci")])
+    wf = _make_wf(host=host)
+    ctx = _make_ctx(tmp_path, event_sink=sink)
+
+    await wf._wait_for_ci(ctx, _make_pr())
+
+    status_messages = [e.message for e in sink.events if isinstance(e, StatusEvent)]
+    assert any("Waiting for CI" in m for m in status_messages)
+    assert status_messages[0].startswith("⏳ Waiting for CI")
+
+
+async def test_wait_polls_until_all_checks_resolved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.001")
+    monkeypatch.setenv("COG_CI_TIMEOUT_SECONDS", "10")
+    # pending, pending, pending, then passed
+    sequence = [
+        _pending_checks("ci"),
+        _pending_checks("ci"),
+        _pending_checks("ci"),
+        _passed_checks("ci"),
+    ]
+    host = _make_host(checks_sequence=sequence)
+    wf = _make_wf(host=host)
+    sink = RecordingEventSink()
+    ctx = _make_ctx(tmp_path, event_sink=sink)
+
+    result = await wf._wait_for_ci(ctx, _make_pr())
+
+    assert result.all_passed is True
+    assert host.get_pr_checks.call_count == 4
+
+
+async def test_wait_emits_resolution_event_on_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.001")
+    monkeypatch.setenv("COG_CI_TIMEOUT_SECONDS", "10")
+    host = _make_host(checks_sequence=[_passed_checks("ci")])
+    wf = _make_wf(host=host)
+    sink = RecordingEventSink()
+    ctx = _make_ctx(tmp_path, event_sink=sink)
+
+    await wf._wait_for_ci(ctx, _make_pr())
+
+    messages = [e.message for e in sink.events if isinstance(e, StatusEvent)]
+    assert any("✓" in m and "passed" in m for m in messages)
+
+
+async def test_wait_emits_resolution_event_on_fail_with_check_names(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.001")
+    monkeypatch.setenv("COG_CI_TIMEOUT_SECONDS", "10")
+    host = _make_host(checks_sequence=[_failed_checks("lint", "tests")])
+    wf = _make_wf(host=host)
+    sink = RecordingEventSink()
+    ctx = _make_ctx(tmp_path, event_sink=sink)
+
+    await wf._wait_for_ci(ctx, _make_pr())
+
+    messages = [e.message for e in sink.events if isinstance(e, StatusEvent)]
+    resolution = next(m for m in messages if "✗" in m)
+    assert "lint" in resolution
+    assert "tests" in resolution
+
+
+async def test_wait_emits_heartbeat_every_60s(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Heartbeat emitted after 60s of waiting."""
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.001")
+    monkeypatch.setenv("COG_CI_TIMEOUT_SECONDS", "10")
+
+    async def fake_sleep(_duration: float) -> None:
+        pass
+
+    time_values = [0.0, 0.0, 61.0, 61.0, 61.0]  # advance past 60s on 3rd call
+    time_idx = [0]
+
+    def fake_monotonic() -> float:
+        val = time_values[min(time_idx[0], len(time_values) - 1)]
+        time_idx[0] += 1
+        return val
+
+    # Returns pending twice then passed
+    sequence = [_pending_checks("ci"), _pending_checks("ci"), _passed_checks("ci")]
+    host = _make_host(checks_sequence=sequence)
+    wf = _make_wf(host=host)
+    sink = RecordingEventSink()
+    ctx = _make_ctx(tmp_path, event_sink=sink)
+
+    with (
+        patch("asyncio.sleep", side_effect=fake_sleep),
+        patch("cog.workflows.ralph.time.monotonic", side_effect=fake_monotonic),
+    ):
+        await wf._wait_for_ci(ctx, _make_pr())
+
+    messages = [e.message for e in sink.events if isinstance(e, StatusEvent)]
+    heartbeats = [m for m in messages if "passed," in m and "pending" in m]
+    assert len(heartbeats) >= 1
+
+
+async def test_wait_does_not_emit_heartbeat_before_first_interval_elapses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.001")
+    monkeypatch.setenv("COG_CI_TIMEOUT_SECONDS", "10")
+
+    # Time never advances past 60s
+    time_values = [0.0, 0.0, 1.0, 1.0, 2.0, 2.0]
+    time_idx = [0]
+
+    def fake_monotonic() -> float:
+        val = time_values[min(time_idx[0], len(time_values) - 1)]
+        time_idx[0] += 1
+        return val
+
+    async def fake_sleep(_: float) -> None:
+        pass
+
+    sequence = [_pending_checks("ci"), _passed_checks("ci")]
+    host = _make_host(checks_sequence=sequence)
+    wf = _make_wf(host=host)
+    sink = RecordingEventSink()
+    ctx = _make_ctx(tmp_path, event_sink=sink)
+
+    with (
+        patch("asyncio.sleep", side_effect=fake_sleep),
+        patch("cog.workflows.ralph.time.monotonic", side_effect=fake_monotonic),
+    ):
+        await wf._wait_for_ci(ctx, _make_pr())
+
+    messages = [e.message for e in sink.events if isinstance(e, StatusEvent)]
+    heartbeats = [m for m in messages if "passed," in m and "pending" in m]
+    assert len(heartbeats) == 0
+
+
+async def test_wait_cancellation_propagates_cancelled_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.001")
+    monkeypatch.setenv("COG_CI_TIMEOUT_SECONDS", "10")
+
+    async def forever_pending(_: int) -> PrChecks:
+        return _pending_checks("ci")
+
+    host = _make_host()
+    host.get_pr_checks.side_effect = forever_pending
+
+    async def cancelling_sleep(_: float) -> None:
+        raise asyncio.CancelledError
+
+    wf = _make_wf(host=host)
+    sink = RecordingEventSink()
+    ctx = _make_ctx(tmp_path, event_sink=sink)
+
+    with (
+        patch("asyncio.sleep", side_effect=cancelling_sleep),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await wf._wait_for_ci(ctx, _make_pr())
+
+
+async def test_wait_honors_cog_ci_poll_interval_env_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "99.5")
+    monkeypatch.setenv("COG_CI_TIMEOUT_SECONDS", "200")
+
+    sleep_args: list[float] = []
+
+    async def recording_sleep(duration: float) -> None:
+        sleep_args.append(duration)
+
+    host = _make_host(checks_sequence=[_pending_checks("ci"), _passed_checks("ci")])
+    wf = _make_wf(host=host)
+    sink = RecordingEventSink()
+    ctx = _make_ctx(tmp_path, event_sink=sink)
+
+    with patch("asyncio.sleep", side_effect=recording_sleep):
+        await wf._wait_for_ci(ctx, _make_pr())
+
+    assert any(abs(d - 99.5) < 0.01 for d in sleep_args)
+
+
+async def test_wait_honors_cog_ci_timeout_env_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A very small timeout causes the wait to raise TimeoutError."""
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.001")
+    monkeypatch.setenv("COG_CI_TIMEOUT_SECONDS", "0.01")
+
+    async def always_pending(_: int) -> PrChecks:
+        await asyncio.sleep(0.001)
+        return _pending_checks("ci")
+
+    host = _make_host()
+    host.get_pr_checks.side_effect = always_pending
+    wf = _make_wf(host=host)
+    sink = RecordingEventSink()
+    ctx = _make_ctx(tmp_path, event_sink=sink)
+
+    with pytest.raises(TimeoutError):
+        await wf._wait_for_ci(ctx, _make_pr())
+
+
+# ---------------------------------------------------------------------------
+# finalize_success + CI gate integration
+# ---------------------------------------------------------------------------
+
+
+async def test_finalize_success_calls_wait_for_ci_after_pr_creation(tmp_path: Path) -> None:
+    host = _make_host(checks_sequence=[_passed_checks("ci")])
+    wf = _make_wf(host=host)
+    ctx = _make_ctx(tmp_path)
+
+    with patch.object(wf, "_wait_for_ci", new_callable=AsyncMock) as mock_wait:
+        mock_wait.return_value = _passed_checks("ci")
+        await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
+
+    mock_wait.assert_awaited_once()
+    # Called with ctx and a PullRequest
+    assert isinstance(mock_wait.call_args.args[1], PullRequest)
+
+
+async def test_finalize_success_ci_pass_marks_processed_and_swaps_labels(tmp_path: Path) -> None:
+    tracker = _make_tracker()
+    host = _make_host(checks_sequence=[_passed_checks("ci")])
+    wf = _make_wf(tracker=tracker, host=host)
+    ctx = _make_ctx(tmp_path)
+
+    with patch.object(wf, "_wait_for_ci", new_callable=AsyncMock) as mock_wait:
+        mock_wait.return_value = _passed_checks("ci")
+        await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
+
+    assert ctx.state_cache.is_processed(ctx.item)
+    removed = [c.args[1] for c in tracker.remove_label.call_args_list]
+    assert "agent-ready" in removed
+
+
+async def test_finalize_success_ci_pass_writes_telemetry_with_outcome_success(
+    tmp_path: Path,
+) -> None:
+    tel = _make_telemetry()
+    host = _make_host()
+    wf = _make_wf(host=host)
+    ctx = _make_ctx(tmp_path, telemetry=tel)
+
+    with patch.object(wf, "_wait_for_ci", new_callable=AsyncMock) as mock_wait:
+        mock_wait.return_value = _passed_checks("ci")
+        await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
+
+    tel.write.assert_awaited_once()
+    assert tel.write.call_args.args[0].outcome == "success"
+
+
+async def test_finalize_success_ci_fail_comments_on_pr_with_failing_checks(tmp_path: Path) -> None:
+    host = _make_host()
+    wf = _make_wf(host=host)
+    ctx = _make_ctx(tmp_path)
+
+    failing = PrChecks(runs=(CheckRun(name="lint", state="failed", link="https://ci/lint"),))
+    with patch.object(wf, "_wait_for_ci", new_callable=AsyncMock) as mock_wait:
+        mock_wait.return_value = failing
+        await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
+
+    host.comment_on_pr.assert_awaited_once()
+    body = host.comment_on_pr.call_args.args[1]
+    assert "lint" in body
+    assert "https://ci/lint" in body
+
+
+async def test_finalize_success_ci_fail_comments_on_tracker_item(tmp_path: Path) -> None:
+    tracker = _make_tracker()
+    host = _make_host()
+    wf = _make_wf(tracker=tracker, host=host)
+    ctx = _make_ctx(tmp_path)
+
+    failing = _failed_checks("tests")
+    with patch.object(wf, "_wait_for_ci", new_callable=AsyncMock) as mock_wait:
+        mock_wait.return_value = failing
+        await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
+
+    # tracker.comment is called twice: once for PR URL, once for CI failure
+    assert tracker.comment.call_count == 2
+    ci_comment = tracker.comment.call_args_list[-1].args[1]
+    assert "CI failed" in ci_comment
+
+
+async def test_finalize_success_ci_fail_adds_agent_failed_label(tmp_path: Path) -> None:
+    tracker = _make_tracker()
+    host = _make_host()
+    wf = _make_wf(tracker=tracker, host=host)
+    ctx = _make_ctx(tmp_path)
+
+    with patch.object(wf, "_wait_for_ci", new_callable=AsyncMock) as mock_wait:
+        mock_wait.return_value = _failed_checks("ci")
+        await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
+
+    added = [c.args[1] for c in tracker.add_label.call_args_list]
+    assert "agent-failed" in added
+
+
+async def test_finalize_success_ci_fail_removes_agent_ready(tmp_path: Path) -> None:
+    tracker = _make_tracker()
+    host = _make_host()
+    wf = _make_wf(tracker=tracker, host=host)
+    ctx = _make_ctx(tmp_path)
+
+    with patch.object(wf, "_wait_for_ci", new_callable=AsyncMock) as mock_wait:
+        mock_wait.return_value = _failed_checks("ci")
+        await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
+
+    removed = [c.args[1] for c in tracker.remove_label.call_args_list]
+    assert "agent-ready" in removed
+
+
+async def test_finalize_success_ci_fail_marks_processed_with_ci_failed_outcome(
+    tmp_path: Path,
+) -> None:
+    host = _make_host()
+    wf = _make_wf(host=host)
+    ctx = _make_ctx(tmp_path)
+
+    with patch.object(wf, "_wait_for_ci", new_callable=AsyncMock) as mock_wait:
+        mock_wait.return_value = _failed_checks("ci")
+        await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
+
+    assert ctx.state_cache.is_processed(ctx.item)
+    assert ctx.state_cache._processed[ctx.state_cache._key(ctx.item)] == "ci-failed"
+
+
+async def test_finalize_success_ci_fail_writes_telemetry_with_cause_class_ci_checks_failed_error(
+    tmp_path: Path,
+) -> None:
+    tel = _make_telemetry()
+    host = _make_host()
+    wf = _make_wf(host=host)
+    ctx = _make_ctx(tmp_path, telemetry=tel)
+
+    with patch.object(wf, "_wait_for_ci", new_callable=AsyncMock) as mock_wait:
+        mock_wait.return_value = _failed_checks("ci")
+        await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
+
+    tel.write.assert_awaited_once()
+    record = tel.write.call_args.args[0]
+    assert record.outcome == "ci-failed"
+    assert record.cause_class == "CiChecksFailedError"
+
+
+async def test_finalize_success_ci_timeout_writes_telemetry_with_cause_class_ci_timeout_error(
+    tmp_path: Path,
+) -> None:
+    tel = _make_telemetry()
+    host = _make_host()
+    wf = _make_wf(host=host)
+    ctx = _make_ctx(tmp_path, telemetry=tel)
+
+    with patch.object(wf, "_wait_for_ci", new_callable=AsyncMock) as mock_wait:
+        mock_wait.side_effect = TimeoutError()
+        await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
+
+    tel.write.assert_awaited_once()
+    record = tel.write.call_args.args[0]
+    assert record.outcome == "ci-failed"
+    assert record.cause_class == "CiTimeoutError"

--- a/tests/test_workflows/test_ralph_ci_wait.py
+++ b/tests/test_workflows/test_ralph_ci_wait.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from cog.core.context import ExecutionContext
+from cog.core.errors import CiTimeoutError
 from cog.core.host import CheckRun, GitHost, PrChecks, PullRequest
 from cog.core.runner import StatusEvent
 from cog.core.tracker import IssueTracker
@@ -357,7 +358,7 @@ async def test_wait_honors_cog_ci_poll_interval_env_override(
 async def test_wait_honors_cog_ci_timeout_env_override(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A very small timeout causes the wait to raise TimeoutError."""
+    """A very small timeout causes the wait to raise CiTimeoutError."""
     monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.001")
     monkeypatch.setenv("COG_CI_TIMEOUT_SECONDS", "0.01")
 
@@ -371,8 +372,9 @@ async def test_wait_honors_cog_ci_timeout_env_override(
     sink = RecordingEventSink()
     ctx = _make_ctx(tmp_path, event_sink=sink)
 
-    with pytest.raises(TimeoutError):
+    with pytest.raises(CiTimeoutError) as exc_info:
         await wf._wait_for_ci(ctx, _make_pr())
+    assert exc_info.value.timeout_seconds == pytest.approx(0.01)
 
 
 # ---------------------------------------------------------------------------
@@ -528,7 +530,7 @@ async def test_finalize_success_ci_timeout_writes_telemetry_with_cause_class_ci_
     ctx = _make_ctx(tmp_path, telemetry=tel)
 
     with patch.object(wf, "_wait_for_ci", new_callable=AsyncMock) as mock_wait:
-        mock_wait.side_effect = TimeoutError()
+        mock_wait.side_effect = CiTimeoutError(timeout_seconds=1800.0)
         await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
 
     tel.write.assert_awaited_once()

--- a/tests/test_workflows/test_ralph_finalization.py
+++ b/tests/test_workflows/test_ralph_finalization.py
@@ -9,10 +9,10 @@ import pytest
 
 from cog.core.context import ExecutionContext
 from cog.core.errors import HostError, StageError
-from cog.core.host import GitHost, PullRequest
+from cog.core.host import GitHost, PrChecks, PullRequest
 from cog.core.tracker import IssueTracker
 from cog.workflows.ralph import RalphWorkflow, _split_final_message
-from tests.fakes import InMemoryStateCache, make_item, make_stage_result
+from tests.fakes import InMemoryStateCache, RecordingEventSink, make_item, make_stage_result
 
 
 @pytest.fixture(autouse=True)
@@ -56,6 +56,9 @@ def _make_host(*, pr: PullRequest | None = None, push_error: HostError | None = 
     host.get_pr_for_branch.return_value = pr
     host.create_pr.return_value = _make_pr()
     host.update_pr.return_value = None
+    host.comment_on_pr.return_value = None
+    # Default: all checks pass so CI wait resolves immediately
+    host.get_pr_checks.return_value = PrChecks(runs=())
     return host
 
 
@@ -89,6 +92,7 @@ def _make_ctx(
         item=make_item(item_id=item_id, title="Fix the bug"),
         work_branch=work_branch,
         telemetry=telemetry,
+        event_sink=RecordingEventSink(),
     )
 
 
@@ -457,6 +461,7 @@ async def test_finalize_success_saves_state_cache(tmp_path: Path) -> None:
         headless=True,
         item=make_item(item_id="42", title="Fix the bug"),
         work_branch="cog/42-fix",
+        event_sink=RecordingEventSink(),
     )
     await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
     cache.save.assert_called_once()
@@ -830,6 +835,7 @@ async def test_full_iteration_end_to_end_success(tmp_path: Path) -> None:
         tmp_dir=tmp_path,
         state_cache=cache,
         headless=True,
+        event_sink=RecordingEventSink(),
     )
 
     await StageExecutor().run(wf, ctx)
@@ -883,6 +889,7 @@ async def test_full_iteration_end_to_end_noop(tmp_path: Path) -> None:
         tmp_dir=tmp_path,
         state_cache=cache,
         headless=True,
+        event_sink=RecordingEventSink(),
     )
 
     await StageExecutor().run(wf, ctx)

--- a/tests/test_workflows/test_ralph_integration.py
+++ b/tests/test_workflows/test_ralph_integration.py
@@ -105,10 +105,13 @@ async def test_end_to_end_with_real_git(git_env: Path) -> None:
         created_at=datetime(2024, 1, 1, tzinfo=UTC),
     )
 
+    from cog.core.host import PrChecks
+
     tracker_mock = AsyncMock(spec=IssueTracker)
     tracker_mock.list_by_label = AsyncMock(return_value=[item])
     tracker_mock.get = AsyncMock(return_value=item)
     host_mock = AsyncMock(spec=GitHost)
+    host_mock.get_pr_checks.return_value = PrChecks(runs=())
 
     wf = RalphWorkflow(runner=EchoRunner(), tracker=tracker_mock, host=host_mock)
 
@@ -169,12 +172,15 @@ def _make_pr(number: int = 1, url: str = "https://github.com/org/repo/pull/1") -
 
 async def test_finalize_success_pr_body_with_structured_final_message(tmp_path: Path) -> None:
     """ScriptedFinalMessageRunner emitting structured output → all three sections in PR body."""
+    from cog.core.host import PrChecks as _PrChecks
+
     final_message = (_FIXTURE_DIR / "final_message_structured.md").read_text()
 
     tracker = AsyncMock(spec=IssueTracker)
     host = AsyncMock(spec=GitHost)
     host.push_branch.return_value = None
     host.get_pr_for_branch.return_value = None
+    host.get_pr_checks.return_value = _PrChecks(runs=())
     pr = _make_pr()
     host.create_pr.return_value = pr
 
@@ -214,12 +220,15 @@ async def test_finalize_success_pr_body_with_structured_final_message(tmp_path: 
 
 async def test_finalize_success_pr_body_with_unstructured_final_message(tmp_path: Path) -> None:
     """Terse final message → Summary = full message, no Key changes, test-plan fallback."""
+    from cog.core.host import PrChecks as _PrChecks
+
     final_message = (_FIXTURE_DIR / "final_message_terse.md").read_text().strip()
 
     tracker = AsyncMock(spec=IssueTracker)
     host = AsyncMock(spec=GitHost)
     host.push_branch.return_value = None
     host.get_pr_for_branch.return_value = None
+    host.get_pr_checks.return_value = _PrChecks(runs=())
     host.create_pr.return_value = _make_pr()
 
     wf = RalphWorkflow(

--- a/tests/test_workflows/test_ralph_rebase.py
+++ b/tests/test_workflows/test_ralph_rebase.py
@@ -547,7 +547,7 @@ async def test_clean_rebase_does_not_add_rebase_stage_to_telemetry_when_precheck
 
 
 async def test_finalize_success_calls_rebase_before_push(tmp_path: Path) -> None:
-    from cog.core.host import PullRequest
+    from cog.core.host import PrChecks, PullRequest
 
     host = AsyncMock(spec=GitHost)
     host.push_branch.return_value = None
@@ -570,9 +570,13 @@ async def test_finalize_success_calls_rebase_before_push(tmp_path: Path) -> None
         rebase_called.append(True)
         return RebaseOutcome(status="clean")
 
+    async def _fake_wait_ci(self_: object, ctx_: object, pr_: object) -> PrChecks:
+        return PrChecks(runs=())  # all_passed=True (no failing checks)
+
     with patch.object(RalphWorkflow, "_rebase_before_push", _fake_rebase):
-        with patch.object(wf, "write_report", new_callable=AsyncMock):
-            await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
+        with patch.object(RalphWorkflow, "_wait_for_ci", _fake_wait_ci):
+            with patch.object(wf, "write_report", new_callable=AsyncMock):
+                await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
 
     assert rebase_called
 

--- a/tests/test_workflows/test_ralph_resume.py
+++ b/tests/test_workflows/test_ralph_resume.py
@@ -9,10 +9,10 @@ import pytest
 
 from cog.core.context import ExecutionContext
 from cog.core.errors import HostError, TrackerError
-from cog.core.host import GitHost, PullRequest
+from cog.core.host import GitHost, PrChecks, PullRequest
 from cog.core.tracker import IssueTracker
 from cog.workflows.ralph import RalphWorkflow
-from tests.fakes import InMemoryStateCache, make_item, make_stage_result
+from tests.fakes import InMemoryStateCache, RecordingEventSink, make_item, make_stage_result
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -59,6 +59,8 @@ def _make_host(*, pr: PullRequest | None = None) -> AsyncMock:
         head_branch="cog/42-fix",
     )
     host.update_pr.return_value = None
+    host.comment_on_pr.return_value = None
+    host.get_pr_checks.return_value = PrChecks(runs=())
     return host
 
 
@@ -284,6 +286,7 @@ def _make_ctx_with_tmp(tmp_path: Path, *, item_id: str = "42") -> ExecutionConte
         headless=True,
         item=make_item(item_id=item_id, title="Fix the bug"),
         work_branch="cog/42-fix-the-bug",
+        event_sink=RecordingEventSink(),
     )
 
 


### PR DESCRIPTION
## Summary

Implements #22's wait-for-CI gate: after `finalize_success` creates a PR, ralph polls `gh pr checks` until all checks resolve (pass or fail) or the 30-minute timeout fires. On pass → existing label-swap + mark-processed + telemetry as today. On fail → PR gets a comment listing failing checks, item gets `agent-failed` added + `agent-ready` removed, state-cached as `ci-failed`.

Structured so #101 (Part 2 — reproduce + fix) can replace `_handle_ci_failure`'s body without touching the surrounding flow.

## Key changes

- **`GitHost.get_pr_checks(number) → PrChecks`** new ABC method. `PrChecks` wraps a tuple of `CheckRun(name, state, link, description)` where state is `pending | passed | failed | skipped`. GitHub implementation shells out to `gh pr checks <N> --json ...` and maps gh state strings to our literal set.
- **`GitHost.comment_on_pr(number, body)`** new ABC method for posting the failing-checks comment to the PR itself (distinct from commenting on the item).
- **`StatusEvent(message)`** new event type on the `RunEvent` union for workflow-emitted status (\"⏳ Waiting for CI on PR #N...\", heartbeat, \"✓ All CI checks passed\"). Rendered by `LogPaneWidget` / `ChatPaneWidget` / `StderrEventSink`.
- **`RalphWorkflow.finalize_success` restructure** — after PR create/update, call `_wait_for_ci(ctx, pr)`; branch on `checks.all_passed` to either `_mark_ci_success` (existing label swap + telemetry + report) or `_handle_ci_failure` (new abandon path). Extension point for #101.
- **`_wait_for_ci` poll loop** — Python-side loop (not `gh --watch`) with 15s poll interval (env-overridable via `COG_CI_POLL_INTERVAL_SECONDS`), 30min timeout (`COG_CI_TIMEOUT_SECONDS`), 60s heartbeat status events. `asyncio.timeout` raises `CiTimeoutError` on ceiling.
- **`CiError` / `CiChecksFailedError` / `CiTimeoutError`** new error classes in `src/cog/core/errors.py`. `cause_class` field (from #73) distinguishes timeout vs check-fail in telemetry.
- **`ci-failed` added to `TelemetryOutcome` literal**. README updated to document the new outcome value.

## Test plan

- [ ] Run `cog ralph` against an item whose PR will pass CI → iteration completes as today; telemetry entry has `outcome=success`, stage table unchanged.
- [ ] Introduce a deliberately broken test on a work branch → `cog ralph` iteration reaches the CI-wait, sees the failure, posts a comment on the PR listing failing check names + links, applies `agent-failed` label, removes `agent-ready`, marks processed with `outcome=ci-failed`, `cause_class=CiChecksFailedError`.
- [ ] During an active wait, verify `LogPane` / stderr shows the `⏳ Waiting for CI on PR #N...` start line plus per-60s heartbeat updates.
- [ ] Set `COG_CI_TIMEOUT_SECONDS=10` and trigger a slow CI run → wait times out after 10s; telemetry has `cause_class=CiTimeoutError`; abandon path fires identically to check-fail.
- [ ] Ctrl-C during the wait → cancellation panel; item retains `agent-ready`; state cache unchanged.
- [ ] Inspect `runs.jsonl` post-fix for a representative sample of iterations — every `ci-failed` entry has a populated `cause_class`.

## Closes

Closes #22

---

Branch was rebased onto main to pick up #33 (rebase stage), #78 (StreamReader buffer), #103 (tool-aware stall), #107 (cadence guidance). Conflict-resolved in `src/cog/core/errors.py` (added both RebaseUnresolvedError + CiError classes), `src/cog/telemetry.py` (union of both outcomes), `src/cog/workflows/ralph.py` (merged imports + finalize_success flow: rebase → push → PR → CI wait). Test fixture added to `tests/test_workflows/test_ralph_ci_wait.py` to patch `_rebase_before_push` since those tests call `finalize_success` (matches the pattern used by other ralph test files after #33 landed).

Previous PR body generated by ralph didn't follow the `### Summary / ### Key changes / ### Test plan` format — rewritten here by hand. #107 (cadence) should prevent this class of issue in future iterations.