### PR TITLE
Ralph workflow: fix-on-CI-failure — reproduce, fix, retry, hand off (part 2 of #22) (#101)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,13 @@ Key fields:
 | `error` | string\|null | `"stage 'X' failed \| cause=RunnerStalledError: ..."` on failure |
 | `cause_class` | string\|null | Exception class name of the underlying cause (e.g. `RunnerStalledError`, `RunnerTimeoutError`) |
 | `pr_url` | string\|null | PR URL if one was opened |
+| `retry_count` | int | Number of CI-fix retries attempted this iteration (0 when no CI failures occurred) |
+| `ci_failed_checks` | array | Deduplicated names of CI checks that failed across all retry attempts; empty when no failures |
 
 `cause_class` is populated when a stage fails with a classifiable runner error — useful for filtering
 retry-eligible failures (`RunnerStalledError`, `RunnerTimeoutError`, `RebaseUnresolvedError`) from logic errors in telemetry queries.
+CI-specific values: `CiFixFailedError` (claude exited without committing — unreproducible or couldn't fix),
+`CiRetryCapExhaustedError` (retry cap hit; all attempts failed).
 
 When a stage fails after the runner has done real work (e.g. committed code), the partial result is
 preserved: `stages` will contain an entry for the failed stage with accurate `duration_s`, `cost_usd`,

--- a/src/cog/core/errors.py
+++ b/src/cog/core/errors.py
@@ -101,3 +101,19 @@ class CiTimeoutError(CiError):
     def __init__(self, timeout_seconds: float) -> None:
         self.timeout_seconds = timeout_seconds
         super().__init__(f"CI did not resolve within {timeout_seconds:.0f}s")
+
+
+class CiFixFailedError(CiError):
+    """Claude exited without committing — unreproducible or couldn't fix."""
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(f"CI fix failed: {reason}")
+
+
+class CiRetryCapExhaustedError(CiError):
+    """All CI fix retry attempts exhausted; still failing."""
+
+    def __init__(self, attempts: int) -> None:
+        self.attempts = attempts
+        super().__init__(f"CI retry cap exhausted after {attempts} attempts")

--- a/src/cog/prompts/claude/ralph/ci_fix.md
+++ b/src/cog/prompts/claude/ralph/ci_fix.md
@@ -1,0 +1,51 @@
+# Ralph: CI fix stage
+
+The PR's CI failed. Your job this iteration:
+
+1. **Reproduce the failure locally.** The failing checks are listed in the
+   runtime context below with links. To see the CI output, run
+   `gh run view <run-id> --log-failed` where `<run-id>` is the numeric ID
+   from the check link (e.g. `.../actions/runs/12345/job/678` → run-id is
+   `12345`). Also try the project's test / lint / type commands directly
+   based on what the check name suggests.
+2. **If you can reproduce**: fix the failure and commit. The wrapper
+   pushes your commit and re-triggers CI.
+3. **If you cannot reproduce** after reasonable effort (check only fires
+   in CI env, ambiguous error, etc.): **exit WITHOUT committing.** In
+   your final message, explain what you tried, what you believe the
+   failure is, and what would unblock it. The wrapper posts that on the
+   PR for a human to triage.
+
+## Bounded tool calls (important)
+
+Claude Code persists any single tool output >30KB to a session-scoped file
+and tells you to `Read` that file. In this container, the subsequent `Read`
+has been observed to hang indefinitely. To avoid this:
+
+- Do NOT run `cat` on large generated or vendored files (e.g. lockfiles,
+  `node_modules/**`, minified assets).
+- Do NOT run `grep -r` over the whole repo. Use `Grep` (Claude Code's
+  built-in) with `head_limit` or file-type filters.
+- Do NOT run `find .` across repos with heavy dependency trees — scope it
+  with `-path` exclusions or use `Glob` instead.
+- When running a command that might produce large output, pipe through
+  `head -c 30000` or equivalent defensively.
+- Prefer per-file inspection via `Read <file>` over broad shell expansions.
+
+## Testing and linting cadence
+
+Tool calls inside the sandbox are expensive. Run only the test file(s)
+affected by your fix during iteration, then the full suite once at the end.
+
+Consult the project's CLAUDE.md for the specific commands this project uses.
+
+## Commit discipline
+
+Commit exactly once when the fix passes the full suite. If you cannot
+reproduce or fix the failure, exit without committing.
+
+## Git rules (hard)
+
+- Make commits locally; do not push them. The wrapper pushes the branch.
+- Do not open PRs or comment on items.
+- Never delete branches or push to the default branch.

--- a/src/cog/telemetry.py
+++ b/src/cog/telemetry.py
@@ -63,6 +63,8 @@ class TelemetryRecord:
     error: str | None
     cause_class: str | None = None
     resumed: bool = False
+    retry_count: int = 0
+    ci_failed_checks: tuple[str, ...] = ()
 
     @classmethod
     def build(
@@ -80,6 +82,8 @@ class TelemetryRecord:
         error: str | None = None,
         cause_class: str | None = None,
         resumed: bool = False,
+        retry_count: int = 0,
+        ci_failed_checks: tuple[str, ...] = (),
     ) -> "TelemetryRecord":
         result_stages = tuple(StageTelemetry.from_stage_result(r) for r in results)
         all_stages = tuple(extra_stages) + result_stages
@@ -98,6 +102,8 @@ class TelemetryRecord:
             error=error,
             cause_class=cause_class,
             resumed=resumed,
+            retry_count=retry_count,
+            ci_failed_checks=ci_failed_checks,
         )
 
 

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -463,9 +463,17 @@ class RalphWorkflow(Workflow):
 
             try:
                 checks = await self._wait_for_ci(ctx, pr)
-            except CiTimeoutError:
+            except CiTimeoutError as e:
                 attempt_history.append((retries_done, ()))
-                break
+                await self._abandon_ci(
+                    ctx,
+                    results,
+                    pr,
+                    attempt_history,
+                    claude_analysis=None,
+                    cause=e,
+                )
+                return
 
             if checks.all_passed:
                 await self._mark_ci_success(

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -17,7 +17,8 @@ import cog.git as git
 from cog.checks import RALPH_CHECKS
 from cog.core.context import ExecutionContext
 from cog.core.errors import (
-    CiChecksFailedError,
+    CiFixFailedError,
+    CiRetryCapExhaustedError,
     CiTimeoutError,
     GitError,
     HostError,
@@ -48,6 +49,52 @@ def _parse_float_env(key: str, default: float) -> float:
         return float(os.environ[key])
     except (KeyError, ValueError):
         return default
+
+
+def _parse_int_env(key: str, default: int) -> int:
+    try:
+        return int(os.environ[key])
+    except (KeyError, ValueError):
+        return default
+
+
+# attempt_history: list of (attempt_number, tuple_of_check_names)
+_AttemptHistory = list[tuple[int, tuple[str, ...]]]
+
+
+def _dedupe_attempt_checks(attempt_history: _AttemptHistory) -> tuple[str, ...]:
+    """Return all check names from attempt history, deduplicated (order-preserving)."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for _, names in attempt_history:
+        for name in names:
+            if name not in seen:
+                seen.add(name)
+                result.append(name)
+    return tuple(result)
+
+
+def _format_cap_comment(attempt_history: _AttemptHistory, retries_done: int) -> str:
+    """Build the smart cap-exhausted PR comment."""
+    check_sets = [set(names) for _, names in attempt_history if names]
+    intersection = set.intersection(*check_sets) if len(check_sets) > 1 else set()
+
+    if intersection and len(check_sets) > 1:
+        signal = (
+            f"⚠ These checks failed on every attempt: {sorted(intersection)} — "
+            f"consider whether they're flaky or environment-specific."
+        )
+    elif len(check_sets) > 1:
+        signal = "⚠ Different checks failed on each attempt — fixes may be introducing regressions."
+    else:
+        signal = "⚠ Could not confirm a fix after retrying."
+
+    lines = [f"🤖 Cog exhausted {retries_done + 1} CI fix attempts:"]
+    for n, names in attempt_history:
+        label = "initial" if n == 0 else f"fix {n}"
+        lines.append(f"- Attempt {n} ({label}): {', '.join(names) if names else '(unknown)'}")
+    lines.append(signal)
+    return "\n".join(lines)
 
 
 _DEFAULT_POLL_INTERVAL = 15.0
@@ -138,6 +185,7 @@ class RalphWorkflow(Workflow):
         self._restart = restart
         self._processed_this_loop: set[tuple[str, str]] = set()
         self._resumed_this_iteration: dict[str, bool] = {}
+        self._ci_retries: dict[str, int] = {}
 
     async def select_item(self, ctx: ExecutionContext) -> Item | None:
         items = await self._tracker.list_by_label("agent-ready", assignee="@me")
@@ -291,14 +339,13 @@ class RalphWorkflow(Workflow):
         try:
             checks = await self._wait_for_ci(ctx, pr)
         except CiTimeoutError as e:
-            await self._handle_ci_failure(ctx, results, pr, None, e)
+            await self._abandon_ci(ctx, results, pr, [(0, ())], claude_analysis=None, cause=e)
             return
 
         if checks.all_passed:
             await self._mark_ci_success(ctx, results, pr)
         else:
-            error = CiChecksFailedError(failing=tuple(r.name for r in checks.failed))
-            await self._handle_ci_failure(ctx, results, pr, checks, error)
+            await self._handle_ci_failure(ctx, results, pr, checks)
 
     async def _wait_for_ci(self, ctx: ExecutionContext, pr: PullRequest) -> PrChecks:
         poll_interval = _parse_float_env("COG_CI_POLL_INTERVAL_SECONDS", _DEFAULT_POLL_INTERVAL)
@@ -355,6 +402,9 @@ class RalphWorkflow(Workflow):
         ctx: ExecutionContext,
         results: list[StageResult],
         pr: PullRequest,
+        *,
+        retry_count: int = 0,
+        ci_failed_checks: tuple[str, ...] = (),
     ) -> None:
         await self._tracker.remove_label(ctx.item, "agent-ready")  # type: ignore[arg-type]
         try:
@@ -363,7 +413,14 @@ class RalphWorkflow(Workflow):
             pass
         ctx.state_cache.mark_processed(ctx.item, "success")  # type: ignore[arg-type]
         ctx.state_cache.save()
-        await self._write_telemetry(ctx, results, "success", pr_url=pr.url)
+        await self._write_telemetry(
+            ctx,
+            results,
+            "success",
+            pr_url=pr.url,
+            retry_count=retry_count,
+            ci_failed_checks=ci_failed_checks,
+        )
         await self.write_report(ctx, results, "success", error=None)
 
     async def _handle_ci_failure(
@@ -371,24 +428,144 @@ class RalphWorkflow(Workflow):
         ctx: ExecutionContext,
         results: list[StageResult],
         pr: PullRequest,
-        checks: PrChecks | None,
-        error: CiChecksFailedError | CiTimeoutError,
+        checks: PrChecks,
+    ) -> None:
+        retries_done = self._ci_retries.get(ctx.item.item_id, 0)  # type: ignore[union-attr]
+        max_retries = _parse_int_env("COG_CI_MAX_RETRIES", 2)
+
+        attempt_history: _AttemptHistory = [(0, tuple(r.name for r in checks.failed))]
+
+        while retries_done < max_retries:
+            retries_done += 1
+            self._ci_retries[ctx.item.item_id] = retries_done  # type: ignore[union-attr]
+
+            fix_result = await self._run_ci_fix_stage(
+                ctx, pr, checks, retries_done, attempt_history
+            )
+
+            if fix_result.commits_created == 0:
+                await self._abandon_ci(
+                    ctx,
+                    results,
+                    pr,
+                    attempt_history,
+                    initial_checks=checks,
+                    claude_analysis=fix_result.final_message,
+                    cause=CiFixFailedError(reason="no-commit"),
+                )
+                return
+
+            try:
+                await self._host.push_branch(ctx.work_branch)  # type: ignore[union-attr,arg-type]
+            except HostError as e:
+                await self._handle_push_failed(ctx, results, e)
+                return
+
+            try:
+                checks = await self._wait_for_ci(ctx, pr)
+            except CiTimeoutError:
+                attempt_history.append((retries_done, ()))
+                break
+
+            if checks.all_passed:
+                await self._mark_ci_success(
+                    ctx,
+                    results,
+                    pr,
+                    retry_count=retries_done,
+                    ci_failed_checks=_dedupe_attempt_checks(attempt_history),
+                )
+                return
+            attempt_history.append((retries_done, tuple(r.name for r in checks.failed)))
+
+        await self._abandon_ci(
+            ctx,
+            results,
+            pr,
+            attempt_history,
+            claude_analysis=None,
+            cause=CiRetryCapExhaustedError(attempts=retries_done + 1),
+        )
+
+    async def _run_ci_fix_stage(
+        self,
+        ctx: ExecutionContext,
+        pr: PullRequest,
+        checks: PrChecks,
+        attempt_number: int,
+        attempt_history: _AttemptHistory,
+    ) -> StageResult:
+        stage = Stage(
+            name=f"ci-fix-{attempt_number}",
+            prompt_source=lambda c: self._build_ci_fix_prompt(
+                c, pr, checks, attempt_number, attempt_history
+            ),
+            model=os.environ.get("COG_RALPH_BUILD_MODEL", "claude-sonnet-4-6"),
+            runner=self._runner,
+            tolerate_failure=False,
+        )
+        return await StageExecutor()._run_stage(stage, ctx)
+
+    def _build_ci_fix_prompt(
+        self,
+        ctx: ExecutionContext,
+        pr: PullRequest,
+        checks: PrChecks,
+        attempt_number: int,
+        attempt_history: _AttemptHistory,
+    ) -> str:
+        parts: list[str] = [_load_prompt("ci_fix")]
+        parts.append("\n## Your task this iteration\n")
+        if ctx.item:
+            parts.append(f"Issue #{ctx.item.item_id}: {ctx.item.title}")
+        if ctx.work_branch:
+            parts.append(f"Branch: {ctx.work_branch}")
+        parts.append(f"PR: {pr.url}\n")
+        parts.append("\n## Failing checks\n")
+        for r in checks.failed:
+            parts.append(f"- **{r.name}**: {r.link}")
+        if attempt_number > 1:
+            parts.append("\n## Previous attempts\n")
+            for n, names in attempt_history:
+                check_str = ", ".join(names) if names else "(unknown)"
+                parts.append(f"- Attempt {n}: failed on {check_str}")
+        return "\n".join(parts)
+
+    async def _abandon_ci(
+        self,
+        ctx: ExecutionContext,
+        results: list[StageResult],
+        pr: PullRequest,
+        attempt_history: _AttemptHistory,
+        *,
+        initial_checks: PrChecks | None = None,
+        claude_analysis: str | None,
+        cause: Exception,
     ) -> None:
         assert ctx.item is not None
         assert self._host is not None
 
-        lines = ["🤖 Cog: CI failed on this PR. See:"]
-        if checks is not None:
-            for r in checks.failed:
-                lines.append(f"- **{r.name}**: {r.link}")
-        await self._host.comment_on_pr(pr.number, "\n".join(lines))
+        if isinstance(cause, CiRetryCapExhaustedError):
+            retries_done = self._ci_retries.get(ctx.item.item_id, 0)
+            pr_comment = _format_cap_comment(attempt_history, retries_done)
+        else:
+            lines = ["🤖 Cog: CI failed on this PR. See:"]
+            if initial_checks is not None:
+                for r in initial_checks.failed:
+                    lines.append(f"- **{r.name}**: {r.link}")
+            elif attempt_history and attempt_history[0][1]:
+                for name in attempt_history[0][1]:
+                    lines.append(f"- **{name}**")
+            if claude_analysis:
+                lines.append(f"\nClaude's analysis:\n\n> {claude_analysis[:2000]}")
+            pr_comment = "\n".join(lines)
 
+        await self._host.comment_on_pr(pr.number, pr_comment)
         await self._tracker.comment(
             ctx.item,
-            f"🤖 Cog opened PR #{pr.number} but CI failed. "
-            f"See the PR for failing checks. `agent-failed` applied.",
+            f"🤖 Cog opened PR #{pr.number} but CI failed and could not be automatically fixed. "
+            f"`agent-failed` applied.",
         )
-
         await self._tracker.ensure_label(
             "agent-failed",
             color="d93f0b",
@@ -396,7 +573,6 @@ class RalphWorkflow(Workflow):
         )
         await self._tracker.add_label(ctx.item, "agent-failed")
         await self._tracker.remove_label(ctx.item, "agent-ready")
-
         ctx.state_cache.mark_processed(ctx.item, "ci-failed")
         ctx.state_cache.save()
         await self._write_telemetry(
@@ -404,10 +580,12 @@ class RalphWorkflow(Workflow):
             results,
             "ci-failed",
             pr_url=pr.url,
-            error=error,
-            cause_class=type(error).__name__,
+            error=cause,
+            cause_class=type(cause).__name__,
+            retry_count=self._ci_retries.get(ctx.item.item_id, 0),
+            ci_failed_checks=_dedupe_attempt_checks(attempt_history),
         )
-        await self.write_report(ctx, results, "error", error=error)
+        await self.write_report(ctx, results, "error", error=cause)
 
     async def finalize_noop(
         self,
@@ -690,6 +868,8 @@ class RalphWorkflow(Workflow):
         pr_url: str | None = None,
         error: Exception | None = None,
         cause_class: str | None = None,
+        retry_count: int = 0,
+        ci_failed_checks: tuple[str, ...] = (),
     ) -> None:
         error_str: str | None = None
         resolved_cause_class = cause_class
@@ -716,5 +896,7 @@ class RalphWorkflow(Workflow):
             error=error_str,
             cause_class=resolved_cause_class,
             resumed=resumed,
+            retry_count=retry_count,
+            ci_failed_checks=ci_failed_checks,
         )
         await ctx.telemetry.write(record)

--- a/tests/test_workflows/test_ralph_ci_fix.py
+++ b/tests/test_workflows/test_ralph_ci_fix.py
@@ -1,0 +1,994 @@
+"""Tests for RalphWorkflow CI fix retry loop."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cog.core.context import ExecutionContext
+from cog.core.host import CheckRun, GitHost, PrChecks, PullRequest
+from cog.core.runner import AgentRunner, ResultEvent, RunResult
+from cog.core.tracker import IssueTracker
+from cog.workflows.ralph import (
+    RalphWorkflow,
+    _dedupe_attempt_checks,
+    _format_cap_comment,
+)
+from tests.fakes import (
+    InMemoryStateCache,
+    RecordingEventSink,
+    ScriptedFinalMessageRunner,
+    make_item,
+    make_stage_result,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_pr(number: int = 42, url: str = "https://github.com/org/repo/pull/42") -> PullRequest:
+    return PullRequest(number=number, url=url, state="open", body="", head_branch="cog/42-fix")
+
+
+def _passed_checks(*names: str) -> PrChecks:
+    runs = tuple(CheckRun(name=n, state="passed", link=f"https://ci/{n}") for n in names)
+    return PrChecks(runs=runs)
+
+
+def _failed_checks(*names: str) -> PrChecks:
+    runs = tuple(CheckRun(name=n, state="failed", link=f"https://ci/{n}") for n in names)
+    return PrChecks(runs=runs)
+
+
+def _make_host(
+    *,
+    pr: PullRequest | None = None,
+    push_error: Exception | None = None,
+    checks_sequence: list[PrChecks] | None = None,
+) -> AsyncMock:
+    host = AsyncMock(spec=GitHost)
+    if push_error:
+        host.push_branch.side_effect = push_error
+    else:
+        host.push_branch.return_value = None
+    host.get_pr_for_branch.return_value = pr
+    host.create_pr.return_value = _make_pr()
+    host.update_pr.return_value = None
+    host.comment_on_pr.return_value = None
+    if checks_sequence:
+        host.get_pr_checks.side_effect = checks_sequence
+    else:
+        host.get_pr_checks.return_value = _passed_checks("ci")
+    return host
+
+
+def _make_tracker() -> AsyncMock:
+    tracker = AsyncMock(spec=IssueTracker)
+    tracker.comment.return_value = None
+    tracker.add_label.return_value = None
+    tracker.remove_label.return_value = None
+    tracker.ensure_label.return_value = None
+    return tracker
+
+
+def _make_telemetry() -> AsyncMock:
+    tel = AsyncMock()
+    tel.write.return_value = None
+    return tel
+
+
+def _make_ctx(
+    tmp_path: Path,
+    *,
+    item_id: str = "42",
+    work_branch: str = "cog/42-fix",
+    telemetry: Any = None,
+    event_sink: Any = None,
+) -> ExecutionContext:
+    return ExecutionContext(
+        project_dir=tmp_path,
+        tmp_dir=tmp_path,
+        state_cache=InMemoryStateCache(),
+        headless=True,
+        item=make_item(item_id=item_id, title="Fix the bug"),
+        work_branch=work_branch,
+        telemetry=telemetry,
+        event_sink=event_sink or RecordingEventSink(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _writable_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+
+
+class CommitOnceRunner(AgentRunner):
+    """Runner that creates one commit the first time, zero on subsequent calls."""
+
+    def __init__(self, project_dir: Path, message: str = "fix: CI failure") -> None:
+        self._project_dir = project_dir
+        self._message = message
+        self._call_count = 0
+
+    async def stream(self, prompt: str, *, model: str):
+        import subprocess
+
+        self._call_count += 1
+        if self._call_count == 1:
+            subprocess.run(
+                ["git", "commit", "--allow-empty", "-m", self._message],
+                cwd=self._project_dir,
+                capture_output=True,
+                check=True,
+            )
+        yield ResultEvent(
+            result=RunResult(
+                final_message="Fixed the failure.",
+                total_cost_usd=0.1,
+                exit_status=0,
+                stream_json_path=Path("/dev/null"),
+                duration_seconds=1.0,
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# _dedupe_attempt_checks unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_dedupe_attempt_checks_deduplicates_across_attempts() -> None:
+    history = [(0, ("test_x", "lint")), (1, ("test_x", "test_y"))]
+    result = _dedupe_attempt_checks(history)
+    assert result == ("test_x", "lint", "test_y")
+
+
+def test_dedupe_attempt_checks_empty_history() -> None:
+    assert _dedupe_attempt_checks([]) == ()
+
+
+def test_dedupe_attempt_checks_single_attempt() -> None:
+    history = [(0, ("test_a", "test_b"))]
+    assert _dedupe_attempt_checks(history) == ("test_a", "test_b")
+
+
+def test_dedupe_attempt_checks_preserves_order() -> None:
+    history = [(0, ("z", "a")), (1, ("b",))]
+    assert _dedupe_attempt_checks(history) == ("z", "a", "b")
+
+
+# ---------------------------------------------------------------------------
+# _format_cap_comment unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_cap_comment_flags_same_check_repeated() -> None:
+    history = [(0, ("test_x", "lint")), (1, ("test_x",)), (2, ("test_x",))]
+    comment = _format_cap_comment(history, retries_done=2)
+    assert "flaky or environment-specific" in comment
+    assert "test_x" in comment
+
+
+def test_cap_comment_flags_different_checks_per_attempt() -> None:
+    history = [(0, ("test_x",)), (1, ("test_y",))]
+    comment = _format_cap_comment(history, retries_done=1)
+    assert "regressions" in comment
+
+
+def test_cap_comment_lists_all_attempt_outcomes() -> None:
+    history = [(0, ("test_x",)), (1, ("test_y",))]
+    comment = _format_cap_comment(history, retries_done=1)
+    assert "Attempt 0" in comment
+    assert "Attempt 1" in comment
+    assert "test_x" in comment
+    assert "test_y" in comment
+
+
+def test_cap_comment_shows_attempt_count() -> None:
+    history = [(0, ("test_x",)), (1, ("test_x",)), (2, ("test_x",))]
+    comment = _format_cap_comment(history, retries_done=2)
+    assert "3" in comment  # total attempts shown
+
+
+# ---------------------------------------------------------------------------
+# Retry loop behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ci_fail_triggers_fix_stage_not_full_pipeline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CI failure triggers ci-fix stage, NOT build/review/document."""
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.01")
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "1")
+
+    host = _make_host(checks_sequence=[_failed_checks("test_x"), _passed_checks("test_x")])
+    tracker = _make_tracker()
+    ctx = _make_ctx(tmp_path)
+
+    stage_names: list[str] = []
+
+    async def fake_run_stage(self: object, stage: object, ctx: object) -> object:
+        stage_names.append(getattr(stage, "name", "?"))
+        return make_stage_result(
+            getattr(stage, "name", "build"),
+            commits=1,
+            final_message="Fixed it.",
+        )
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(runner=ScriptedFinalMessageRunner(""), tracker=tracker, host=host)
+        pr = _make_pr()
+        results = [make_stage_result("build", commits=1)]
+        await wf._handle_ci_failure(ctx, results, pr, _failed_checks("test_x"))
+
+    assert any(n.startswith("ci-fix-") for n in stage_names)
+    assert "build" not in stage_names
+    assert "review" not in stage_names
+    assert "document" not in stage_names
+
+
+@pytest.mark.asyncio
+async def test_retry_uses_ci_fix_not_build_prompt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ci-fix stage loads ci_fix.md, not build.md."""
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "1")
+
+    captured_prompts: list[str] = []
+
+    class CapturingRunner(AgentRunner):
+        async def stream(self, prompt: str, *, model: str):
+            captured_prompts.append(prompt)
+            yield ResultEvent(
+                result=RunResult(
+                    final_message="fixed",
+                    total_cost_usd=0.0,
+                    exit_status=0,
+                    stream_json_path=Path("/dev/null"),
+                    duration_seconds=0.0,
+                )
+            )
+
+    host = _make_host(checks_sequence=[_passed_checks("ci")])
+    ctx = _make_ctx(tmp_path)
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        ps = getattr(stage, "prompt_source", None)
+        if ps:
+            captured_prompts.append(ps(ctx_arg))
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=1)
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(runner=CapturingRunner(), tracker=_make_tracker(), host=host)
+        pr = _make_pr()
+        await wf._handle_ci_failure(ctx, [], pr, _failed_checks("test_x"))
+
+    assert captured_prompts, "No prompts were captured"
+    prompt = captured_prompts[0]
+    assert "Ralph: CI fix stage" in prompt
+    assert "Reproduce the failure" in prompt
+
+
+@pytest.mark.asyncio
+async def test_retry_inherits_build_model_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "1")
+    monkeypatch.setenv("COG_RALPH_BUILD_MODEL", "claude-opus-4-6")
+
+    stage_models: list[str] = []
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        stage_models.append(getattr(stage, "model", "?"))
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=1)
+
+    host = _make_host(checks_sequence=[_passed_checks("ci")])
+    ctx = _make_ctx(tmp_path)
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(
+            runner=ScriptedFinalMessageRunner(""), tracker=_make_tracker(), host=host
+        )
+        await wf._handle_ci_failure(ctx, [], _make_pr(), _failed_checks("test_x"))
+
+    assert stage_models[0] == "claude-opus-4-6"
+
+
+@pytest.mark.asyncio
+async def test_retry_prompt_includes_failing_check_names_and_links(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "1")
+
+    captured: list[str] = []
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        ps = getattr(stage, "prompt_source", None)
+        if ps:
+            captured.append(ps(ctx_arg))
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=0)
+
+    ctx = _make_ctx(tmp_path)
+    checks = _failed_checks("my_test", "lint")
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(
+            runner=ScriptedFinalMessageRunner(""), tracker=_make_tracker(), host=_make_host()
+        )
+        await wf._handle_ci_failure(ctx, [], _make_pr(), checks)
+
+    assert captured
+    assert "my_test" in captured[0]
+    assert "lint" in captured[0]
+    assert "https://ci/my_test" in captured[0]
+
+
+@pytest.mark.asyncio
+async def test_retry_prompt_does_not_inject_ci_logs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression guard: CI logs must NOT be pre-injected into the prompt."""
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "1")
+
+    captured: list[str] = []
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        ps = getattr(stage, "prompt_source", None)
+        if ps:
+            captured.append(ps(ctx_arg))
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=0)
+
+    ctx = _make_ctx(tmp_path)
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(
+            runner=ScriptedFinalMessageRunner(""), tracker=_make_tracker(), host=_make_host()
+        )
+        await wf._handle_ci_failure(ctx, [], _make_pr(), _failed_checks("test_x"))
+
+    assert captured
+    # Prompt must not contain pre-injected log content (only instructions to fetch)
+    assert "::error::" not in captured[0]
+    assert "Run failed" not in captured[0]
+    assert "##[error]" not in captured[0]
+
+
+@pytest.mark.asyncio
+async def test_retry_with_commit_pushes_and_re_waits_for_ci(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "1")
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.01")
+
+    host = _make_host(checks_sequence=[_passed_checks("ci")])
+    tracker = _make_tracker()
+    ctx = _make_ctx(tmp_path)
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=1)
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(runner=ScriptedFinalMessageRunner(""), tracker=tracker, host=host)
+        await wf._handle_ci_failure(ctx, [], _make_pr(), _failed_checks("test_x"))
+
+    host.push_branch.assert_called_once()
+    host.get_pr_checks.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_retry_increments_per_item_retry_counter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "2")
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.01")
+
+    # First CI wait fails, second passes
+    host = _make_host(checks_sequence=[_failed_checks("test_x"), _passed_checks("ci")])
+    ctx = _make_ctx(tmp_path)
+
+    call_count = 0
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        nonlocal call_count
+        call_count += 1
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=1)
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(
+            runner=ScriptedFinalMessageRunner(""), tracker=_make_tracker(), host=host
+        )
+        await wf._handle_ci_failure(ctx, [], _make_pr(), _failed_checks("test_x"))
+
+    assert wf._ci_retries.get("42", 0) == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_counter_is_per_item_not_global(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "1")
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.01")
+
+    host = _make_host(checks_sequence=[_passed_checks("ci"), _passed_checks("ci")])
+    tracker = _make_tracker()
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=1)
+
+    ctx_1 = _make_ctx(tmp_path, item_id="1")
+    ctx_2 = _make_ctx(tmp_path, item_id="2")
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(runner=ScriptedFinalMessageRunner(""), tracker=tracker, host=host)
+        await wf._handle_ci_failure(ctx_1, [], _make_pr(), _failed_checks("test_x"))
+        await wf._handle_ci_failure(ctx_2, [], _make_pr(), _failed_checks("test_y"))
+
+    assert wf._ci_retries.get("1", 0) == 1
+    assert wf._ci_retries.get("2", 0) == 1
+
+
+# ---------------------------------------------------------------------------
+# Cap enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_cap_default_is_2(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default cap is 2; after 2 fix attempts the item is abandoned."""
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.01")
+    # Remove override so we use the default
+    monkeypatch.delenv("COG_CI_MAX_RETRIES", raising=False)
+
+    fix_call_count = 0
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        nonlocal fix_call_count
+        if getattr(stage, "name", "").startswith("ci-fix"):
+            fix_call_count += 1
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=1)
+
+    # Always fail CI to exhaust cap
+    host = _make_host(
+        checks_sequence=[
+            _failed_checks("test_x"),
+            _failed_checks("test_x"),
+        ]
+    )
+    ctx = _make_ctx(tmp_path)
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(
+            runner=ScriptedFinalMessageRunner(""), tracker=_make_tracker(), host=host
+        )
+        await wf._handle_ci_failure(ctx, [], _make_pr(), _failed_checks("test_x"))
+
+    assert fix_call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_cap_honors_env_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "1")
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.01")
+
+    fix_call_count = 0
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        nonlocal fix_call_count
+        if getattr(stage, "name", "").startswith("ci-fix"):
+            fix_call_count += 1
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=1)
+
+    host = _make_host(checks_sequence=[_failed_checks("test_x")])
+    ctx = _make_ctx(tmp_path)
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(
+            runner=ScriptedFinalMessageRunner(""), tracker=_make_tracker(), host=host
+        )
+        await wf._handle_ci_failure(ctx, [], _make_pr(), _failed_checks("test_x"))
+
+    assert fix_call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_cap_zero_means_first_failure_abandons_immediately(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "0")
+
+    fix_call_count = 0
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        nonlocal fix_call_count
+        if getattr(stage, "name", "").startswith("ci-fix"):
+            fix_call_count += 1
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=0)
+
+    ctx = _make_ctx(tmp_path)
+    tracker = _make_tracker()
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(
+            runner=ScriptedFinalMessageRunner(""), tracker=tracker, host=_make_host()
+        )
+        await wf._handle_ci_failure(ctx, [], _make_pr(), _failed_checks("test_x"))
+
+    assert fix_call_count == 0
+    # Should have been abandoned
+    tracker.add_label.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_retry_cap_exhaustion_calls_abandon(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "1")
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.01")
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=1)
+
+    host = _make_host(checks_sequence=[_failed_checks("test_x")])
+    ctx = _make_ctx(tmp_path)
+    tracker = _make_tracker()
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(runner=ScriptedFinalMessageRunner(""), tracker=tracker, host=host)
+        await wf._handle_ci_failure(ctx, [], _make_pr(), _failed_checks("test_x"))
+
+    # Verify that add_label was called with agent-failed (second arg check)
+    add_label_calls = [call[0][1] for call in tracker.add_label.call_args_list]
+    assert "agent-failed" in add_label_calls
+
+
+# ---------------------------------------------------------------------------
+# No-commit / unreproducible path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_commit_on_fix_stage_treats_as_unreproducible(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "1")
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=0)
+
+    ctx = _make_ctx(tmp_path)
+    tracker = _make_tracker()
+    host = _make_host()
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(runner=ScriptedFinalMessageRunner(""), tracker=tracker, host=host)
+        await wf._handle_ci_failure(ctx, [], _make_pr(), _failed_checks("test_x"))
+
+    # Should abandon immediately without pushing
+    host.push_branch.assert_not_called()
+    tracker.add_label.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_unreproducible_comments_on_pr_with_claude_analysis(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "1")
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        return make_stage_result(
+            getattr(stage, "name", "ci-fix"),
+            commits=0,
+            final_message="I tried running the tests but couldn't reproduce the failure.",
+        )
+
+    ctx = _make_ctx(tmp_path)
+    host = _make_host()
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(
+            runner=ScriptedFinalMessageRunner(""), tracker=_make_tracker(), host=host
+        )
+        await wf._handle_ci_failure(ctx, [], _make_pr(), _failed_checks("test_x"))
+
+    pr_comment_body = host.comment_on_pr.call_args[0][1]
+    assert "couldn't reproduce" in pr_comment_body or "analysis" in pr_comment_body.lower()
+
+
+@pytest.mark.asyncio
+async def test_unreproducible_adds_agent_failed_label(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "1")
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=0)
+
+    ctx = _make_ctx(tmp_path)
+    tracker = _make_tracker()
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(
+            runner=ScriptedFinalMessageRunner(""), tracker=tracker, host=_make_host()
+        )
+        await wf._handle_ci_failure(ctx, [], _make_pr(), _failed_checks("test_x"))
+
+    add_calls = [call[0][1] for call in tracker.add_label.call_args_list]
+    assert "agent-failed" in add_calls
+
+
+@pytest.mark.asyncio
+async def test_unreproducible_removes_agent_ready(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "1")
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=0)
+
+    ctx = _make_ctx(tmp_path)
+    tracker = _make_tracker()
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(
+            runner=ScriptedFinalMessageRunner(""), tracker=tracker, host=_make_host()
+        )
+        await wf._handle_ci_failure(ctx, [], _make_pr(), _failed_checks("test_x"))
+
+    remove_calls = [call[0][1] for call in tracker.remove_label.call_args_list]
+    assert "agent-ready" in remove_calls
+
+
+@pytest.mark.asyncio
+async def test_unreproducible_marks_processed_ci_failed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "1")
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=0)
+
+    ctx = _make_ctx(tmp_path)
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(
+            runner=ScriptedFinalMessageRunner(""), tracker=_make_tracker(), host=_make_host()
+        )
+        await wf._handle_ci_failure(ctx, [], _make_pr(), _failed_checks("test_x"))
+
+    assert ctx.state_cache.is_processed(make_item(item_id="42"))
+
+
+@pytest.mark.asyncio
+async def test_unreproducible_writes_telemetry_with_ci_fix_failed_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "1")
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=0)
+
+    tel = _make_telemetry()
+    ctx = _make_ctx(tmp_path, telemetry=tel)
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(
+            runner=ScriptedFinalMessageRunner(""), tracker=_make_tracker(), host=_make_host()
+        )
+        await wf._handle_ci_failure(ctx, [], _make_pr(), _failed_checks("test_x"))
+
+    tel.write.assert_called_once()
+    record = tel.write.call_args[0][0]
+    assert record.cause_class == "CiFixFailedError"
+
+
+# ---------------------------------------------------------------------------
+# Cap-exhausted smart comment
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cap_exhausted_comment_flags_same_check_repeated(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "1")
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.01")
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=1)
+
+    host = _make_host(checks_sequence=[_failed_checks("test_x")])
+    ctx = _make_ctx(tmp_path)
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(
+            runner=ScriptedFinalMessageRunner(""), tracker=_make_tracker(), host=host
+        )
+        await wf._handle_ci_failure(ctx, [], _make_pr(), _failed_checks("test_x"))
+
+    pr_comment = host.comment_on_pr.call_args[0][1]
+    assert "flaky or environment-specific" in pr_comment or "test_x" in pr_comment
+
+
+@pytest.mark.asyncio
+async def test_cap_exhausted_comment_flags_different_checks_as_regression_risk(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "2")
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.01")
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=1)
+
+    # First retry CI fails on test_y, second retry CI fails on test_z
+    host = _make_host(checks_sequence=[_failed_checks("test_y"), _failed_checks("test_z")])
+    ctx = _make_ctx(tmp_path)
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(
+            runner=ScriptedFinalMessageRunner(""), tracker=_make_tracker(), host=host
+        )
+        await wf._handle_ci_failure(ctx, [], _make_pr(), _failed_checks("test_x"))
+
+    pr_comment = host.comment_on_pr.call_args[0][1]
+    assert "regressions" in pr_comment or "different" in pr_comment.lower()
+
+
+# ---------------------------------------------------------------------------
+# Successful retry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_successful_retry_marks_ci_success_not_ci_failed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "1")
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.01")
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=1)
+
+    host = _make_host(checks_sequence=[_passed_checks("ci")])
+    ctx = _make_ctx(tmp_path)
+    tracker = _make_tracker()
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(runner=ScriptedFinalMessageRunner(""), tracker=tracker, host=host)
+        await wf._handle_ci_failure(ctx, [], _make_pr(), _failed_checks("test_x"))
+
+    assert ctx.state_cache.is_processed(make_item(item_id="42", title="Fix the bug"))
+    # Should be "success" outcome
+    remove_calls = [call[0][1] for call in tracker.remove_label.call_args_list]
+    assert "agent-ready" in remove_calls
+
+
+@pytest.mark.asyncio
+async def test_successful_retry_records_retry_count_in_telemetry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "2")
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.01")
+
+    # First fix CI fails again, second fix CI passes
+    host = _make_host(checks_sequence=[_failed_checks("test_x"), _passed_checks("ci")])
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=1)
+
+    tel = _make_telemetry()
+    ctx = _make_ctx(tmp_path, telemetry=tel)
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(
+            runner=ScriptedFinalMessageRunner(""), tracker=_make_tracker(), host=host
+        )
+        await wf._handle_ci_failure(ctx, [], _make_pr(), _failed_checks("test_x"))
+
+    tel.write.assert_called_once()
+    record = tel.write.call_args[0][0]
+    assert record.retry_count == 2
+
+
+@pytest.mark.asyncio
+async def test_successful_retry_records_ci_failed_checks_in_telemetry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "2")
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.01")
+
+    host = _make_host(checks_sequence=[_failed_checks("test_y"), _passed_checks("ci")])
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=1)
+
+    tel = _make_telemetry()
+    ctx = _make_ctx(tmp_path, telemetry=tel)
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(
+            runner=ScriptedFinalMessageRunner(""), tracker=_make_tracker(), host=host
+        )
+        await wf._handle_ci_failure(ctx, [], _make_pr(), _failed_checks("test_x"))
+
+    record = tel.write.call_args[0][0]
+    assert "test_x" in record.ci_failed_checks
+    assert "test_y" in record.ci_failed_checks
+
+
+# ---------------------------------------------------------------------------
+# Telemetry field tests
+# ---------------------------------------------------------------------------
+
+
+def test_telemetry_retry_count_defaults_to_zero_for_no_retries(tmp_path: Path) -> None:
+    from cog.telemetry import TelemetryRecord
+
+    record = TelemetryRecord.build(
+        project="p",
+        workflow="w",
+        item=make_item(),
+        outcome="success",
+        results=[],
+        duration_seconds=1.0,
+    )
+    assert record.retry_count == 0
+
+
+def test_telemetry_ci_failed_checks_defaults_empty(tmp_path: Path) -> None:
+    from cog.telemetry import TelemetryRecord
+
+    record = TelemetryRecord.build(
+        project="p",
+        workflow="w",
+        item=make_item(),
+        outcome="success",
+        results=[],
+        duration_seconds=1.0,
+    )
+    assert record.ci_failed_checks == ()
+
+
+def test_telemetry_ci_failed_checks_dedupes_across_retries() -> None:
+    history = [(0, ("test_x", "lint")), (1, ("test_x", "test_y"))]
+    result = _dedupe_attempt_checks(history)
+    # test_x only appears once
+    assert result.count("test_x") == 1
+    assert "lint" in result
+    assert "test_y" in result
+
+
+def test_telemetry_ci_failed_checks_empty_when_no_failures() -> None:
+    history: _AttemptHistory = [(0, ())]
+    result = _dedupe_attempt_checks(history)
+    assert result == ()
+
+
+def test_telemetry_record_json_round_trip_preserves_new_fields() -> None:
+    import dataclasses
+    import json
+
+    from cog.telemetry import TelemetryRecord
+
+    record = TelemetryRecord.build(
+        project="p",
+        workflow="w",
+        item=make_item(),
+        outcome="ci-failed",
+        results=[],
+        duration_seconds=1.0,
+        retry_count=2,
+        ci_failed_checks=("test_x", "lint"),
+    )
+    d = dataclasses.asdict(record)
+    parsed = json.loads(json.dumps(d))
+    assert parsed["retry_count"] == 2
+    assert parsed["ci_failed_checks"] == ["test_x", "lint"]
+
+
+def test_telemetry_record_retry_count_field_defaults_zero() -> None:
+    import dataclasses
+
+    from cog.telemetry import TelemetryRecord
+
+    record = TelemetryRecord.build(
+        project="p",
+        workflow="w",
+        item=make_item(),
+        outcome="success",
+        results=[],
+        duration_seconds=1.0,
+    )
+    d = dataclasses.asdict(record)
+    assert d["retry_count"] == 0
+
+
+def test_telemetry_record_ci_failed_checks_field_defaults_empty() -> None:
+    import dataclasses
+
+    from cog.telemetry import TelemetryRecord
+
+    record = TelemetryRecord.build(
+        project="p",
+        workflow="w",
+        item=make_item(),
+        outcome="success",
+        results=[],
+        duration_seconds=1.0,
+    )
+    d = dataclasses.asdict(record)
+    assert d["ci_failed_checks"] == ()
+
+
+# ---------------------------------------------------------------------------
+# Prompt tests
+# ---------------------------------------------------------------------------
+
+
+def test_ci_fix_prompt_exists_and_loads() -> None:
+    from cog.workflows.ralph import _load_prompt
+
+    text = _load_prompt("ci_fix")
+    assert len(text) > 0
+
+
+def test_ci_fix_prompt_instructs_claude_to_fetch_logs_via_gh() -> None:
+    from cog.workflows.ralph import _load_prompt
+
+    content = _load_prompt("ci_fix")
+    assert "gh run view" in content
+    assert "--log-failed" in content
+
+
+def test_ci_fix_prompt_defines_commit_or_exit_contract() -> None:
+    from cog.workflows.ralph import _load_prompt
+
+    content = _load_prompt("ci_fix")
+    assert "commit" in content.lower()
+    assert "exit" in content.lower()
+
+
+def test_ci_fix_prompt_does_not_inject_log_content() -> None:
+    """Regression guard: prompt must not have pre-injected log placeholders."""
+    from cog.workflows.ralph import _load_prompt
+
+    content = _load_prompt("ci_fix")
+    assert "{ci_log}" not in content
+    assert "{log_output}" not in content
+    assert "{{" not in content
+
+
+# Type alias reference for tests
+from cog.workflows.ralph import _AttemptHistory  # noqa: E402

--- a/tests/test_workflows/test_ralph_ci_fix.py
+++ b/tests/test_workflows/test_ralph_ci_fix.py
@@ -544,8 +544,6 @@ async def test_ci_timeout_during_retry_abandons_with_timeout_cause(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """If CI times out during a retry, abandon with CiTimeoutError, not CiRetryCapExhaustedError."""
-    from cog.core.errors import CiTimeoutError
-
     monkeypatch.setenv("COG_CI_MAX_RETRIES", "2")
     monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.01")
     monkeypatch.setenv("COG_CI_TIMEOUT_SECONDS", "0.01")

--- a/tests/test_workflows/test_ralph_ci_fix.py
+++ b/tests/test_workflows/test_ralph_ci_fix.py
@@ -106,36 +106,6 @@ def _writable_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
 
 
-class CommitOnceRunner(AgentRunner):
-    """Runner that creates one commit the first time, zero on subsequent calls."""
-
-    def __init__(self, project_dir: Path, message: str = "fix: CI failure") -> None:
-        self._project_dir = project_dir
-        self._message = message
-        self._call_count = 0
-
-    async def stream(self, prompt: str, *, model: str):
-        import subprocess
-
-        self._call_count += 1
-        if self._call_count == 1:
-            subprocess.run(
-                ["git", "commit", "--allow-empty", "-m", self._message],
-                cwd=self._project_dir,
-                capture_output=True,
-                check=True,
-            )
-        yield ResultEvent(
-            result=RunResult(
-                final_message="Fixed the failure.",
-                total_cost_usd=0.1,
-                exit_status=0,
-                stream_json_path=Path("/dev/null"),
-                duration_seconds=1.0,
-            )
-        )
-
-
 # ---------------------------------------------------------------------------
 # _dedupe_attempt_checks unit tests
 # ---------------------------------------------------------------------------
@@ -561,6 +531,47 @@ async def test_retry_cap_exhaustion_calls_abandon(
     # Verify that add_label was called with agent-failed (second arg check)
     add_label_calls = [call[0][1] for call in tracker.add_label.call_args_list]
     assert "agent-failed" in add_label_calls
+
+
+# ---------------------------------------------------------------------------
+# CI timeout during retry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ci_timeout_during_retry_abandons_with_timeout_cause(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If CI times out during a retry, abandon with CiTimeoutError, not CiRetryCapExhaustedError."""
+    from cog.core.errors import CiTimeoutError
+
+    monkeypatch.setenv("COG_CI_MAX_RETRIES", "2")
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.01")
+    monkeypatch.setenv("COG_CI_TIMEOUT_SECONDS", "0.01")
+
+    async def fake_run_stage(self: object, stage: object, ctx_arg: object) -> object:
+        return make_stage_result(getattr(stage, "name", "ci-fix"), commits=1)
+
+    # The fix stage commits; then _wait_for_ci times out
+    host = _make_host()
+    # Make get_pr_checks always return pending so CI times out
+    from cog.core.host import CheckRun, PrChecks
+
+    host.get_pr_checks.return_value = PrChecks(
+        runs=(CheckRun(name="ci", state="pending", link=""),)
+    )
+    tel = _make_telemetry()
+    ctx = _make_ctx(tmp_path, telemetry=tel)
+    tracker = _make_tracker()
+
+    with patch("cog.core.workflow.StageExecutor._run_stage", fake_run_stage):
+        wf = RalphWorkflow(runner=ScriptedFinalMessageRunner(""), tracker=tracker, host=host)
+        await wf._handle_ci_failure(ctx, [], _make_pr(), _failed_checks("test_x"))
+
+    tel.write.assert_called_once()
+    record = tel.write.call_args[0][0]
+    assert record.cause_class == "CiTimeoutError"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_workflows/test_ralph_ci_wait.py
+++ b/tests/test_workflows/test_ralph_ci_wait.py
@@ -514,9 +514,11 @@ async def test_finalize_success_ci_fail_marks_processed_with_ci_failed_outcome(
     assert ctx.state_cache._processed[ctx.state_cache._key(ctx.item)] == "ci-failed"
 
 
-async def test_finalize_success_ci_fail_writes_telemetry_with_cause_class_ci_checks_failed_error(
+async def test_finalize_success_ci_fail_writes_telemetry_with_ci_failed_outcome(
     tmp_path: Path,
 ) -> None:
+    # When CI fails and the fix stage commits nothing (EchoRunner returns 0 commits),
+    # cause_class is CiFixFailedError (the fix stage ran but couldn't reproduce/fix).
     tel = _make_telemetry()
     host = _make_host()
     wf = _make_wf(host=host)
@@ -529,7 +531,7 @@ async def test_finalize_success_ci_fail_writes_telemetry_with_cause_class_ci_che
     tel.write.assert_awaited_once()
     record = tel.write.call_args.args[0]
     assert record.outcome == "ci-failed"
-    assert record.cause_class == "CiChecksFailedError"
+    assert record.cause_class == "CiFixFailedError"
 
 
 async def test_finalize_success_ci_timeout_writes_telemetry_with_cause_class_ci_timeout_error(


### PR DESCRIPTION
## Summary



## Closes

Closes #101

## Test plan


- [ ] When CI fails on a PR, verify ralph invokes a `ci-fix-1` stage (visible in stream-json) — NOT build/review/document
- [ ] Verify `gh run view <run-id> --log-failed` is mentioned in the prompt that goes to claude for the ci-fix stage
- [ ] When the fix stage creates a commit, confirm ralph pushes the branch and re-polls CI (observe `get_pr_checks` calls in stream-json)
- [ ] When fix succeeds: item state_cache shows `success`, telemetry has `retry_count=1`, `ci_failed_checks` contains the original failing check name
- [ ] When fix stage exits without committing: confirm PR gets a comment with `Claude's analysis:` section containing claude's final message, `agent-failed` label applied, item marked `ci-failed`
- [ ] Set `COG_CI_MAX_RETRIES=0` and verify a CI failure immediately abandons (no fix stage invoked, smart cap comment posted)
- [ ] Set `COG_CI_MAX_RETRIES=1` and have the fix introduce a NEW failing check: verify the smart cap comment says "Different checks failed on each attempt — fixes may be introducing regressions"
- [ ] Same scenario but same check fails on both attempts: verify smart cap comment says "These checks failed on every attempt: ... — consider whether they're flaky or environment-specific"
- [ ] Confirm `runs.jsonl` entries have `retry_count` and `ci_failed_checks` fields after a retry scenario
- [ ] Verify `cog doctor` still healthy and `cog ralph --headless --loop` still completes with both green and red PRs

---
🤖 Generated by [ralph](https://github.com/jessiepuls/ralph). Iteration cost: $9.27.