### PR TITLE
ClaudeCliRunner: raise asyncio StreamReader line limit to prevent ValueError on large stream-json events (#78)

### DIFF
--- a/src/cog/runners/claude_cli.py
+++ b/src/cog/runners/claude_cli.py
@@ -58,6 +58,25 @@ def _parse_float_env(name: str, default: float) -> float:
         return default
 
 
+def _parse_int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        print(
+            f"WARNING: {name}={raw!r} is not a valid integer; defaulting to {default}",
+            file=sys.stderr,
+        )
+        return default
+
+
+# 16 MiB: 256× the observed worst-case line (~64 KiB). Per-line RAM is
+# transient — the buffer is cleared after each line is parsed.
+_STREAM_LINE_LIMIT_BYTES = _parse_int_env("COG_STREAM_LINE_LIMIT_BYTES", 16 * 1024 * 1024)
+
+
 class ClaudeCliRunner(AgentRunner):
     def __init__(self, sandbox: Sandbox) -> None:
         self._sandbox = sandbox
@@ -89,7 +108,9 @@ class ClaudeCliRunner(AgentRunner):
         )
         env = self._sandbox.wrap_env(dict(os.environ))
 
-        proc = await asyncio.create_subprocess_exec(*argv, env=env, stdout=PIPE, stderr=PIPE)
+        proc = await asyncio.create_subprocess_exec(
+            *argv, env=env, stdout=PIPE, stderr=PIPE, limit=_STREAM_LINE_LIMIT_BYTES
+        )
         assert proc.stdout is not None  # guaranteed by stdout=PIPE
         # Drain stderr concurrently so the pipe buffer (~64KB on Linux) can't fill and
         # block claude's stderr writes — which would cascade into stdout stalling and

--- a/tests/test_runners/test_claude_cli_line_limit.py
+++ b/tests/test_runners/test_claude_cli_line_limit.py
@@ -1,0 +1,106 @@
+"""Tests for the ClaudeCliRunner asyncio StreamReader line-limit fix.
+
+Large stream-json events (e.g. tool_result from a big Read) can exceed asyncio's
+default 64 KiB per-line limit and raise ValueError. These tests verify the limit
+is raised to the configured value and that large lines parse successfully.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from cog.core.runner import ResultEvent, RunEvent
+from cog.runners.claude_cli import ClaudeCliRunner, _parse_int_env
+from tests.test_runners.helpers import RecordingSandbox
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _RealSubprocessSandbox(RecordingSandbox):
+    """Sandbox that replaces the simulated claude argv with a python3 one-liner."""
+
+    def __init__(self, python_snippet: str) -> None:
+        super().__init__()
+        self._snippet = python_snippet
+
+    def wrap_argv(self, argv):  # type: ignore[override]
+        return ["python3", "-c", self._snippet]
+
+
+async def _collect(stream) -> list[RunEvent]:
+    return [event async for event in stream]
+
+
+def _result_line(cost: float = 0.0) -> str:
+    return json.dumps({"type": "result", "total_cost_usd": cost, "exit_status": 0})
+
+
+# ---------------------------------------------------------------------------
+# Real-subprocess tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_runner_handles_single_line_above_64kib():
+    # Emit one assistant message whose JSON encoding is ~100 KiB — well above
+    # asyncio's 64 KiB default limit — then a valid result line. The runner
+    # must parse both without raising ValueError.
+    big_text = "x" * 100_000
+    assistant_line = json.dumps(
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": big_text}]},
+        }
+    )
+    snippet = (
+        f"import sys\nprint({assistant_line!r})\nprint({_result_line()!r})\nsys.stdout.flush()\n"
+    )
+    sandbox = _RealSubprocessSandbox(snippet)
+    runner = ClaudeCliRunner(sandbox)
+
+    events = await asyncio.wait_for(_collect(runner.stream("ignored", model="m")), timeout=10.0)
+
+    assert any(isinstance(e, ResultEvent) for e in events)
+
+
+@pytest.mark.asyncio
+async def test_runner_completes_normally_with_small_lines():
+    # Baseline regression guard: normal small-line output still works.
+    snippet = f"import sys\nprint({_result_line(0.42)!r})\nsys.stdout.flush()\n"
+    sandbox = _RealSubprocessSandbox(snippet)
+    runner = ClaudeCliRunner(sandbox)
+
+    events = await asyncio.wait_for(_collect(runner.stream("ignored", model="m")), timeout=10.0)
+
+    results = [e for e in events if isinstance(e, ResultEvent)]
+    assert len(results) == 1
+    assert results[0].result.total_cost_usd == pytest.approx(0.42)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _parse_int_env and the limit constant
+# ---------------------------------------------------------------------------
+
+
+def test_line_limit_defaults_to_16_mib_when_env_unset(monkeypatch):
+    monkeypatch.delenv("COG_STREAM_LINE_LIMIT_BYTES", raising=False)
+    assert _parse_int_env("COG_STREAM_LINE_LIMIT_BYTES", 16 * 1024 * 1024) == 16 * 1024 * 1024
+
+
+def test_line_limit_honors_cog_stream_line_limit_bytes_env_override(monkeypatch):
+    monkeypatch.setenv("COG_STREAM_LINE_LIMIT_BYTES", "131072")
+    assert _parse_int_env("COG_STREAM_LINE_LIMIT_BYTES", 16 * 1024 * 1024) == 131072
+
+
+def test_line_limit_invalid_env_value_warns_and_uses_default(monkeypatch, capsys):
+    monkeypatch.setenv("COG_STREAM_LINE_LIMIT_BYTES", "not-a-number")
+    result = _parse_int_env("COG_STREAM_LINE_LIMIT_BYTES", 16 * 1024 * 1024)
+    assert result == 16 * 1024 * 1024
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.err
+    assert "COG_STREAM_LINE_LIMIT_BYTES" in captured.err

--- a/tests/test_runners/test_claude_cli_sandbox.py
+++ b/tests/test_runners/test_claude_cli_sandbox.py
@@ -1,6 +1,8 @@
 """Tests for ClaudeCliRunner sandbox integration."""
 
-from cog.runners.claude_cli import ClaudeCliRunner
+from unittest.mock import AsyncMock, patch
+
+from cog.runners.claude_cli import _STREAM_LINE_LIMIT_BYTES, ClaudeCliRunner
 from tests.test_runners.helpers import RecordingSandbox, fixture_proc, patch_exec
 
 
@@ -57,3 +59,16 @@ async def test_prepare_called_each_stream_invocation():
         async for _ in runner.stream("second", model="claude-sonnet-4-5"):
             pass
     assert sandbox.prepare_calls == 2
+
+
+async def test_create_subprocess_exec_is_called_with_limit_kwarg():
+    sandbox = RecordingSandbox()
+    proc = fixture_proc("happy.jsonl")
+    runner = ClaudeCliRunner(sandbox)
+    mock = AsyncMock(return_value=proc)
+    with patch("cog.runners.claude_cli.asyncio.create_subprocess_exec", new=mock):
+        async for _ in runner.stream("hello", model="claude-sonnet-4-5"):
+            pass
+    _, kwargs = mock.call_args
+    assert "limit" in kwargs
+    assert kwargs["limit"] == _STREAM_LINE_LIMIT_BYTES


### PR DESCRIPTION
## Summary



## Closes

Closes #78

## Test plan


- [ ] Run `COG_STREAM_LINE_LIMIT_BYTES=65537 cog ralph` against any item that causes Claude to `Read` a file larger than ~64 KiB — confirm `ValueError: Separator is found, but chunk is longer than limit` surfaces (proving the env threading works and the old limit was the culprit).
- [ ] Run the same item without the env override — confirm it completes without a `ValueError`.
- [ ] Check telemetry after a real run: no `cause_class=ValueError` entries matching the "chunk is longer than limit" pattern.
- [ ] Verify `uv run pytest` passes (765 tests, 3 docker skips).
- [ ] Verify `uv run mypy src` exits 0.
- [ ] Verify `uv run ruff check . && uv run ruff format --check .` exit 0.
- [ ] In a Python REPL, confirm `from cog.runners.claude_cli import _STREAM_LINE_LIMIT_BYTES` gives `16777216` (16 MiB) with no env var set.
- [ ] Set `COG_STREAM_LINE_LIMIT_BYTES=not-a-number` and confirm a `WARNING:` line appears on stderr at runner import time with the correct fallback value.

---
🤖 Generated by [ralph](https://github.com/jessiepuls/ralph). Iteration cost: $1.13.