### PR TITLE
Ralph build + review prompts: testing / linting cadence + commit discipline (#107)

### DIFF
--- a/src/cog/prompts/claude/ralph/build.md
+++ b/src/cog/prompts/claude/ralph/build.md
@@ -61,6 +61,43 @@ has been observed to hang indefinitely. To avoid this:
   `head -c 30000` or equivalent defensively.
 - Prefer per-file inspection via `Read <file>` over broad shell expansions.
 
+## Testing and linting cadence
+
+Tool calls inside the sandbox are expensive. Each test-suite or type-check
+invocation typically rebuilds the project's dependency environment
+(~30-60s cold) before running the tool itself. Running these after every
+small edit adds up fast and dominates iteration wall-clock.
+
+Default cadence:
+
+- **During iteration**: run only the test file(s) affected by your
+  current change. Pass a specific test file (not the whole suite) to
+  the project's test runner. Fail-fast flags (e.g., `-x` for pytest,
+  `-failfast` for go test, equivalents elsewhere) help you see the
+  first error quickly.
+- **After you have all intended changes complete**: run the full test
+  suite and any additional verification (type checker, linter) once
+  each to confirm.
+- **Type checkers**: run once at the end, not after every edit.
+- **Linters / formatters**: run once at the end. They're fast but
+  routinely produce auto-fixable nits that don't affect your logic.
+
+Full-suite and type-check runs during iteration should be the exception,
+not the routine. If an unexpected test starts failing after a final
+full-suite run, expand back to targeted runs to isolate.
+
+Consult the project's CLAUDE.md for the specific commands (test runner,
+type checker, linter) this project uses. If CLAUDE.md doesn't list them,
+infer from the project's config files (pyproject.toml, package.json,
+go.mod, etc.).
+
+## Commit discipline
+
+Commit once your intended change passes the full suite, not after each
+fix within an iteration. Multiple commits within one iteration are fine
+only if they represent distinct logical moves (e.g., "refactor X" then
+"add feature Y"), not "fix first typo, fix second typo."
+
 ## Final message format
 
 End your final message with three structured sections in this order:

--- a/src/cog/prompts/claude/ralph/review.md
+++ b/src/cog/prompts/claude/ralph/review.md
@@ -54,6 +54,36 @@ has been observed to hang indefinitely. To avoid this:
 - Prefer per-file inspection via `Read <file>` over patch-level inspection
   via `git diff`.
 
+## Testing and linting cadence
+
+Tool calls inside the sandbox are expensive. Each test-suite or type-check
+invocation typically rebuilds the project's dependency environment
+(~30-60s cold) before running the tool itself. Running these after every
+small edit adds up fast and dominates iteration wall-clock.
+
+Default cadence:
+
+- **During iteration**: run only the test file(s) affected by your
+  current change. Pass a specific test file (not the whole suite) to
+  the project's test runner. Fail-fast flags (e.g., `-x` for pytest,
+  `-failfast` for go test, equivalents elsewhere) help you see the
+  first error quickly.
+- **After you have all intended changes complete**: run the full test
+  suite and any additional verification (type checker, linter) once
+  each to confirm.
+- **Type checkers**: run once at the end, not after every edit.
+- **Linters / formatters**: run once at the end. They're fast but
+  routinely produce auto-fixable nits that don't affect your logic.
+
+Full-suite and type-check runs during iteration should be the exception,
+not the routine. If an unexpected test starts failing after a final
+full-suite run, expand back to targeted runs to isolate.
+
+Consult the project's CLAUDE.md for the specific commands (test runner,
+type checker, linter) this project uses. If CLAUDE.md doesn't list them,
+infer from the project's config files (pyproject.toml, package.json,
+go.mod, etc.).
+
 ## Git rules (hard)
 
 - Make commits locally; do not push them.

--- a/tests/test_workflows/test_ralph_prompts.py
+++ b/tests/test_workflows/test_ralph_prompts.py
@@ -209,3 +209,76 @@ def test_build_prompt_test_plan_defers_to_claude_md():
     content = _load_prompt("build")
     test_plan = _test_plan_section(content)
     assert "CLAUDE.md" in test_plan
+
+
+def _cadence_section(content: str) -> str:
+    match = re.search(r"## Testing and linting cadence\n(.*?)(?=\n## |\Z)", content, re.DOTALL)
+    assert match, "## Testing and linting cadence section not found"
+    return match.group(1)
+
+
+def test_build_prompt_has_testing_cadence_section():
+    content = _load_prompt("build")
+    assert "## Testing and linting cadence" in content
+
+
+def test_build_prompt_cadence_describes_target_specific_file_during_iteration():
+    content = _load_prompt("build")
+    cadence = _cadence_section(content)
+    assert "specific test file" in cadence or "test file(s)" in cadence
+
+
+def test_build_prompt_cadence_describes_full_suite_only_at_end():
+    content = _load_prompt("build")
+    cadence = _cadence_section(content)
+    assert "full test" in cadence or "full suite" in cadence
+
+
+def test_build_prompt_cadence_mentions_type_checker_and_linter_once_at_end():
+    content = _load_prompt("build")
+    cadence = _cadence_section(content)
+    assert "type checker" in cadence or "Type checker" in cadence
+    assert "linter" in cadence.lower()
+
+
+def test_build_prompt_cadence_is_language_agnostic():
+    content = _load_prompt("build")
+    cadence = _cadence_section(content)
+    # Tool names may appear only as parenthetical examples following "e.g.,"
+    for tool in ("pytest", "mypy", "ruff"):
+        # Strip all "e.g., ..." parentheticals and check no bare references remain
+        stripped = re.sub(r"e\.g\.,\s*[^)]+", "", cadence)
+        assert tool not in stripped, (
+            f"'{tool}' appears outside a parenthetical e.g. example in cadence section"
+        )
+
+
+def test_build_prompt_references_claude_md_for_project_commands():
+    content = _load_prompt("build")
+    cadence = _cadence_section(content)
+    assert "CLAUDE.md" in cadence
+
+
+def test_build_prompt_has_commit_discipline_section():
+    content = _load_prompt("build")
+    assert "## Commit discipline" in content
+
+
+def test_review_prompt_has_testing_cadence_section():
+    content = _load_prompt("review")
+    assert "## Testing and linting cadence" in content
+
+
+def test_review_prompt_cadence_is_language_agnostic():
+    content = _load_prompt("review")
+    cadence = _cadence_section(content)
+    for tool in ("pytest", "mypy", "ruff"):
+        stripped = re.sub(r"e\.g\.,\s*[^)]+", "", cadence)
+        assert tool not in stripped, (
+            f"'{tool}' appears outside a parenthetical e.g. example in review cadence section"
+        )
+
+
+def test_review_prompt_does_not_have_commit_discipline_section():
+    content = _load_prompt("review")
+    assert "## Commit discipline" not in content


### PR DESCRIPTION
## Summary

### Summary

Added "Testing and linting cadence" to both `build.md` and `review.md`, and "Commit discipline" to `build.md` only, as specified in #107. Both sections are placed immediately after `## Bounded tool calls (important)`. Language is project-agnostic — `pytest`/`mypy`/`ruff` appear only as parenthetical `e.g.` examples. 10 new regression tests pin the content.

### Key changes

- `src/cog/prompts/claude/ralph/build.md` — new `## Testing and linting cadence` section (targeted runs during iteration, full suite + type checker + linter once at end) and `## Commit discipline` section (commit per logical move, not per fix)
- `src/cog/prompts/claude/ralph/review.md` — same `## Testing and linting cadence` section; no commit discipline (review stage rarely commits)
- `tests/test_workflows/test_ralph_prompts.py` — 10 new content-regression tests covering cadence presence, targeted-file guidance, full-suite-at-end guidance, type checker/linter cadence, language-agnosticism, CLAUDE.md reference, commit discipline in build, cadence in review, language-agnosticism in review, and absence of commit discipline in review

## Closes

Closes #107

## Test plan


- [ ] Read `src/cog/prompts/claude/ralph/build.md` and confirm `## Testing and linting cadence` appears after `## Bounded tool calls (important)` and before `## Commit discipline`, which itself appears before `## Final message format`
- [ ] Read `src/cog/prompts/claude/ralph/review.md` and confirm `## Testing and linting cadence` appears after `## Bounded tool calls (important)` and that `## Commit discipline` is absent
- [ ] Confirm neither cadence section contains bare references to `pytest`, `mypy`, or `ruff` outside a parenthetical `e.g.` clause
- [ ] Confirm both cadence sections mention `CLAUDE.md` as the authority for project-specific commands
- [ ] Confirm `build.md`'s commit discipline section says to commit once the full suite passes, not after each fix
- [ ] Run a cog ralph iteration on a comparable agent-ready issue; observe that ralph runs targeted test files during iteration and full suite only at completion — compare cost and turn count against the baseline ($7.39 / ~300 turns)

---
🤖 Generated by [ralph](https://github.com/jessiepuls/ralph). Iteration cost: $1.07.