### PR TITLE
Refine: stop _extract_title_body truncating Body at nested h3 subsections

### DIFF
--- a/src/cog/workflows/refine.py
+++ b/src/cog/workflows/refine.py
@@ -28,7 +28,7 @@ _INTERVIEW_COMPLETE = "<<interview-complete>>"
 _SLUG_RE = re.compile(r"[^a-z0-9-]+")
 _COLLAPSE_RE = re.compile(r"-+")
 _SECTION_RE = re.compile(
-    r"^###\s+(Title|Body)\s*\n(.*?)(?=\n###\s|\Z)",
+    r"^###\s+(Title|Body)\s*\n(.*?)(?=\n###\s+(?:Title|Body)\b|\Z)",
     re.MULTILINE | re.DOTALL | re.IGNORECASE,
 )
 

--- a/tests/test_workflows/test_refine_rewrite.py
+++ b/tests/test_workflows/test_refine_rewrite.py
@@ -179,6 +179,30 @@ def test_extract_body_only_when_no_structured_sections_uses_full_message_as_body
     assert not sections
 
 
+def test_extract_body_preserves_nested_h3_subsections():
+    message = (
+        "### Title\nT\n\n"
+        "### Body\n"
+        "## Problem\nP\n\n"
+        "## Scope\n"
+        "### onDestroy placement\n"
+        "Add a second onDestroy block.\n\n"
+        "### Test approach\n"
+        "Use unmount() from render().\n"
+    )
+    sections = _extract_title_body(message)
+    assert sections["title"] == "T"
+    assert "### onDestroy placement" in sections["body"]
+    assert "Use unmount() from render()." in sections["body"]
+
+
+def test_extract_treats_repeat_title_or_body_h3_as_section_delimiter():
+    message = "### Title\nFirst title\n\n### Body\nFirst body content.\n\n### Title\nSecond title\n"
+    sections = _extract_title_body(message)
+    assert sections["title"] == "Second title"
+    assert sections["body"] == "First body content."
+
+
 # ---------------------------------------------------------------------------
 # stages()
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The Body capture's stop condition in `_SECTION_RE` was `(?=\n###\s|\Z)` — i.e. any subsequent h3 heading. But the rewrite prompt explicitly tells claude to use nested subsections inside Body, so any rewrite that emitted `### Subsection` under Scope / Open questions / etc. got truncated from the first h3 onward.
- Tighten the lookahead to `### Title` / `### Body` only. Those are the only delimiters that actually mark new top-level sections; anything else under either is content.
- Real-world hit (jessiepuls/meal-planning#401): rewrite produced a body that started subsections after `## Scope`, the regex chopped at the first `### `, and the published body ends literally at `## Scope` with no content under it.

Fixes #138.

## Test plan

- [x] Added `test_extract_body_preserves_nested_h3_subsections` (the bug repro)
- [x] Added `test_extract_treats_repeat_title_or_body_h3_as_section_delimiter` (boundary case — make sure we still split on legitimate repeat sentinels)
- [x] `uv run pytest` (1020 passed, 3 skipped)
- [x] `uv run mypy src` (clean)
- [x] `uv run ruff check .` and `uv run ruff format --check .` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)