### PR TITLE
Refine: write interview transcript to .cog/ so sandbox can read it

### DIFF
--- a/src/cog/workflows/refine.py
+++ b/src/cog/workflows/refine.py
@@ -101,8 +101,22 @@ class RefineWorkflow(Workflow):
         self._runner = runner
         self._tracker = tracker
         self._transcripts: dict[str, list[InterviewTurn]] = {}
-        self._transcript_paths: dict[str, Path] = {}
         self._review_outcomes: dict[str, ReviewOutcome] = {}
+
+    @staticmethod
+    def _transcript_host_path(project_dir: Path, item_id: str) -> Path:
+        return project_dir / ".cog" / f"interview-{item_id}.md"
+
+    @staticmethod
+    def _transcript_sandbox_path(item_id: str) -> str:
+        # cwd is mounted at /work inside DockerSandbox; the rewrite stage
+        # reads the transcript from there.
+        return f"/work/.cog/interview-{item_id}.md"
+
+    @classmethod
+    def _cleanup_transcript_file(cls, project_dir: Path, item_id: str) -> None:
+        path = cls._transcript_host_path(project_dir, item_id)
+        path.unlink(missing_ok=True)
 
     async def select_item(self, ctx: ExecutionContext) -> Item | None:
         items = await self._tracker.list_by_label("needs-refinement", assignee="@me")
@@ -123,9 +137,9 @@ class RefineWorkflow(Workflow):
         assert ctx.input_provider is not None, "refine interview requires an input provider"
         transcript = await self._run_interview(ctx)
         self._transcripts[ctx.item.item_id] = transcript
-        transcript_path = ctx.tmp_dir / f"interview-{ctx.item.item_id}.md"
+        transcript_path = self._transcript_host_path(ctx.project_dir, ctx.item.item_id)
+        transcript_path.parent.mkdir(parents=True, exist_ok=True)
         transcript_path.write_text(_format_transcript_markdown(transcript), encoding="utf-8")
-        self._transcript_paths[ctx.item.item_id] = transcript_path
 
     def stages(self, ctx: ExecutionContext) -> list[Stage]:
         return [
@@ -203,6 +217,7 @@ class RefineWorkflow(Workflow):
         )
         await ctx.telemetry.write(record)
         await self._write_report(ctx, results, transcript, review, outcome="success")
+        self._cleanup_transcript_file(ctx.project_dir, ctx.item.item_id)
 
     async def finalize_noop(self, ctx: ExecutionContext, results: list[StageResult]) -> None:
         assert ctx.item is not None
@@ -235,6 +250,7 @@ class RefineWorkflow(Workflow):
 
         if review is not None:
             await self._write_report(ctx, results, transcript, review, outcome="noop")
+        self._cleanup_transcript_file(ctx.project_dir, ctx.item.item_id)
 
     async def finalize_error(
         self, ctx: ExecutionContext, error: Exception, results: list[StageResult]
@@ -366,7 +382,7 @@ class RefineWorkflow(Workflow):
     def _build_rewrite_prompt(self, ctx: ExecutionContext) -> str:
         assert ctx.item is not None
         transcript = self._transcripts[ctx.item.item_id]
-        transcript_path = self._transcript_paths[ctx.item.item_id]
+        transcript_path = self._transcript_sandbox_path(ctx.item.item_id)
         item = ctx.item
         parts = [
             _load_refine_prompt("rewrite"),

--- a/tests/test_workflows/test_refine_finalize.py
+++ b/tests/test_workflows/test_refine_finalize.py
@@ -247,3 +247,29 @@ async def test_finalize_noop_writes_report_with_body_after_placeholder(tmp_path,
     content = report_files[0].read_text()
     assert "Abandoned" in content
     assert "body unchanged" in content
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [ReviewDecision.ACCEPT, ReviewDecision.ABANDON],
+)
+@pytest.mark.asyncio
+async def test_finalize_deletes_transcript_file(tmp_path, monkeypatch, outcome):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    tracker = AsyncMock()
+    item_id = "12"
+    item = make_item(item_id=item_id, title="T", body="B")
+    review = ReviewOutcome(decision=outcome, final_body="B", final_title="T")
+    wf = _make_wf_with_data(
+        item_id, transcript=_sentinel_transcript(), review=review, tracker=tracker
+    )
+    transcript_path = tmp_path / ".cog" / f"interview-{item_id}.md"
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text("stub", encoding="utf-8")
+    telemetry = AsyncMock() if outcome == ReviewDecision.ACCEPT else None
+    ctx = _make_ctx(tmp_path, item=item, telemetry=telemetry)
+    if outcome == ReviewDecision.ACCEPT:
+        await wf.finalize_success(ctx, [make_stage_result("rewrite")])
+    else:
+        await wf.finalize_noop(ctx, [make_stage_result("rewrite")])
+    assert not transcript_path.exists()

--- a/tests/test_workflows/test_refine_prompts.py
+++ b/tests/test_workflows/test_refine_prompts.py
@@ -43,11 +43,10 @@ def _make_workflow_with_transcript(
         ),
     ]
     wf._transcripts[item_id] = turns
-    transcript_path = tmp_path / "tmp" / f"interview-{item_id}.md"
+    ctx = _make_ctx(tmp_path, item_id)
+    transcript_path = tmp_path / ".cog" / f"interview-{item_id}.md"
     transcript_path.parent.mkdir(parents=True, exist_ok=True)
     transcript_path.write_text("stub content", encoding="utf-8")
-    wf._transcript_paths[item_id] = transcript_path
-    ctx = _make_ctx(tmp_path, item_id)
     return wf, ctx
 
 
@@ -58,11 +57,10 @@ def test_refine_rewrite_prompt_tells_claude_to_read_transcript_file(tmp_path):
     assert "interview-30.md" in prompt
 
 
-def test_refine_rewrite_prompt_points_to_tmp_dir_path(tmp_path):
+def test_refine_rewrite_prompt_points_to_sandbox_path(tmp_path):
     wf, ctx = _make_workflow_with_transcript(tmp_path, "31")
     prompt = wf._build_rewrite_prompt(ctx)
-    expected = str(ctx.tmp_dir / "interview-31.md")
-    assert expected in prompt
+    assert "/work/.cog/interview-31.md" in prompt
 
 
 def test_refine_rewrite_prompt_does_not_inline_transcript_content(tmp_path):

--- a/tests/test_workflows/test_refine_rewrite.py
+++ b/tests/test_workflows/test_refine_rewrite.py
@@ -104,10 +104,7 @@ def test_rewrite_prompt_includes_original_body_and_comments(tmp_path):
     wf = _make_workflow([])
     transcript = _make_sentinel_transcript()
     wf._transcripts["1"] = transcript
-    transcript_path = tmp_path / "tmp" / "interview-1.md"
-    transcript_path.parent.mkdir(parents=True, exist_ok=True)
-    transcript_path.write_text("stub", encoding="utf-8")
-    wf._transcript_paths["1"] = transcript_path
+    _setup_transcript_path(tmp_path, "1")
     ctx = _make_ctx(tmp_path, item=item)
     prompt = wf._build_rewrite_prompt(ctx)
     assert "Original body" in prompt
@@ -120,28 +117,24 @@ def test_rewrite_prompt_does_not_inline_transcript_content(tmp_path):
     wf = _make_workflow([])
     transcript = _make_sentinel_transcript()
     wf._transcripts["2"] = transcript
-    transcript_path = tmp_path / "tmp" / "interview-2.md"
-    transcript_path.parent.mkdir(parents=True, exist_ok=True)
-    transcript_path.write_text("stub", encoding="utf-8")
-    wf._transcript_paths["2"] = transcript_path
+    _setup_transcript_path(tmp_path, "2")
     ctx = _make_ctx(tmp_path, item=item)
     prompt = wf._build_rewrite_prompt(ctx)
     assert "What does this item need?" not in prompt
     assert "It needs caching." not in prompt
 
 
-def _setup_transcript_path(wf: RefineWorkflow, tmp_path: Path, item_id: str) -> None:
-    path = tmp_path / "tmp" / f"interview-{item_id}.md"
+def _setup_transcript_path(tmp_path: Path, item_id: str) -> None:
+    path = tmp_path / ".cog" / f"interview-{item_id}.md"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("stub", encoding="utf-8")
-    wf._transcript_paths[item_id] = path
 
 
 def test_rewrite_prompt_omits_early_end_block_on_sentinel_end(tmp_path):
     item = make_item(item_id="3", title="T", body="B")
     wf = _make_workflow([])
     wf._transcripts["3"] = _make_sentinel_transcript()
-    _setup_transcript_path(wf, tmp_path, "3")
+    _setup_transcript_path(tmp_path, "3")
     ctx = _make_ctx(tmp_path, item=item)
     prompt = wf._build_rewrite_prompt(ctx)
     # The runtime-injected block uses "## Refinement status" as a heading
@@ -152,7 +145,7 @@ def test_rewrite_prompt_includes_early_end_block_on_user_end(tmp_path):
     item = make_item(item_id="4", title="T", body="B")
     wf = _make_workflow([])
     wf._transcripts["4"] = _make_user_end_transcript()
-    _setup_transcript_path(wf, tmp_path, "4")
+    _setup_transcript_path(tmp_path, "4")
     ctx = _make_ctx(tmp_path, item=item)
     prompt = wf._build_rewrite_prompt(ctx)
     # The runtime-injected block uses "## Refinement status" as a heading
@@ -324,12 +317,12 @@ def _make_pre_stages_ctx(tmp_path: Path, item_id: str) -> ExecutionContext:
 
 
 @pytest.mark.asyncio
-async def test_pre_stages_writes_transcript_to_ctx_tmp_dir_with_expected_filename(tmp_path):
+async def test_pre_stages_writes_transcript_to_dotcog_dir_with_expected_filename(tmp_path):
     runner = ScriptedInterviewRunner([(f"Question\n{_INTERVIEW_COMPLETE}", 0.1)])
     wf = RefineWorkflow(runner=runner, tracker=AsyncMock())
     ctx = _make_pre_stages_ctx(tmp_path, "20")
     await wf.pre_stages(ctx)
-    assert (ctx.tmp_dir / "interview-20.md").exists()
+    assert (ctx.project_dir / ".cog" / "interview-20.md").exists()
 
 
 @pytest.mark.asyncio
@@ -338,20 +331,19 @@ async def test_transcript_file_contains_all_turns_in_markdown_format(tmp_path):
     wf = RefineWorkflow(runner=runner, tracker=AsyncMock())
     ctx = _make_pre_stages_ctx(tmp_path, "21")
     await wf.pre_stages(ctx)
-    content = (ctx.tmp_dir / "interview-21.md").read_text(encoding="utf-8")
+    content = (ctx.project_dir / ".cog" / "interview-21.md").read_text(encoding="utf-8")
     assert "## Turn 1 — Assistant" in content
     assert "My question" in content
 
 
 @pytest.mark.asyncio
-async def test_rewrite_prompt_references_actual_transcript_path(tmp_path):
+async def test_rewrite_prompt_references_sandbox_transcript_path(tmp_path):
     runner = ScriptedInterviewRunner([(f"Q\n{_INTERVIEW_COMPLETE}", 0.1)])
     wf = RefineWorkflow(runner=runner, tracker=AsyncMock())
     ctx = _make_pre_stages_ctx(tmp_path, "22")
     await wf.pre_stages(ctx)
     prompt = wf._build_rewrite_prompt(ctx)
-    expected_path = str(ctx.tmp_dir / "interview-22.md")
-    assert expected_path in prompt
+    assert "/work/.cog/interview-22.md" in prompt
 
 
 def test_refine_checks_do_not_contain_default_branch():


### PR DESCRIPTION
## Summary

- The rewrite stage runs inside `DockerSandbox`, which only mounts `cwd`, `~/.claude*`, `~/.config/gh`, `~/.gitconfig`, and `~/.local/state/cog`. The transcript path baked into the rewrite prompt was `ctx.tmp_dir` (a `tempfile.mkdtemp` path under `/var/folders/...` on macOS or `/tmp/cog-XXXX` on Linux) — neither is mounted, so claude's `Read` failed at the end of every refine.
- Write the transcript to `<project_dir>/.cog/interview-{id}.md` instead. `cwd` is mounted at `/work`, so the prompt now references `/work/.cog/interview-{id}.md` inside the sandbox. The `/work` convention is consistent with `prompts/claude/chat/preamble.md`.
- Cleanup runs in `finalize_success` and `finalize_noop` so `.cog/` stays clean during normal runs. Crash-leftovers are harmless and gitignored.

Fixes #131.

## Test plan

- [x] `uv run pytest` (1018 passed, 3 skipped — docker integration tests)
- [x] `uv run mypy src` (clean)
- [x] `uv run ruff check .` and `uv run ruff format --check .` (clean)
- [x] Added a parametrized test in `test_refine_finalize.py` that both finalize paths delete the transcript file
- [x] Updated path-assertion tests in `test_refine_prompts.py` and `test_refine_rewrite.py` to match the new sandbox path

🤖 Generated with [Claude Code](https://claude.com/claude-code)