### PR TITLE
Ralph workflow: rebase onto updated default branch before push (claude-driven, conflict auto-resolve) (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Status: early development — not yet usable. See the open issues for the v1 pla
 ## Commands
 
     cog                   Launch the main menu (TUI)
-    cog ralph             Autonomous agent: picks next agent-ready issue, runs build/review/document, opens PR
+    cog ralph             Autonomous agent: picks next agent-ready issue, runs build/review/document/rebase, opens PR
     cog refine            Interactive: refine a needs-refinement issue and rewrite it
 
 Options for `cog ralph`:
@@ -89,7 +89,7 @@ Key fields:
 | Field | Type | Description |
 |-------|------|-------------|
 | `ts` | string | ISO-8601 UTC timestamp |
-| `outcome` | string | `success`, `error`, `no-op`, `push-failed`, `deferred-by-blocker` |
+| `outcome` | string | `success`, `error`, `no-op`, `push-failed`, `deferred-by-blocker`, `rebase-conflict` |
 | `stages` | array | Per-stage entry with `stage`, `duration_s`, `cost_usd`, `exit_status`, `commits`; for `cog refine` the first entry is `"interview"` |
 | `total_cost_usd` | float | Sum of stage costs |
 | `duration_seconds` | float | Wall time across all stages |
@@ -98,7 +98,7 @@ Key fields:
 | `pr_url` | string\|null | PR URL if one was opened |
 
 `cause_class` is populated when a stage fails with a classifiable runner error — useful for filtering
-retry-eligible failures (`RunnerStalledError`, `RunnerTimeoutError`) from logic errors in telemetry queries.
+retry-eligible failures (`RunnerStalledError`, `RunnerTimeoutError`, `RebaseUnresolvedError`) from logic errors in telemetry queries.
 
 When a stage fails after the runner has done real work (e.g. committed code), the partial result is
 preserved: `stages` will contain an entry for the failed stage with accurate `duration_s`, `cost_usd`,

--- a/src/cog/core/errors.py
+++ b/src/cog/core/errors.py
@@ -75,3 +75,13 @@ class DockerImageBuildError(SandboxError):
 
 class GitError(Exception):
     """Non-zero exit or unexpected output from a git subprocess."""
+
+
+class RebaseUnresolvedError(Exception):
+    """Raised (conceptually) when claude's rebase stage exits mid-state."""
+
+    def __init__(self, final_message: str) -> None:
+        self.final_message = final_message
+        super().__init__(
+            f"Rebase could not be completed by claude. Analysis: {final_message[:200]}"
+        )

--- a/src/cog/git.py
+++ b/src/cog/git.py
@@ -93,5 +93,5 @@ async def rebase_in_progress(project_dir: Path) -> bool:
 
 
 async def rebase_abort(project_dir: Path) -> None:
-    """`git rebase --abort`. No-op if no rebase in progress."""
+    """`git rebase --abort`. Raises GitError if no rebase is in progress."""
     await _run(["git", "rebase", "--abort"], project_dir)

--- a/src/cog/git.py
+++ b/src/cog/git.py
@@ -80,3 +80,18 @@ async def log_short_shas(project_dir: Path, revision_range: str) -> list[str]:
         project_dir,
     )
     return [s for s in result.splitlines() if s]
+
+
+async def rebase_in_progress(project_dir: Path) -> bool:
+    """True if a git rebase is currently paused (conflict or interactive).
+
+    Checks for .git/rebase-merge/ or .git/rebase-apply/ — git's canonical
+    mid-rebase markers.
+    """
+    git_dir = project_dir / ".git"
+    return (git_dir / "rebase-merge").is_dir() or (git_dir / "rebase-apply").is_dir()
+
+
+async def rebase_abort(project_dir: Path) -> None:
+    """`git rebase --abort`. No-op if no rebase in progress."""
+    await _run(["git", "rebase", "--abort"], project_dir)

--- a/src/cog/prompts/claude/ralph/rebase.md
+++ b/src/cog/prompts/claude/ralph/rebase.md
@@ -1,0 +1,35 @@
+# Ralph: rebase before push
+
+The work branch has completed its stages. Before pushing, rebase it onto
+`origin/<default>` so the PR opens without merge-conflict noise.
+
+## Steps
+
+1. Run `git fetch origin` to make sure you have the latest.
+2. Run `git rebase origin/<default>` (replace `<default>` with the actual
+   default branch name, e.g. `origin/main`).
+3. If the rebase is clean: done. Exit normally.
+4. If conflicts: inspect the unmerged files, understand both sides,
+   produce a meaningful merged version, `git add`, `git rebase --continue`.
+   Repeat for each conflicting commit until the rebase completes.
+5. If you cannot semantically resolve a conflict (e.g., both sides made
+   genuinely incompatible decisions that need a human to arbitrate):
+   run `git rebase --abort` and exit WITHOUT completing. Explain in your
+   final message what you saw and why you could not resolve it.
+
+The wrapper will `git rebase --abort` as a safety net if you leave the
+rebase mid-state. No prose / commit expectations from you on the
+clean-rebase path — you are just driving `git`.
+
+## Bounded tool calls (important)
+
+Claude Code persists any single tool output >30KB to a session-scoped file
+and tells you to `Read` that file. In this container, the subsequent `Read`
+has been observed to hang indefinitely. To avoid this:
+
+- Do NOT run `git diff` without bounds on large repos.
+- Do NOT run `grep -r` over the whole repo.
+- When running a command that might produce large output, pipe through
+  `head -c 30000` or equivalent defensively.
+- Use `Read <file>` to inspect specific conflict files rather than broad
+  shell expansions.

--- a/src/cog/telemetry.py
+++ b/src/cog/telemetry.py
@@ -13,7 +13,14 @@ from cog import __version__ as cog_version
 from cog.core.item import Item
 from cog.core.outcomes import StageResult
 
-TelemetryOutcome = Literal["success", "no-op", "error", "push-failed", "deferred-by-blocker"]
+TelemetryOutcome = Literal[
+    "success",
+    "no-op",
+    "error",
+    "push-failed",
+    "deferred-by-blocker",
+    "rebase-conflict",
+]
 
 
 @dataclass(frozen=True)

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -6,6 +6,7 @@ import os
 import re
 import sys
 from collections.abc import Callable
+from dataclasses import dataclass
 from importlib.resources import files
 from pathlib import Path
 from typing import ClassVar, Literal
@@ -13,17 +14,24 @@ from typing import ClassVar, Literal
 import cog.git as git
 from cog.checks import RALPH_CHECKS
 from cog.core.context import ExecutionContext
-from cog.core.errors import HostError, StageError, TrackerError
+from cog.core.errors import GitError, HostError, RebaseUnresolvedError, StageError, TrackerError
 from cog.core.host import GitHost
 from cog.core.item import Item
 from cog.core.outcomes import Outcome, StageResult
 from cog.core.runner import AgentRunner
 from cog.core.stage import Stage
 from cog.core.tracker import IssueTracker
-from cog.core.workflow import Workflow
+from cog.core.workflow import StageExecutor, Workflow
 from cog.state_paths import project_slug, project_state_dir
 from cog.telemetry import TelemetryRecord
 from cog.ui.widgets.log_pane import LogPaneWidget
+
+
+@dataclass(frozen=True)
+class RebaseOutcome:
+    status: Literal["clean", "conflict"]
+    final_message: str = ""  # claude's analysis on conflict; empty on clean
+
 
 _PRIORITY_RE = re.compile(r"^p(\d+)$")
 _SLUG_RE = re.compile(r"[^a-z0-9-]+")
@@ -235,6 +243,12 @@ class RalphWorkflow(Workflow):
     ) -> None:
         assert ctx.item is not None and ctx.work_branch is not None
         assert self._host is not None, "RalphWorkflow.finalize_success requires host"
+
+        rebase = await self._rebase_before_push(ctx)
+        if rebase.status == "conflict":
+            await self._handle_rebase_conflict(ctx, results, rebase.final_message)
+            return
+
         try:
             await self._host.push_branch(ctx.work_branch)
         except HostError as e:
@@ -425,6 +439,83 @@ class RalphWorkflow(Workflow):
             body += f"\n⚠ Document stage failed: {doc.error}. Docs may be out of date.\n"
         return body
 
+    async def _rebase_before_push(self, ctx: ExecutionContext) -> RebaseOutcome:
+        assert ctx.work_branch is not None
+        default = await git.default_branch(ctx.project_dir)
+        await git.fetch_origin(ctx.project_dir)
+
+        # Cheap pre-check: skip stage invocation when work branch already
+        # contains everything from origin/<default>. Common no-op on quiet
+        # iterations; saves ~$0.05-0.10 per iteration.
+        try:
+            behind = await git.commits_between(
+                ctx.project_dir, ctx.work_branch, f"origin/{default}"
+            )
+        except GitError:
+            # Transient git error — assume rebase is needed, fall through.
+            behind = 1
+
+        if behind == 0:
+            return RebaseOutcome(status="clean")
+
+        stage = Stage(
+            name="rebase",
+            prompt_source=_make_prompt_source("rebase"),
+            model=os.environ.get("COG_RALPH_BUILD_MODEL", "claude-sonnet-4-6"),
+            runner=self._runner,
+            tolerate_failure=False,
+        )
+        result = await StageExecutor()._run_stage(stage, ctx)
+
+        if await git.rebase_in_progress(ctx.project_dir):
+            # Claude exited mid-rebase — safety net abort.
+            await git.rebase_abort(ctx.project_dir)
+            return RebaseOutcome(status="conflict", final_message=result.final_message)
+
+        return RebaseOutcome(status="clean")
+
+    async def _handle_rebase_conflict(
+        self,
+        ctx: ExecutionContext,
+        results: list[StageResult],
+        claude_final_message: str,
+    ) -> None:
+        assert ctx.item is not None
+        default = await git.default_branch(ctx.project_dir)
+        body = (
+            f"🤖 Cog finished stages but could not rebase onto the latest "
+            f"`origin/{default}` due to conflicts claude couldn't semantically "
+            f"resolve.\n\n"
+            f"Claude's analysis:\n\n> {claude_final_message}\n\n"
+            f"The work branch is intact locally. Cog will retry on the next "
+            f"`cog ralph` invocation — the conflict may resolve once main "
+            f"advances further, or a human can resolve manually and re-run."
+        )
+        await self._tracker.comment(ctx.item, body)
+
+        # Additive agent-failed signal (matches #51 pattern)
+        await self._tracker.ensure_label(
+            "agent-failed",
+            color="d93f0b",
+            description="Cog attempted this and hit an error; retry is still eligible",
+        )
+        await self._tracker.add_label(ctx.item, "agent-failed")
+
+        # Keep agent-ready — user / next iteration re-triggers.
+        # Don't mark_processed — item stays eligible.
+        # Prevent same-loop re-pick.
+        self._processed_this_loop.add((ctx.item.tracker_id, ctx.item.item_id))
+
+        err = RebaseUnresolvedError(final_message=claude_final_message)
+        await self._write_telemetry(
+            ctx,
+            results,
+            "rebase-conflict",
+            error=err,
+            cause_class=type(err).__name__,
+        )
+        await self.write_report(ctx, results, "error", error=err)
+
     async def _handle_push_failed(
         self,
         ctx: ExecutionContext,
@@ -464,13 +555,14 @@ class RalphWorkflow(Workflow):
         *,
         pr_url: str | None = None,
         error: Exception | None = None,
+        cause_class: str | None = None,
     ) -> None:
         error_str: str | None = None
-        cause_class: str | None = None
+        resolved_cause_class = cause_class
         if error is not None:
             error_str = str(error)
-            if isinstance(error, StageError) and error.cause is not None:
-                cause_class = type(error.cause).__name__
+            if cause_class is None and isinstance(error, StageError) and error.cause is not None:
+                resolved_cause_class = type(error.cause).__name__
         if ctx.telemetry is None:
             return
         resumed = self._resumed_this_iteration.get(ctx.item.item_id, False)  # type: ignore[union-attr]
@@ -484,7 +576,7 @@ class RalphWorkflow(Workflow):
             pr_url=pr_url,
             duration_seconds=sum(r.duration_seconds for r in results),
             error=error_str,
-            cause_class=cause_class,
+            cause_class=resolved_cause_class,
             resumed=resumed,
         )
         await ctx.telemetry.write(record)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -17,6 +17,8 @@ from cog.git import (
     delete_branch,
     fetch_origin,
     merge_ff_only,
+    rebase_abort,
+    rebase_in_progress,
 )
 from tests.fakes import FakeSubprocessRegistry
 
@@ -190,3 +192,42 @@ async def test_delete_branch_removes_branch(tmp_path: Path) -> None:
     with _patch_exec(registry):
         await delete_branch(tmp_path, "cog/42-my-branch")
     assert ("git", "branch", "-D", "cog/42-my-branch") in registry.calls
+
+
+# ---------------------------------------------------------------------------
+# rebase_in_progress — filesystem checks, no subprocess
+# ---------------------------------------------------------------------------
+
+
+async def test_rebase_in_progress_returns_false_when_no_rebase_state(tmp_path: Path) -> None:
+    (tmp_path / ".git").mkdir()
+    assert await rebase_in_progress(tmp_path) is False
+
+
+async def test_rebase_in_progress_returns_true_when_rebase_merge_dir_exists(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "rebase-merge").mkdir()
+    assert await rebase_in_progress(tmp_path) is True
+
+
+async def test_rebase_in_progress_returns_true_when_rebase_apply_dir_exists(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "rebase-apply").mkdir()
+    assert await rebase_in_progress(tmp_path) is True
+
+
+# ---------------------------------------------------------------------------
+# rebase_abort — subprocess
+# ---------------------------------------------------------------------------
+
+
+async def test_rebase_abort_calls_git_rebase_abort(tmp_path: Path) -> None:
+    registry = FakeSubprocessRegistry()
+    registry.expect(("git", "rebase", "--abort"), stdout=b"")
+    with _patch_exec(registry):
+        await rebase_abort(tmp_path)
+    assert ("git", "rebase", "--abort") in registry.calls

--- a/tests/test_telemetry_record.py
+++ b/tests/test_telemetry_record.py
@@ -213,7 +213,7 @@ def test_telemetry_outcome_literal_accepts_rebase_conflict():
         project="p",
         workflow="ralph",
         item=_make_item(),
-        outcome="rebase-conflict",  # type: ignore[arg-type]
+        outcome="rebase-conflict",
         results=[],
         duration_seconds=1.0,
         cause_class="RebaseUnresolvedError",

--- a/tests/test_telemetry_record.py
+++ b/tests/test_telemetry_record.py
@@ -208,6 +208,20 @@ def test_outcome_literal_accepted():
         assert record.outcome == outcome
 
 
+def test_telemetry_outcome_literal_accepts_rebase_conflict():
+    record = TelemetryRecord.build(
+        project="p",
+        workflow="ralph",
+        item=_make_item(),
+        outcome="rebase-conflict",  # type: ignore[arg-type]
+        results=[],
+        duration_seconds=1.0,
+        cause_class="RebaseUnresolvedError",
+    )
+    assert record.outcome == "rebase-conflict"
+    assert record.cause_class == "RebaseUnresolvedError"
+
+
 def test_telemetry_record_cause_class_default_is_none():
     record = TelemetryRecord.build(
         project="p",

--- a/tests/test_workflows/test_ralph_finalization.py
+++ b/tests/test_workflows/test_ralph_finalization.py
@@ -21,6 +21,17 @@ def _writable_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
 
 
+@pytest.fixture(autouse=True)
+def _clean_rebase(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch _rebase_before_push to return clean so finalize_success tests don't hit git."""
+    from cog.workflows.ralph import RebaseOutcome
+
+    async def _noop(self: object, ctx: object) -> RebaseOutcome:
+        return RebaseOutcome(status="clean")
+
+    monkeypatch.setattr(RalphWorkflow, "_rebase_before_push", _noop)
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_workflows/test_ralph_integration.py
+++ b/tests/test_workflows/test_ralph_integration.py
@@ -23,6 +23,17 @@ def _writable_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
 
 
+@pytest.fixture(autouse=True)
+def _clean_rebase(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch _rebase_before_push to return clean so integration tests don't hit git."""
+    from cog.workflows.ralph import RebaseOutcome
+
+    async def _noop(self: object, ctx: object) -> RebaseOutcome:
+        return RebaseOutcome(status="clean")
+
+    monkeypatch.setattr(RalphWorkflow, "_rebase_before_push", _noop)
+
+
 def _git(*args: str, cwd: Path) -> None:
     subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
 

--- a/tests/test_workflows/test_ralph_prompts.py
+++ b/tests/test_workflows/test_ralph_prompts.py
@@ -30,6 +30,37 @@ def test_load_prompt_reads_all_three_files():
         assert len(text) > 0, f"{stage}.md is empty"
 
 
+# ---------------------------------------------------------------------------
+# Rebase prompt
+# ---------------------------------------------------------------------------
+
+
+def test_rebase_prompt_exists_and_loads():
+    text = _load_prompt("rebase")
+    assert len(text) > 0
+
+
+def test_rebase_prompt_instructs_claude_to_run_git_rebase_themselves():
+    content = _load_prompt("rebase")
+    assert "git rebase" in content
+
+
+def test_rebase_prompt_describes_bail_semantics():
+    content = _load_prompt("rebase")
+    # Must mention aborting and exiting when conflict can't be resolved
+    assert "git rebase --abort" in content
+    assert "exit" in content.lower()
+
+
+def test_rebase_prompt_does_not_inject_repo_state():
+    # Regression guard: rebase prompt must use on-demand pattern —
+    # no pre-injected git state placeholders.
+    content = _load_prompt("rebase")
+    assert "{git_status}" not in content
+    assert "{branch}" not in content
+    assert "{{" not in content
+
+
 def test_build_prompt_contains_static_text(tmp_path):
     item = make_item()
     ctx = _make_ctx(tmp_path, item=item)

--- a/tests/test_workflows/test_ralph_rebase.py
+++ b/tests/test_workflows/test_ralph_rebase.py
@@ -1,0 +1,623 @@
+"""Tests for RalphWorkflow rebase-before-push logic."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cog.core.context import ExecutionContext
+from cog.core.errors import GitError
+from cog.core.host import GitHost
+from cog.core.outcomes import StageResult
+from cog.core.tracker import IssueTracker
+from cog.core.workflow import StageExecutor
+from cog.workflows.ralph import RalphWorkflow, RebaseOutcome
+from tests.fakes import (
+    EchoRunner,
+    InMemoryStateCache,
+    make_item,
+    make_stage_result,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _writable_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+
+
+def _make_tracker() -> AsyncMock:
+    tracker = AsyncMock(spec=IssueTracker)
+    tracker.comment.return_value = None
+    tracker.add_label.return_value = None
+    tracker.remove_label.return_value = None
+    tracker.ensure_label.return_value = None
+    return tracker
+
+
+def _make_telemetry() -> AsyncMock:
+    tel = AsyncMock()
+    tel.write.return_value = None
+    return tel
+
+
+def _make_ctx(
+    tmp_path: Path,
+    *,
+    item_id: str = "42",
+    work_branch: str = "cog/42-fix",
+    telemetry: object = None,
+) -> ExecutionContext:
+    return ExecutionContext(
+        project_dir=tmp_path,
+        tmp_dir=tmp_path,
+        state_cache=InMemoryStateCache(),
+        headless=True,
+        item=make_item(item_id=item_id, title="Fix the bug"),
+        work_branch=work_branch,
+        telemetry=telemetry,
+    )
+
+
+def _make_wf(
+    tracker: AsyncMock | None = None,
+    host: AsyncMock | None = None,
+) -> RalphWorkflow:
+    return RalphWorkflow(
+        runner=EchoRunner(),
+        tracker=tracker or _make_tracker(),
+        host=host or AsyncMock(spec=GitHost),
+    )
+
+
+def _patch_git(**kwargs: object):
+    """Return a context manager that patches multiple git module functions."""
+    return patch.multiple("cog.workflows.ralph.git", **kwargs)
+
+
+def _patch_run_stage(result: StageResult):
+    """Patch StageExecutor._run_stage to return a fixed result."""
+    return patch.object(StageExecutor, "_run_stage", new_callable=AsyncMock, return_value=result)
+
+
+def _make_clean_stage_result(final_message: str = "") -> StageResult:
+    return make_stage_result("rebase", final_message=final_message)
+
+
+# ---------------------------------------------------------------------------
+# _rebase_before_push — pre-check
+# ---------------------------------------------------------------------------
+
+
+async def test_rebase_skipped_when_work_branch_not_behind_default(tmp_path: Path) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    with _patch_git(
+        default_branch=AsyncMock(return_value="main"),
+        fetch_origin=AsyncMock(return_value=None),
+        commits_between=AsyncMock(return_value=0),
+    ):
+        with patch.object(StageExecutor, "_run_stage", new_callable=AsyncMock) as mock_run:
+            outcome = await wf._rebase_before_push(ctx)
+
+    assert outcome.status == "clean"
+    mock_run.assert_not_awaited()
+
+
+async def test_rebase_invoked_when_work_branch_behind_default(tmp_path: Path) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    stage_result = _make_clean_stage_result()
+    with _patch_git(
+        default_branch=AsyncMock(return_value="main"),
+        fetch_origin=AsyncMock(return_value=None),
+        commits_between=AsyncMock(return_value=2),
+        rebase_in_progress=AsyncMock(return_value=False),
+    ):
+        with _patch_run_stage(stage_result):
+            outcome = await wf._rebase_before_push(ctx)
+
+    assert outcome.status == "clean"
+
+
+async def test_rebase_pre_check_fetches_origin_before_comparing(tmp_path: Path) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    fetch_calls: list[object] = []
+
+    async def _fetch(project_dir: Path) -> None:
+        fetch_calls.append(project_dir)
+
+    with _patch_git(
+        default_branch=AsyncMock(return_value="main"),
+        fetch_origin=_fetch,
+        commits_between=AsyncMock(return_value=0),
+    ):
+        await wf._rebase_before_push(ctx)
+
+    assert len(fetch_calls) == 1
+
+
+async def test_rebase_pre_check_git_error_falls_through_to_stage_invocation(
+    tmp_path: Path,
+) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    stage_result = _make_clean_stage_result()
+    with _patch_git(
+        default_branch=AsyncMock(return_value="main"),
+        fetch_origin=AsyncMock(return_value=None),
+        commits_between=AsyncMock(side_effect=GitError("rev-list failed")),
+        rebase_in_progress=AsyncMock(return_value=False),
+    ):
+        with patch.object(
+            StageExecutor, "_run_stage", new_callable=AsyncMock, return_value=stage_result
+        ) as mock_run:
+            outcome = await wf._rebase_before_push(ctx)
+
+    # Stage must have been invoked (behind=1 assumed on git error)
+    mock_run.assert_awaited_once()
+    assert outcome.status == "clean"
+
+
+# ---------------------------------------------------------------------------
+# _rebase_before_push — stage properties
+# ---------------------------------------------------------------------------
+
+
+async def test_rebase_stage_uses_rebase_prompt_not_build_prompt(tmp_path: Path) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    captured_stages: list[object] = []
+
+    async def _capture(self: object, stage: object, ctx: object) -> StageResult:
+        captured_stages.append(stage)
+        return _make_clean_stage_result()
+
+    with _patch_git(
+        default_branch=AsyncMock(return_value="main"),
+        fetch_origin=AsyncMock(return_value=None),
+        commits_between=AsyncMock(return_value=1),
+        rebase_in_progress=AsyncMock(return_value=False),
+    ):
+        with patch.object(StageExecutor, "_run_stage", _capture):
+            await wf._rebase_before_push(ctx)
+
+    assert len(captured_stages) == 1
+    stage = captured_stages[0]
+    # Prompt source should produce the rebase prompt content
+    from cog.core.stage import Stage
+
+    assert isinstance(stage, Stage)
+    prompt_text = stage.prompt_source(ctx)
+    assert "git rebase" in prompt_text
+    assert "Ralph: build stage" not in prompt_text
+
+
+async def test_rebase_stage_inherits_cog_ralph_build_model_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COG_RALPH_BUILD_MODEL", "claude-haiku-4-5-20251001")
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    captured_stages: list[object] = []
+
+    async def _capture(self: object, stage: object, ctx: object) -> StageResult:
+        captured_stages.append(stage)
+        return _make_clean_stage_result()
+
+    with _patch_git(
+        default_branch=AsyncMock(return_value="main"),
+        fetch_origin=AsyncMock(return_value=None),
+        commits_between=AsyncMock(return_value=1),
+        rebase_in_progress=AsyncMock(return_value=False),
+    ):
+        with patch.object(StageExecutor, "_run_stage", _capture):
+            await wf._rebase_before_push(ctx)
+
+    from cog.core.stage import Stage
+
+    stage = captured_stages[0]
+    assert isinstance(stage, Stage)
+    assert stage.model == "claude-haiku-4-5-20251001"
+
+
+async def test_rebase_prompt_does_not_inject_git_state_content(tmp_path: Path) -> None:
+    """Regression guard: rebase stage must use on-demand pattern (no pre-injected state)."""
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    captured_stages: list[object] = []
+
+    async def _capture(self: object, stage: object, ctx: object) -> StageResult:
+        captured_stages.append(stage)
+        return _make_clean_stage_result()
+
+    with _patch_git(
+        default_branch=AsyncMock(return_value="main"),
+        fetch_origin=AsyncMock(return_value=None),
+        commits_between=AsyncMock(return_value=1),
+        rebase_in_progress=AsyncMock(return_value=False),
+    ):
+        with patch.object(StageExecutor, "_run_stage", _capture):
+            await wf._rebase_before_push(ctx)
+
+    from cog.core.stage import Stage
+
+    stage = captured_stages[0]
+    assert isinstance(stage, Stage)
+    prompt_text = stage.prompt_source(ctx)
+    # Must not contain injected git status or branch state
+    assert "git status" not in prompt_text
+    assert "HEAD is" not in prompt_text
+
+
+# ---------------------------------------------------------------------------
+# _rebase_before_push — clean path
+# ---------------------------------------------------------------------------
+
+
+async def test_clean_rebase_after_claude_proceeds_returns_clean(tmp_path: Path) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    stage_result = _make_clean_stage_result("Rebase complete.")
+    with _patch_git(
+        default_branch=AsyncMock(return_value="main"),
+        fetch_origin=AsyncMock(return_value=None),
+        commits_between=AsyncMock(return_value=3),
+        rebase_in_progress=AsyncMock(return_value=False),
+    ):
+        with _patch_run_stage(stage_result):
+            outcome = await wf._rebase_before_push(ctx)
+
+    assert outcome.status == "clean"
+    assert outcome.final_message == ""
+
+
+# ---------------------------------------------------------------------------
+# _rebase_before_push — conflict / mid-rebase path
+# ---------------------------------------------------------------------------
+
+
+async def test_claude_left_mid_rebase_triggers_abort(tmp_path: Path) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    stage_result = _make_clean_stage_result("Both sides changed foo().")
+    abort_calls: list[object] = []
+
+    async def _fake_abort(project_dir: Path) -> None:
+        abort_calls.append(project_dir)
+
+    with _patch_git(
+        default_branch=AsyncMock(return_value="main"),
+        fetch_origin=AsyncMock(return_value=None),
+        commits_between=AsyncMock(return_value=1),
+        rebase_in_progress=AsyncMock(return_value=True),
+        rebase_abort=_fake_abort,
+    ):
+        with _patch_run_stage(stage_result):
+            outcome = await wf._rebase_before_push(ctx)
+
+    assert outcome.status == "conflict"
+    assert len(abort_calls) == 1
+
+
+async def test_abort_invokes_git_rebase_abort(tmp_path: Path) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    stage_result = _make_clean_stage_result()
+    mock_abort = AsyncMock(return_value=None)
+    with _patch_git(
+        default_branch=AsyncMock(return_value="main"),
+        fetch_origin=AsyncMock(return_value=None),
+        commits_between=AsyncMock(return_value=1),
+        rebase_in_progress=AsyncMock(return_value=True),
+        rebase_abort=mock_abort,
+    ):
+        with _patch_run_stage(stage_result):
+            await wf._rebase_before_push(ctx)
+
+    mock_abort.assert_awaited_once_with(tmp_path)
+
+
+async def test_unresolved_conflict_returns_conflict_with_final_message(tmp_path: Path) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    stage_result = _make_clean_stage_result("foo() defined differently on both sides.")
+    with _patch_git(
+        default_branch=AsyncMock(return_value="main"),
+        fetch_origin=AsyncMock(return_value=None),
+        commits_between=AsyncMock(return_value=1),
+        rebase_in_progress=AsyncMock(return_value=True),
+        rebase_abort=AsyncMock(return_value=None),
+    ):
+        with _patch_run_stage(stage_result):
+            outcome = await wf._rebase_before_push(ctx)
+
+    assert outcome.status == "conflict"
+    assert "foo() defined differently" in outcome.final_message
+
+
+# ---------------------------------------------------------------------------
+# _rebase_before_push — helper outcome contracts
+# ---------------------------------------------------------------------------
+
+
+async def test_rebase_before_push_helper_returns_clean_outcome_when_precheck_skips(
+    tmp_path: Path,
+) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    with _patch_git(
+        default_branch=AsyncMock(return_value="main"),
+        fetch_origin=AsyncMock(return_value=None),
+        commits_between=AsyncMock(return_value=0),
+    ):
+        outcome = await wf._rebase_before_push(ctx)
+
+    assert isinstance(outcome, RebaseOutcome)
+    assert outcome.status == "clean"
+
+
+async def test_rebase_before_push_helper_returns_clean_outcome_when_stage_completes(
+    tmp_path: Path,
+) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    stage_result = _make_clean_stage_result()
+    with _patch_git(
+        default_branch=AsyncMock(return_value="main"),
+        fetch_origin=AsyncMock(return_value=None),
+        commits_between=AsyncMock(return_value=1),
+        rebase_in_progress=AsyncMock(return_value=False),
+    ):
+        with _patch_run_stage(stage_result):
+            outcome = await wf._rebase_before_push(ctx)
+
+    assert isinstance(outcome, RebaseOutcome)
+    assert outcome.status == "clean"
+
+
+async def test_rebase_before_push_helper_returns_conflict_outcome_when_mid_rebase_after_claude(
+    tmp_path: Path,
+) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    stage_result = _make_clean_stage_result("analysis")
+    with _patch_git(
+        default_branch=AsyncMock(return_value="main"),
+        fetch_origin=AsyncMock(return_value=None),
+        commits_between=AsyncMock(return_value=1),
+        rebase_in_progress=AsyncMock(return_value=True),
+        rebase_abort=AsyncMock(return_value=None),
+    ):
+        with _patch_run_stage(stage_result):
+            outcome = await wf._rebase_before_push(ctx)
+
+    assert isinstance(outcome, RebaseOutcome)
+    assert outcome.status == "conflict"
+
+
+async def test_rebase_before_push_helper_aborts_mid_rebase_state_before_returning(
+    tmp_path: Path,
+) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    stage_result = _make_clean_stage_result()
+    abort_called = []
+    with _patch_git(
+        default_branch=AsyncMock(return_value="main"),
+        fetch_origin=AsyncMock(return_value=None),
+        commits_between=AsyncMock(return_value=1),
+        rebase_in_progress=AsyncMock(return_value=True),
+        rebase_abort=AsyncMock(side_effect=lambda d: abort_called.append(d)),
+    ):
+        with _patch_run_stage(stage_result):
+            outcome = await wf._rebase_before_push(ctx)
+
+    assert len(abort_called) == 1
+    assert outcome.status == "conflict"
+
+
+# ---------------------------------------------------------------------------
+# _handle_rebase_conflict — label / state behavior
+# ---------------------------------------------------------------------------
+
+
+async def test_handle_rebase_conflict_keeps_agent_ready(tmp_path: Path) -> None:
+    tracker = _make_tracker()
+    wf = _make_wf(tracker=tracker)
+    ctx = _make_ctx(tmp_path)
+    with _patch_git(default_branch=AsyncMock(return_value="main")):
+        with patch.object(wf, "write_report", new_callable=AsyncMock):
+            await wf._handle_rebase_conflict(ctx, [], "analysis")
+
+    removed = [c.args[1] for c in tracker.remove_label.call_args_list]
+    assert "agent-ready" not in removed
+
+
+async def test_handle_rebase_conflict_adds_agent_failed(tmp_path: Path) -> None:
+    tracker = _make_tracker()
+    wf = _make_wf(tracker=tracker)
+    ctx = _make_ctx(tmp_path)
+    with _patch_git(default_branch=AsyncMock(return_value="main")):
+        with patch.object(wf, "write_report", new_callable=AsyncMock):
+            await wf._handle_rebase_conflict(ctx, [], "analysis")
+
+    added = [c.args[1] for c in tracker.add_label.call_args_list]
+    assert "agent-failed" in added
+
+
+async def test_handle_rebase_conflict_does_not_mark_processed(tmp_path: Path) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    with _patch_git(default_branch=AsyncMock(return_value="main")):
+        with patch.object(wf, "write_report", new_callable=AsyncMock):
+            await wf._handle_rebase_conflict(ctx, [], "analysis")
+
+    assert not ctx.state_cache.is_processed(ctx.item)
+
+
+async def test_handle_rebase_conflict_adds_to_processed_this_loop_set(tmp_path: Path) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    with _patch_git(default_branch=AsyncMock(return_value="main")):
+        with patch.object(wf, "write_report", new_callable=AsyncMock):
+            await wf._handle_rebase_conflict(ctx, [], "analysis")
+
+    assert (ctx.item.tracker_id, ctx.item.item_id) in wf._processed_this_loop
+
+
+async def test_handle_rebase_conflict_comments_on_item_with_claude_analysis(
+    tmp_path: Path,
+) -> None:
+    tracker = _make_tracker()
+    wf = _make_wf(tracker=tracker)
+    ctx = _make_ctx(tmp_path)
+    with _patch_git(default_branch=AsyncMock(return_value="main")):
+        with patch.object(wf, "write_report", new_callable=AsyncMock):
+            await wf._handle_rebase_conflict(ctx, [], "Both sides changed bar()")
+
+    tracker.comment.assert_awaited_once()
+    body = tracker.comment.call_args.args[1]
+    assert "Both sides changed bar()" in body
+    assert "origin/main" in body
+
+
+# ---------------------------------------------------------------------------
+# _handle_rebase_conflict — telemetry
+# ---------------------------------------------------------------------------
+
+
+async def test_rebase_conflict_writes_telemetry_with_outcome_rebase_conflict(
+    tmp_path: Path,
+) -> None:
+    tel = _make_telemetry()
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path, telemetry=tel)
+    with _patch_git(default_branch=AsyncMock(return_value="main")):
+        with patch.object(wf, "write_report", new_callable=AsyncMock):
+            await wf._handle_rebase_conflict(ctx, [], "analysis")
+
+    tel.write.assert_awaited_once()
+    record = tel.write.call_args.args[0]
+    assert record.outcome == "rebase-conflict"
+
+
+async def test_rebase_conflict_writes_telemetry_with_cause_class_rebase_unresolved_error(
+    tmp_path: Path,
+) -> None:
+    tel = _make_telemetry()
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path, telemetry=tel)
+    with _patch_git(default_branch=AsyncMock(return_value="main")):
+        with patch.object(wf, "write_report", new_callable=AsyncMock):
+            await wf._handle_rebase_conflict(ctx, [], "analysis")
+
+    record = tel.write.call_args.args[0]
+    assert record.cause_class == "RebaseUnresolvedError"
+
+
+async def test_clean_rebase_does_not_add_rebase_stage_to_telemetry_when_precheck_skipped(
+    tmp_path: Path,
+) -> None:
+    """When pre-check skips the stage, no rebase stage row appears in telemetry."""
+    tel = _make_telemetry()
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path, telemetry=tel)
+    with _patch_git(
+        default_branch=AsyncMock(return_value="main"),
+        fetch_origin=AsyncMock(return_value=None),
+        commits_between=AsyncMock(return_value=0),
+    ):
+        outcome = await wf._rebase_before_push(ctx)
+
+    assert outcome.status == "clean"
+    # No telemetry written by the helper itself on clean pre-check skip
+    tel.write.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# finalize_success integration with _rebase_before_push
+# ---------------------------------------------------------------------------
+
+
+async def test_finalize_success_calls_rebase_before_push(tmp_path: Path) -> None:
+    from cog.core.host import PullRequest
+
+    host = AsyncMock(spec=GitHost)
+    host.push_branch.return_value = None
+    host.get_pr_for_branch.return_value = None
+    pr = PullRequest(
+        number=1,
+        url="https://example.com/pr/1",
+        state="open",
+        body="",
+        head_branch="cog/42-fix",
+    )
+    host.create_pr.return_value = pr
+
+    wf = _make_wf(host=host)
+    ctx = _make_ctx(tmp_path)
+
+    rebase_called = []
+
+    async def _fake_rebase(self_: object, ctx_: object) -> RebaseOutcome:
+        rebase_called.append(True)
+        return RebaseOutcome(status="clean")
+
+    with patch.object(RalphWorkflow, "_rebase_before_push", _fake_rebase):
+        with patch.object(wf, "write_report", new_callable=AsyncMock):
+            await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
+
+    assert rebase_called
+
+
+async def test_finalize_success_skips_push_on_conflict(tmp_path: Path) -> None:
+    host = AsyncMock(spec=GitHost)
+    wf = _make_wf(host=host)
+    ctx = _make_ctx(tmp_path)
+
+    async def _fake_rebase(self_: object, ctx_: object) -> RebaseOutcome:
+        return RebaseOutcome(status="conflict", final_message="incompatible")
+
+    with patch.object(RalphWorkflow, "_rebase_before_push", _fake_rebase):
+        with patch.object(wf, "_handle_rebase_conflict", new_callable=AsyncMock) as mock_conflict:
+            await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
+
+    host.push_branch.assert_not_awaited()
+    mock_conflict.assert_awaited_once()
+
+
+async def test_finalize_success_routes_to_handle_rebase_conflict_with_final_message(
+    tmp_path: Path,
+) -> None:
+    host = AsyncMock(spec=GitHost)
+    wf = _make_wf(host=host)
+    ctx = _make_ctx(tmp_path)
+
+    async def _fake_rebase(self_: object, ctx_: object) -> RebaseOutcome:
+        return RebaseOutcome(status="conflict", final_message="the message")
+
+    with patch.object(RalphWorkflow, "_rebase_before_push", _fake_rebase):
+        with patch.object(wf, "_handle_rebase_conflict", new_callable=AsyncMock) as mock_conflict:
+            await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
+
+    _call_args = mock_conflict.call_args
+    assert _call_args.args[2] == "the message"
+
+
+# ---------------------------------------------------------------------------
+# #101 integration skeleton — rebase helper shared with fix-push path
+# ---------------------------------------------------------------------------
+
+
+async def test_rebase_before_push_is_accessible_as_shared_helper(tmp_path: Path) -> None:
+    """_rebase_before_push is a method on RalphWorkflow available to call sites."""
+    wf = _make_wf()
+    assert hasattr(wf, "_rebase_before_push")
+    assert callable(wf._rebase_before_push)

--- a/tests/test_workflows/test_ralph_resume.py
+++ b/tests/test_workflows/test_ralph_resume.py
@@ -265,6 +265,17 @@ def _writable_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
 
 
+@pytest.fixture(autouse=True)
+def _clean_rebase(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch _rebase_before_push to return clean so finalize_success tests don't hit git."""
+    from cog.workflows.ralph import RebaseOutcome
+
+    async def _noop(self: object, ctx: object) -> RebaseOutcome:
+        return RebaseOutcome(status="clean")
+
+    monkeypatch.setattr(RalphWorkflow, "_rebase_before_push", _noop)
+
+
 def _make_ctx_with_tmp(tmp_path: Path, *, item_id: str = "42") -> ExecutionContext:
     return ExecutionContext(
         project_dir=tmp_path,


### PR DESCRIPTION
## Summary



## Closes

Closes #33

## Test plan


- [ ] **Pre-check short-circuits on no-op**: run `cog ralph --item <N>` on an item where main hasn't advanced. Confirm no `rebase` stage appears in the telemetry `stages` array and no rebase stage fires; iteration proceeds to push + PR normally.

- [ ] **Clean rebase (conflict resolution by Claude)**: advance main on a file that the work branch also touches (non-conflicting change). Run `cog ralph --item <N>`. Confirm the rebase stage fires, Claude resolves cleanly, push succeeds, PR has no merge-conflict banner.

- [ ] **Incompatible conflict → abandon**: advance main on a file where both sides define the same function differently. Run `cog ralph --item <N>`. Confirm:
  - Rebase stage fires
  - Claude exits with an analysis message
  - Ralph posts an abandon comment citing Claude's analysis and `origin/<default>`
  - Issue retains `agent-ready` label
  - Issue gains `agent-failed` label
  - `_processed_this_loop` prevents same-loop re-pick
  - `runs.jsonl` shows `outcome=rebase-conflict` and `cause_class=RebaseUnresolvedError`

- [ ] **Retry after resolution**: after the abandon scenario above, let main advance further (or resolve the incompatibility on main's side), then run `cog ralph` again. Confirm the previously-deferred item is re-picked, rebase succeeds, and iteration completes normally.

- [ ] **Git safety net**: simulate Claude crashing mid-rebase (leave `.git/rebase-merge/` in place). Confirm `rebase_in_progress` returns `True`, `rebase_abort` is called, and the outcome is `conflict`.

- [ ] **No new env var**: confirm `COG_RALPH_BUILD_MODEL` is reused for the rebase stage model (no new variable needed).

---
🤖 Generated by [ralph](https://github.com/jessiepuls/ralph). Iteration cost: $5.68.