### PR TITLE
Convert prompt injection to on-demand fetching + create CLAUDE.md with prompt-writing conventions (#102)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,12 +110,70 @@ strict).
   "must run in a worker" need to assert dispatch (e.g. `run_worker`
   was called), not just the downstream flow.
 
+### Test granularity
+
+- **Parametrize when inputs vary, keep separate tests when behaviors differ.**
+  Use `@pytest.mark.parametrize` to collapse near-identical tests that only
+  differ in input values. Use separate test functions when the assertion or
+  setup differs meaningfully.
+- **Group assertions for one behavior, split for independent behaviors.**
+  Multiple `assert` statements in one test are fine when they all verify a
+  single invariant. Split into separate tests when failures would have
+  different diagnoses.
+- **Unit vs integration: pick one abstraction level per behavior.** Test
+  the public surface (workflow methods, CLI commands) for behavioral
+  correctness; test helpers/internals only when they have non-obvious
+  logic. Avoid testing the same thing at both levels.
+- **Over-testing signals**: if your test name ends in `_field_X_value_Y`,
+  consider grouping. If you have 5 tests that all exercise one code path
+  with different data, parametrize them. If you find yourself asserting
+  implementation details (e.g., internal dict contents) rather than
+  observable behavior, step back.
+
 ## Prompts
 
 Prompts live as markdown in `src/cog/prompts/claude/{ralph,refine}/*.md`
 and are loaded via `importlib.resources` at runtime. Each stage has its
 own file. When changing prompt behavior, change the markdown — not
 Python strings.
+
+### Prompt-writing conventions
+
+**Prefer on-demand fetching over context injection.** For any prompt
+content that is large (>few KB), variable, or would be partially consumed:
+give claude a pointer + instruction, not the content itself.
+
+Bad:
+```
+## Issue body
+{{full item body interpolated here — 20KB}}
+```
+
+Good:
+```
+To see the item body, run `gh issue view <item_id> --json body,comments`.
+Fetch when you need it; don't assume you need the full body for every decision.
+```
+
+Benefits: smaller prompts start faster, allow claude-code's context
+compaction to drop unused content, leave headroom before the #48/#78
+stall classes emerge, and pick up live state on retry.
+
+Exceptions (keep injected): small, always-needed, stable context — item
+number, item title, branch name.
+
+**Structured final-message sections.** Build prompts tell claude to end
+with `### Summary / ### Key changes / ### Test plan` so cog's finalize
+step can extract structured metadata into the PR body. Never change these
+section names without updating `_split_final_message` in
+`workflows/ralph.py` and matching fixtures.
+
+**Tracker-agnostic language.** Refer to "tracked items" not "GitHub
+issues" in prompts and non-GitHub-specific code.
+
+**Bounded tool calls.** All cog prompts warn claude about claude-code's
+>30KB tool-output persistence behavior. Preserve that warning in any new
+prompt.
 
 ## Style / conventions
 

--- a/src/cog/prompts/claude/ralph/build.md
+++ b/src/cog/prompts/claude/ralph/build.md
@@ -11,10 +11,22 @@ linter, fix failures, commit. Nothing else. Pushing the branch, opening
 the PR, and commenting on the item all happen in the wrapper after you
 exit.
 
+## Item context
+
+To see the item's current body and comments:
+
+    gh issue view <item_id> --json body,comments --jq '.body,.comments'
+
+where `<item_id>` is the number shown in the runtime context at the end
+of this prompt. Fetch when you need it — not every decision requires the
+full body. Claude Code persists any tool output >30KB to a session-scoped
+file; pipe through `head -c 30000` or use `--jq` to stay bounded.
+
 ## Steps
 
-1. Read the item title, body, and comments (provided in the runtime
-   context section appended below).
+1. Fetch the item body and comments when you need them (see **Item
+   context** above). Item number and title are already in the runtime
+   context.
 2. Implement the change required by the item.
 3. Write or update tests that exercise the new or changed behavior.
 4. Run the project's test suite. Fix any failures.

--- a/src/cog/prompts/claude/ralph/document.md
+++ b/src/cog/prompts/claude/ralph/document.md
@@ -20,6 +20,17 @@ Focus on user-facing changes that aren't self-evident from the code:
 4. **Upgrade notes** — anything a user upgrading from a previous version
    needs to do.
 
+## Item context
+
+To see the item's current body and comments:
+
+    gh issue view <item_id> --json body,comments --jq '.body,.comments'
+
+where `<item_id>` is the number shown in the runtime context at the end
+of this prompt. Fetch when you need it — not every decision requires the
+full body. Claude Code persists any tool output >30KB to a session-scoped
+file; pipe through `head -c 30000` or use `--jq` to stay bounded.
+
 ## Steps
 
 1. Run `git diff --stat $(git merge-base HEAD main 2>/dev/null || git merge-base HEAD master)..HEAD`
@@ -30,7 +41,7 @@ Focus on user-facing changes that aren't self-evident from the code:
 3. Run `git log --oneline $(git merge-base HEAD main 2>/dev/null || git merge-base HEAD master)..HEAD`
    for bounded commit subjects to inform the narrative (NOT `-p`, which
    includes full patches).
-4. Read the item body (provided in the runtime context below) for context
+4. Fetch the item body if needed (see **Item context** above) for context
    on the intent of the change.
 5. Update relevant documentation files (README, CHANGELOG, docstrings,
    inline comments that explain WHY — not what).

--- a/src/cog/prompts/claude/ralph/review.md
+++ b/src/cog/prompts/claude/ralph/review.md
@@ -22,6 +22,17 @@ final message.
    prevents? Near-duplicate blocks that should be extracted? Comments that
    restate what the code does?
 
+## Item context
+
+To see the item's current body and comments:
+
+    gh issue view <item_id> --json body,comments --jq '.body,.comments'
+
+where `<item_id>` is the number shown in the runtime context at the end
+of this prompt. Fetch when you need it — not every decision requires the
+full body. Claude Code persists any tool output >30KB to a session-scoped
+file; pipe through `head -c 30000` or use `--jq` to stay bounded.
+
 ## Steps
 
 1. Run `git diff --stat $(git merge-base HEAD main 2>/dev/null || git merge-base HEAD master)..HEAD`
@@ -33,7 +44,8 @@ final message.
 4. For other changed files: optionally run
    `git diff <base>..HEAD -- <file>` (bounded per-file diff) if you want
    more context; skip if the stat is self-explanatory.
-5. Read the item body (provided in the runtime context below).
+5. Fetch the item body if needed (see **Item context** above) to check
+   implementation against the acceptance criteria.
 6. Identify any defects, missing coverage, or style violations.
 7. Fix what you can directly. Commit fixes with clear messages.
 8. In your final message, list any remaining concerns that require human

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -141,12 +141,6 @@ def _build_prompt(stage_name: str, ctx: ExecutionContext) -> str:
     parts.append(f"Issue #{item.item_id}: {item.title}")
     if ctx.work_branch:
         parts.append(f"Branch: {ctx.work_branch}")
-    parts.append(f"\n### Issue body\n\n{item.body}\n")
-    if item.comments:
-        comments_formatted = "\n\n".join(
-            f"**{c.author}** ({c.created_at.isoformat()}):\n{c.body}" for c in item.comments
-        )
-        parts.append(f"\n### Comments\n\n{comments_formatted}\n")
     return "\n".join(parts)
 
 

--- a/src/cog/workflows/refine.py
+++ b/src/cog/workflows/refine.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum
 from importlib.resources import files
+from pathlib import Path
 from typing import ClassVar, Literal
 
 from cog.checks import REFINE_CHECKS
@@ -67,6 +68,15 @@ class ReviewOutcome:
     final_title: str
 
 
+def _format_transcript_markdown(turns: list[InterviewTurn]) -> str:
+    parts: list[str] = []
+    for i, turn in enumerate(turns, 1):
+        parts.append(f"## Turn {i} — Assistant\n\n{turn.assistant_message}")
+        if turn.user_message is not None:
+            parts.append(f"## Turn {i} — User\n\n{turn.user_message}")
+    return "\n\n".join(parts)
+
+
 def _load_refine_prompt(name: str) -> str:
     return files("cog.prompts.claude.refine").joinpath(f"{name}.md").read_text(encoding="utf-8")
 
@@ -91,6 +101,7 @@ class RefineWorkflow(Workflow):
         self._runner = runner
         self._tracker = tracker
         self._transcripts: dict[str, list[InterviewTurn]] = {}
+        self._transcript_paths: dict[str, Path] = {}
         self._review_outcomes: dict[str, ReviewOutcome] = {}
 
     async def select_item(self, ctx: ExecutionContext) -> Item | None:
@@ -112,6 +123,9 @@ class RefineWorkflow(Workflow):
         assert ctx.input_provider is not None, "refine interview requires an input provider"
         transcript = await self._run_interview(ctx)
         self._transcripts[ctx.item.item_id] = transcript
+        transcript_path = ctx.tmp_dir / f"interview-{ctx.item.item_id}.md"
+        transcript_path.write_text(_format_transcript_markdown(transcript), encoding="utf-8")
+        self._transcript_paths[ctx.item.item_id] = transcript_path
 
     def stages(self, ctx: ExecutionContext) -> list[Stage]:
         return [
@@ -351,6 +365,7 @@ class RefineWorkflow(Workflow):
     def _build_rewrite_prompt(self, ctx: ExecutionContext) -> str:
         assert ctx.item is not None
         transcript = self._transcripts[ctx.item.item_id]
+        transcript_path = self._transcript_paths[ctx.item.item_id]
         item = ctx.item
         parts = [
             _load_refine_prompt("rewrite"),
@@ -362,11 +377,13 @@ class RefineWorkflow(Workflow):
             parts.append("\n### Comments\n")
             for c in item.comments:
                 parts.append(f"\n**{c.author}**:\n{c.body}\n")
-        parts.append("\n## Interview transcript\n")
-        for i, turn in enumerate(transcript, 1):
-            parts.append(f"\n### Turn {i} — Assistant\n{turn.assistant_message}\n")
-            if turn.user_message is not None:
-                parts.append(f"\n### Turn {i} — User\n{turn.user_message}\n")
+        parts.append(
+            f"\n## Interview transcript\n\n"
+            f"The full interview transcript is at `{transcript_path}`. "
+            f"Read it to understand the user's decisions. Use grep / partial "
+            f"reads if the transcript is long — don't read the whole thing "
+            f"if you don't need to."
+        )
         if transcript[-1].end == InterviewEnd.USER:
             parts.append(
                 "\n## Refinement status\n\n"

--- a/tests/test_workflows/test_ralph_prompts.py
+++ b/tests/test_workflows/test_ralph_prompts.py
@@ -75,13 +75,6 @@ def test_build_prompt_includes_issue_number_and_title(tmp_path):
     assert "Issue #42: Test issue" in prompt
 
 
-def test_build_prompt_includes_body(tmp_path):
-    item = make_item(body="The body content here.")
-    ctx = _make_ctx(tmp_path, item=item)
-    prompt = _build_prompt("build", ctx)
-    assert "The body content here." in prompt
-
-
 def test_build_prompt_includes_branch_when_set(tmp_path):
     item = make_item()
     ctx = _make_ctx(tmp_path, item=item, work_branch="ralph/42-my-feature")
@@ -96,7 +89,53 @@ def test_build_prompt_omits_branch_when_none(tmp_path):
     assert "Branch:" not in prompt
 
 
-def test_build_prompt_includes_comments_section_when_present(tmp_path):
+def test_build_prompt_raises_when_item_unset(tmp_path):
+    ctx = _make_ctx(tmp_path, item=None)
+    with pytest.raises(AssertionError):
+        _build_prompt("build", ctx)
+
+
+# ---------------------------------------------------------------------------
+# On-demand fetching — prompt static content
+# ---------------------------------------------------------------------------
+
+
+def test_build_prompt_tells_claude_to_fetch_body_via_gh_issue_view():
+    content = _load_prompt("build")
+    assert "gh issue view" in content
+
+
+def test_review_prompt_tells_claude_to_fetch_body_via_gh_issue_view():
+    content = _load_prompt("review")
+    assert "gh issue view" in content
+
+
+def test_document_prompt_tells_claude_to_fetch_body_via_gh_issue_view():
+    content = _load_prompt("document")
+    assert "gh issue view" in content
+
+
+def test_ralph_prompts_include_bounded_output_guidance_for_gh_fetch():
+    for stage in ("build", "review", "document"):
+        content = _load_prompt(stage)
+        assert "head -c 30000" in content or "--jq" in content, (
+            f"{stage}.md is missing bounded-output guidance for gh fetch"
+        )
+
+
+# ---------------------------------------------------------------------------
+# On-demand fetching — runtime assembly regression guards
+# ---------------------------------------------------------------------------
+
+
+def test_build_prompt_runtime_assembly_does_not_include_full_item_body(tmp_path):
+    item = make_item(body="The body content should not appear here.")
+    ctx = _make_ctx(tmp_path, item=item)
+    prompt = _build_prompt("build", ctx)
+    assert "The body content should not appear here." not in prompt
+
+
+def test_build_prompt_runtime_assembly_does_not_include_comments_section(tmp_path):
     comment = Comment(
         author="alice",
         body="Great idea!",
@@ -105,22 +144,22 @@ def test_build_prompt_includes_comments_section_when_present(tmp_path):
     item = make_item(comments=(comment,))
     ctx = _make_ctx(tmp_path, item=item)
     prompt = _build_prompt("build", ctx)
-    assert "### Comments" in prompt
-    assert "alice" in prompt
-    assert "Great idea!" in prompt
-
-
-def test_build_prompt_omits_comments_section_when_empty(tmp_path):
-    item = make_item(comments=())
-    ctx = _make_ctx(tmp_path, item=item)
-    prompt = _build_prompt("build", ctx)
+    assert "Great idea!" not in prompt
     assert "### Comments" not in prompt
 
 
-def test_build_prompt_raises_when_item_unset(tmp_path):
-    ctx = _make_ctx(tmp_path, item=None)
-    with pytest.raises(AssertionError):
-        _build_prompt("build", ctx)
+def test_build_prompt_runtime_assembly_still_includes_item_number_and_title(tmp_path):
+    item = make_item(item_id="99", title="My feature")
+    ctx = _make_ctx(tmp_path, item=item)
+    prompt = _build_prompt("build", ctx)
+    assert "Issue #99: My feature" in prompt
+
+
+def test_build_prompt_runtime_assembly_still_includes_branch_name_when_set(tmp_path):
+    item = make_item(item_id="7")
+    ctx = _make_ctx(tmp_path, item=item, work_branch="ralph/7-my-branch")
+    prompt = _build_prompt("build", ctx)
+    assert "Branch: ralph/7-my-branch" in prompt
 
 
 def test_no_unbounded_git_diff_in_prompts():

--- a/tests/test_workflows/test_refine_integration.py
+++ b/tests/test_workflows/test_refine_integration.py
@@ -58,9 +58,11 @@ async def test_refine_interview_end_to_end_with_scripted_runner(tmp_path):
     sink = RecordingEventSink()
     provider = ScriptedInputProvider(["my answer"])
 
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
     ctx = ExecutionContext(
         project_dir=tmp_path,
-        tmp_dir=tmp_path / "tmp",
+        tmp_dir=tmp_dir,
         state_cache=InMemoryStateCache(),
         headless=False,
         item=items[0],

--- a/tests/test_workflows/test_refine_integration_ext.py
+++ b/tests/test_workflows/test_refine_integration_ext.py
@@ -87,9 +87,11 @@ async def test_refine_iteration_sentinel_accept_updates_body_and_swaps_labels(tm
 
     sink = RecordingEventSink()
     provider = ScriptedInputProvider([])
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
     ctx = ExecutionContext(
         project_dir=tmp_path,
-        tmp_dir=tmp_path / "tmp",
+        tmp_dir=tmp_dir,
         state_cache=InMemoryStateCache(),
         headless=False,
         item=items[0],

--- a/tests/test_workflows/test_refine_interview.py
+++ b/tests/test_workflows/test_refine_interview.py
@@ -41,9 +41,11 @@ def _make_ctx(
     provider: ScriptedInputProvider | None = None,
     tmp_path: Path,
 ) -> ExecutionContext:
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir(exist_ok=True)
     return ExecutionContext(
         project_dir=tmp_path,
-        tmp_dir=tmp_path / "tmp",
+        tmp_dir=tmp_dir,
         state_cache=InMemoryStateCache(),
         headless=False,
         item=item,

--- a/tests/test_workflows/test_refine_prompts.py
+++ b/tests/test_workflows/test_refine_prompts.py
@@ -1,0 +1,79 @@
+"""Tests for RefineWorkflow rewrite prompt assembly (on-demand transcript pattern)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from cog.core.context import ExecutionContext
+from cog.workflows.refine import InterviewEnd, InterviewTurn, RefineWorkflow
+from tests.fakes import InMemoryStateCache, ScriptedRewriteRunner, make_item
+
+
+def _make_ctx(tmp_path: Path, item_id: str) -> ExecutionContext:
+    item = make_item(item_id=item_id, title="My item", body="Body text")
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    return ExecutionContext(
+        project_dir=tmp_path,
+        tmp_dir=tmp_dir,
+        state_cache=InMemoryStateCache(),
+        headless=False,
+        item=item,
+    )
+
+
+def _make_workflow_with_transcript(
+    tmp_path: Path, item_id: str
+) -> tuple[RefineWorkflow, ExecutionContext]:
+    wf = RefineWorkflow(runner=ScriptedRewriteRunner(""), tracker=AsyncMock())
+    turns = [
+        InterviewTurn(
+            assistant_message="What does this need?",
+            user_message="It needs caching.",
+            cost_usd=0.1,
+            duration_seconds=1.0,
+        ),
+        InterviewTurn(
+            assistant_message="Got it.",
+            user_message=None,
+            cost_usd=0.1,
+            duration_seconds=1.0,
+            end=InterviewEnd.SENTINEL,
+        ),
+    ]
+    wf._transcripts[item_id] = turns
+    transcript_path = tmp_path / "tmp" / f"interview-{item_id}.md"
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text("stub content", encoding="utf-8")
+    wf._transcript_paths[item_id] = transcript_path
+    ctx = _make_ctx(tmp_path, item_id)
+    return wf, ctx
+
+
+def test_refine_rewrite_prompt_tells_claude_to_read_transcript_file(tmp_path):
+    wf, ctx = _make_workflow_with_transcript(tmp_path, "30")
+    prompt = wf._build_rewrite_prompt(ctx)
+    assert "Read" in prompt or "read" in prompt
+    assert "interview-30.md" in prompt
+
+
+def test_refine_rewrite_prompt_points_to_tmp_dir_path(tmp_path):
+    wf, ctx = _make_workflow_with_transcript(tmp_path, "31")
+    prompt = wf._build_rewrite_prompt(ctx)
+    expected = str(ctx.tmp_dir / "interview-31.md")
+    assert expected in prompt
+
+
+def test_refine_rewrite_prompt_does_not_inline_transcript_content(tmp_path):
+    wf, ctx = _make_workflow_with_transcript(tmp_path, "32")
+    prompt = wf._build_rewrite_prompt(ctx)
+    assert "What does this need?" not in prompt
+    assert "It needs caching." not in prompt
+    assert "Got it." not in prompt
+
+
+def test_refine_rewrite_prompt_includes_partial_read_guidance(tmp_path):
+    wf, ctx = _make_workflow_with_transcript(tmp_path, "33")
+    prompt = wf._build_rewrite_prompt(ctx)
+    assert "grep" in prompt or "partial" in prompt

--- a/tests/test_workflows/test_refine_rewrite.py
+++ b/tests/test_workflows/test_refine_rewrite.py
@@ -9,12 +9,21 @@ import pytest
 
 from cog.core.context import ExecutionContext
 from cog.workflows.refine import (
+    _INTERVIEW_COMPLETE,
     InterviewEnd,
     InterviewTurn,
     RefineWorkflow,
     _extract_title_body,
+    _format_transcript_markdown,
 )
-from tests.fakes import InMemoryStateCache, ScriptedRewriteRunner, make_item
+from tests.fakes import (
+    InMemoryStateCache,
+    RecordingEventSink,
+    ScriptedInputProvider,
+    ScriptedInterviewRunner,
+    ScriptedRewriteRunner,
+    make_item,
+)
 
 
 def _make_ctx(tmp_path: Path, item=None) -> ExecutionContext:
@@ -92,7 +101,12 @@ def test_rewrite_prompt_includes_original_body_and_comments(tmp_path):
     )
     item = make_item(item_id="1", title="My issue", body="Original body", comments=(comment,))
     wf = _make_workflow([])
-    wf._transcripts["1"] = _make_sentinel_transcript()
+    transcript = _make_sentinel_transcript()
+    wf._transcripts["1"] = transcript
+    transcript_path = tmp_path / "tmp" / "interview-1.md"
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text("stub", encoding="utf-8")
+    wf._transcript_paths["1"] = transcript_path
     ctx = _make_ctx(tmp_path, item=item)
     prompt = wf._build_rewrite_prompt(ctx)
     assert "Original body" in prompt
@@ -100,22 +114,33 @@ def test_rewrite_prompt_includes_original_body_and_comments(tmp_path):
     assert "Good point" in prompt
 
 
-def test_rewrite_prompt_includes_full_transcript(tmp_path):
+def test_rewrite_prompt_does_not_inline_transcript_content(tmp_path):
     item = make_item(item_id="2", title="T", body="B")
     wf = _make_workflow([])
     transcript = _make_sentinel_transcript()
     wf._transcripts["2"] = transcript
+    transcript_path = tmp_path / "tmp" / "interview-2.md"
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text("stub", encoding="utf-8")
+    wf._transcript_paths["2"] = transcript_path
     ctx = _make_ctx(tmp_path, item=item)
     prompt = wf._build_rewrite_prompt(ctx)
-    assert "What does this item need?" in prompt
-    assert "It needs caching." in prompt
-    assert "Got it." in prompt
+    assert "What does this item need?" not in prompt
+    assert "It needs caching." not in prompt
+
+
+def _setup_transcript_path(wf: RefineWorkflow, tmp_path: Path, item_id: str) -> None:
+    path = tmp_path / "tmp" / f"interview-{item_id}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("stub", encoding="utf-8")
+    wf._transcript_paths[item_id] = path
 
 
 def test_rewrite_prompt_omits_early_end_block_on_sentinel_end(tmp_path):
     item = make_item(item_id="3", title="T", body="B")
     wf = _make_workflow([])
     wf._transcripts["3"] = _make_sentinel_transcript()
+    _setup_transcript_path(wf, tmp_path, "3")
     ctx = _make_ctx(tmp_path, item=item)
     prompt = wf._build_rewrite_prompt(ctx)
     # The runtime-injected block uses "## Refinement status" as a heading
@@ -126,6 +151,7 @@ def test_rewrite_prompt_includes_early_end_block_on_user_end(tmp_path):
     item = make_item(item_id="4", title="T", body="B")
     wf = _make_workflow([])
     wf._transcripts["4"] = _make_user_end_transcript()
+    _setup_transcript_path(wf, tmp_path, "4")
     ctx = _make_ctx(tmp_path, item=item)
     prompt = wf._build_rewrite_prompt(ctx)
     # The runtime-injected block uses "## Refinement status" as a heading
@@ -218,3 +244,110 @@ async def test_classify_outcome_returns_noop_on_abandon(tmp_path):
     ctx = _make_ctx(tmp_path, item=item)
     outcome = await wf.classify_outcome(ctx, [])
     assert outcome == "noop"
+
+
+# ---------------------------------------------------------------------------
+# _format_transcript_markdown
+# ---------------------------------------------------------------------------
+
+
+def test_format_transcript_markdown_includes_all_turns():
+    turns = [
+        InterviewTurn(
+            assistant_message="First question",
+            user_message="First answer",
+            cost_usd=0.1,
+            duration_seconds=1.0,
+        ),
+        InterviewTurn(
+            assistant_message="Second question",
+            user_message=None,
+            cost_usd=0.1,
+            duration_seconds=1.0,
+            end=InterviewEnd.SENTINEL,
+        ),
+    ]
+    md = _format_transcript_markdown(turns)
+    assert "First question" in md
+    assert "First answer" in md
+    assert "Second question" in md
+
+
+def test_format_transcript_markdown_uses_section_headings():
+    turns = [
+        InterviewTurn(
+            assistant_message="Hello",
+            user_message="Hi",
+            cost_usd=0.0,
+            duration_seconds=0.0,
+        )
+    ]
+    md = _format_transcript_markdown(turns)
+    assert "## Turn 1 — Assistant" in md
+    assert "## Turn 1 — User" in md
+
+
+def test_format_transcript_markdown_omits_user_section_when_no_user_message():
+    turns = [
+        InterviewTurn(
+            assistant_message="Done",
+            user_message=None,
+            cost_usd=0.0,
+            duration_seconds=0.0,
+            end=InterviewEnd.SENTINEL,
+        )
+    ]
+    md = _format_transcript_markdown(turns)
+    assert "## Turn 1 — Assistant" in md
+    assert "User" not in md
+
+
+# ---------------------------------------------------------------------------
+# pre_stages — transcript file creation
+# ---------------------------------------------------------------------------
+
+
+def _make_pre_stages_ctx(tmp_path: Path, item_id: str) -> ExecutionContext:
+    item = make_item(item_id=item_id, title="Test item", body="Body")
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    return ExecutionContext(
+        project_dir=tmp_path,
+        tmp_dir=tmp_dir,
+        state_cache=InMemoryStateCache(),
+        headless=False,
+        item=item,
+        event_sink=RecordingEventSink(),
+        input_provider=ScriptedInputProvider([]),
+    )
+
+
+@pytest.mark.asyncio
+async def test_pre_stages_writes_transcript_to_ctx_tmp_dir_with_expected_filename(tmp_path):
+    runner = ScriptedInterviewRunner([(f"Question\n{_INTERVIEW_COMPLETE}", 0.1)])
+    wf = RefineWorkflow(runner=runner, tracker=AsyncMock())
+    ctx = _make_pre_stages_ctx(tmp_path, "20")
+    await wf.pre_stages(ctx)
+    assert (ctx.tmp_dir / "interview-20.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_transcript_file_contains_all_turns_in_markdown_format(tmp_path):
+    runner = ScriptedInterviewRunner([(f"My question\n{_INTERVIEW_COMPLETE}", 0.1)])
+    wf = RefineWorkflow(runner=runner, tracker=AsyncMock())
+    ctx = _make_pre_stages_ctx(tmp_path, "21")
+    await wf.pre_stages(ctx)
+    content = (ctx.tmp_dir / "interview-21.md").read_text(encoding="utf-8")
+    assert "## Turn 1 — Assistant" in content
+    assert "My question" in content
+
+
+@pytest.mark.asyncio
+async def test_rewrite_prompt_references_actual_transcript_path(tmp_path):
+    runner = ScriptedInterviewRunner([(f"Q\n{_INTERVIEW_COMPLETE}", 0.1)])
+    wf = RefineWorkflow(runner=runner, tracker=AsyncMock())
+    ctx = _make_pre_stages_ctx(tmp_path, "22")
+    await wf.pre_stages(ctx)
+    prompt = wf._build_rewrite_prompt(ctx)
+    expected_path = str(ctx.tmp_dir / "interview-22.md")
+    assert expected_path in prompt


### PR DESCRIPTION
## Summary

Converted all large/variable prompt injection sites to on-demand fetching and documented the conventions in CLAUDE.md.

## Key changes

- `ralph.py` `_build_prompt` strips item body + comments; `build.md`, `review.md`, `document.md` each gain an `## Item context` section telling claude to run `gh issue view <item_id>` when needed
- `refine.py` `pre_stages` writes the interview transcript to `ctx.tmp_dir/interview-{id}.md`; `_build_rewrite_prompt` replaces the inlined transcript with a file pointer + partial-read guidance; new `_format_transcript_markdown` helper formats the file content with `## Turn N` headings
- `CLAUDE.md` gains a "Prompt-writing conventions" subsection (on-demand pattern, structured sections, bounded tool calls) and an expanded "Test granularity" subsection under testing conventions
- Test files updated: 3 existing `_make_ctx` helpers fixed to create `tmp_dir`, removed body/comments injection assertions in ralph prompts, added regression guards and new pre_stages tests; new `test_refine_prompts.py` file

## Closes

Closes #102

## Test plan

- [ ] `cog ralph` on an item with a substantial body and comments: build/review/document stages should fetch the item via `gh issue view` (visible in stream-json output) rather than receiving it pre-injected
- [ ] `cog refine` on a multi-turn interview: after the rewrite stage, inspect `tmp_dir/interview-{id}.md` — should exist, contain `## Turn N — Assistant / User` headings, and include all turns; the rewrite prompt should reference this path
- [ ] Compare build prompt sizes before/after: a typical item body (5-15KB) should no longer appear in the initial prompt
- [ ] On a retry scenario (e.g., re-queued item with updated body): build stage should fetch the latest body, not a frozen pre-stages snapshot

---
🤖 Generated by cog. Iteration cost: $3.949
