### PR TITLE
DockerSandbox: skip credential refresh when `~/.claude/.credentials.json` is still valid (#135)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ cog                      Launch the TUI
 cog ralph [options]      Autonomous agent (see docs/workflows/ralph.md)
 cog refine [options]     Interactive refinement (see docs/workflows/refine.md)
 cog doctor               Run preflight checks and exit
+cog auth refresh         Sync Claude Code credentials from macOS keychain
 ```
 
 ### `cog ralph`
@@ -121,6 +122,15 @@ Refine requires the TUI (no `--headless`).
 | `--project-dir PATH` | Directory to run checks from (default: cwd) |
 
 Exits non-zero if any error-level preflight check fails.
+
+### `cog auth refresh`
+
+Copies Claude Code credentials from the macOS keychain to
+`~/.claude/.credentials.json`. Useful when the sandbox can't reach the
+keychain directly.
+
+No flags. Exits non-zero if the `security` binary is absent or the
+keychain entry doesn't exist. A no-op when `ANTHROPIC_API_KEY` is set.
 
 ## Docs
 

--- a/src/cog/cli.py
+++ b/src/cog/cli.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 
 import typer
@@ -8,6 +9,8 @@ from cog import __version__
 from cog.ui.wire import build_and_run
 
 app = typer.Typer()
+auth = typer.Typer()
+app.add_typer(auth, name="auth")
 
 
 def _version_callback(value: bool) -> None:
@@ -104,6 +107,47 @@ def doctor(
     print_results(results)
     if any(r.level == "error" and not r.ok for r in results):
         raise typer.Exit(1)
+
+
+@auth.command("refresh")
+def auth_refresh() -> None:
+    """Copy Claude Code credentials from the macOS keychain to ~/.claude/.credentials.json."""
+    from cog.runners.docker_sandbox import ensure_credentials
+
+    result = asyncio.run(ensure_credentials(force=True))
+
+    if result == "api_key_set":
+        print("ANTHROPIC_API_KEY is set; no keychain refresh needed")
+        return
+
+    if result == "security_missing":
+        print("keychain refresh requires macOS 'security' binary", file=sys.stderr)
+        raise typer.Exit(1)
+
+    if result == "keychain_missing":
+        print(
+            "Claude Code credentials not found in keychain; log in via 'claude' first",
+            file=sys.stderr,
+        )
+        raise typer.Exit(1)
+
+    # result == "refreshed"
+    print(_format_expiry_message())
+
+
+def _format_expiry_message() -> str:
+    creds_file = Path.home() / ".claude" / ".credentials.json"
+    try:
+        import json
+
+        data = json.loads(creds_file.read_bytes())
+        expires_at_ms = data["claudeAiOauth"]["expiresAt"]
+        dt = datetime.fromtimestamp(expires_at_ms / 1000, tz=UTC).astimezone()
+        return (
+            f"refreshed credentials from keychain (expires {dt.strftime('%Y-%m-%d %H:%M:%S %Z')})"
+        )
+    except Exception:
+        return "refreshed credentials from keychain"
 
 
 main = app

--- a/src/cog/runners/docker_sandbox.py
+++ b/src/cog/runners/docker_sandbox.py
@@ -1,9 +1,11 @@
 import asyncio
 import importlib.resources
+import json
 import os
 import shutil
 import sys
 import tempfile
+import time
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
@@ -29,6 +31,48 @@ def _write_credentials(data: bytes) -> None:
     os.replace(tmp_path, dest)
 
 
+def _existing_credentials_still_valid() -> bool:
+    creds_file = Path.home() / ".claude" / ".credentials.json"
+    try:
+        data = json.loads(creds_file.read_bytes())
+        expires_at = data["claudeAiOauth"]["expiresAt"]
+        if not isinstance(expires_at, int):
+            raise TypeError("expiresAt is not an int")
+        now_ms = int(time.time() * 1000)
+        return expires_at > now_ms + 5 * 60 * 1000
+    except Exception:
+        return False
+
+
+async def ensure_credentials(force: bool = False) -> str:
+    """Sync keychain credentials to ~/.claude/.credentials.json unless already valid.
+
+    Returns a sentinel string: 'api_key_set', 'skipped', 'security_missing',
+    'keychain_missing', or 'refreshed'. Callers map these to appropriate messages.
+    """
+    if "ANTHROPIC_API_KEY" in os.environ:
+        return "api_key_set"
+    if not force and _existing_credentials_still_valid():
+        return "skipped"
+    if not shutil.which("security"):
+        return "security_missing"
+    print("refreshing Claude Code credentials from keychain", file=sys.stderr)
+    proc = await asyncio.create_subprocess_exec(
+        "security",
+        "find-generic-password",
+        "-s",
+        "Claude Code-credentials",
+        "-w",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    stdout, _ = await proc.communicate()
+    if proc.returncode != 0:
+        return "keychain_missing"
+    _write_credentials(stdout)
+    return "refreshed"
+
+
 class DockerSandbox:
     def __init__(self, image: str = "cog:latest") -> None:
         self._image = image
@@ -40,7 +84,15 @@ class DockerSandbox:
         if not self._built:
             await self._ensure_image_built()
             self._built = True
-        await self._refresh_keychain_credentials()
+        result = await ensure_credentials()
+        if result == "security_missing":
+            print(
+                "warning: no ANTHROPIC_API_KEY and 'security' binary not found;"
+                " skipping keychain refresh",
+                file=sys.stderr,
+            )
+        elif result == "keychain_missing":
+            print("warning: Claude Code credentials not found in keychain", file=sys.stderr)
 
     def wrap_argv(self, argv: Sequence[str]) -> list[str]:
         return [
@@ -137,31 +189,6 @@ class DockerSandbox:
         await proc.wait()
         if proc.returncode != 0:
             raise DockerImageBuildError(f"docker build exited {proc.returncode}")
-
-    async def _refresh_keychain_credentials(self) -> None:
-        if "ANTHROPIC_API_KEY" in os.environ:
-            return
-        if not shutil.which("security"):
-            print(
-                "warning: no ANTHROPIC_API_KEY and 'security' binary not found;"
-                " skipping keychain refresh",
-                file=sys.stderr,
-            )
-            return
-        proc = await asyncio.create_subprocess_exec(
-            "security",
-            "find-generic-password",
-            "-s",
-            "Claude Code-credentials",
-            "-w",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-        stdout, _ = await proc.communicate()
-        if proc.returncode != 0:
-            print("warning: Claude Code credentials not found in keychain", file=sys.stderr)
-            return
-        _write_credentials(stdout)
 
     def _mount_args(self) -> list[str]:
         home = Path.home()

--- a/tests/test_sandbox/test_auth_refresh_cli.py
+++ b/tests/test_sandbox/test_auth_refresh_cli.py
@@ -1,0 +1,156 @@
+"""Tests for the `cog auth refresh` CLI subcommand."""
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+from cog.cli import app
+
+runner = CliRunner()
+
+_FAKE_EXPIRY_MSG = "refreshed credentials from keychain (expires 2026-01-01 00:00:00 UTC)"
+
+
+def _write_creds(home: Path, expires_offset_ms: int = 60 * 60 * 1000) -> None:
+    creds_dir = home / ".claude"
+    creds_dir.mkdir(parents=True, exist_ok=True)
+    expires_at = int(time.time() * 1000) + expires_offset_ms
+    data = {"claudeAiOauth": {"expiresAt": expires_at}}
+    (creds_dir / ".credentials.json").write_text(json.dumps(data))
+
+
+def _patch_ensure(result: str) -> Any:
+    mock = AsyncMock(return_value=result)
+    return patch("cog.runners.docker_sandbox.ensure_credentials", mock)
+
+
+def _patch_expiry() -> Any:
+    return patch("cog.cli._format_expiry_message", return_value=_FAKE_EXPIRY_MSG)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_auth_refresh_success_exits_zero() -> None:
+    with _patch_ensure("refreshed"), _patch_expiry():
+        result = runner.invoke(app, ["auth", "refresh"])
+
+    assert result.exit_code == 0
+
+
+def test_auth_refresh_success_prints_expiry_message() -> None:
+    with _patch_ensure("refreshed"), _patch_expiry():
+        result = runner.invoke(app, ["auth", "refresh"])
+
+    assert _FAKE_EXPIRY_MSG in result.output
+
+
+# ---------------------------------------------------------------------------
+# ANTHROPIC_API_KEY set
+# ---------------------------------------------------------------------------
+
+
+def test_auth_refresh_api_key_set_exits_zero() -> None:
+    with _patch_ensure("api_key_set"):
+        result = runner.invoke(app, ["auth", "refresh"])
+
+    assert result.exit_code == 0
+
+
+def test_auth_refresh_api_key_set_prints_message() -> None:
+    with _patch_ensure("api_key_set"):
+        result = runner.invoke(app, ["auth", "refresh"])
+
+    assert "ANTHROPIC_API_KEY is set" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Error: security binary missing
+# ---------------------------------------------------------------------------
+
+
+def test_auth_refresh_security_missing_exits_one() -> None:
+    with _patch_ensure("security_missing"):
+        result = runner.invoke(app, ["auth", "refresh"])
+
+    assert result.exit_code == 1
+
+
+def test_auth_refresh_security_missing_mentions_security_binary() -> None:
+    with _patch_ensure("security_missing"):
+        result = runner.invoke(app, ["auth", "refresh"])
+
+    assert "security" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Error: keychain entry missing
+# ---------------------------------------------------------------------------
+
+
+def test_auth_refresh_keychain_missing_exits_one() -> None:
+    with _patch_ensure("keychain_missing"):
+        result = runner.invoke(app, ["auth", "refresh"])
+
+    assert result.exit_code == 1
+
+
+def test_auth_refresh_keychain_missing_message_mentions_claude() -> None:
+    with _patch_ensure("keychain_missing"):
+        result = runner.invoke(app, ["auth", "refresh"])
+
+    assert "claude" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# ensure_credentials called with force=True
+# ---------------------------------------------------------------------------
+
+
+def test_auth_refresh_calls_ensure_with_force_true() -> None:
+    mock = AsyncMock(return_value="refreshed")
+
+    with patch("cog.runners.docker_sandbox.ensure_credentials", mock), _patch_expiry():
+        runner.invoke(app, ["auth", "refresh"])
+
+    mock.assert_awaited_once_with(force=True)
+
+
+# ---------------------------------------------------------------------------
+# Expiry fallback when creds file unreadable after refresh
+# ---------------------------------------------------------------------------
+
+
+def test_auth_refresh_fallback_message_when_no_creds_file(tmp_path: Path) -> None:
+    # No credentials file on disk — _format_expiry_message falls back to base message
+    with (
+        _patch_ensure("refreshed"),
+        patch("cog.cli.Path.home", return_value=tmp_path),
+    ):
+        result = runner.invoke(app, ["auth", "refresh"])
+
+    assert result.exit_code == 0
+    assert "refreshed credentials from keychain" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Expiry timestamp in success message
+# ---------------------------------------------------------------------------
+
+
+def test_auth_refresh_success_includes_expiry_timestamp(tmp_path: Path) -> None:
+    _write_creds(tmp_path, expires_offset_ms=2 * 60 * 60 * 1000)
+
+    with (
+        _patch_ensure("refreshed"),
+        patch("cog.cli.Path.home", return_value=tmp_path),
+    ):
+        result = runner.invoke(app, ["auth", "refresh"])
+
+    assert "expires" in result.output

--- a/tests/test_sandbox/test_ensure_credentials.py
+++ b/tests/test_sandbox/test_ensure_credentials.py
@@ -1,0 +1,303 @@
+"""Tests for ensure_credentials and _existing_credentials_still_valid."""
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cog.runners.docker_sandbox import ensure_credentials
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeProc:
+    def __init__(self, returncode: int = 0, stdout: bytes = b"") -> None:
+        self.returncode = returncode
+        self._stdout = stdout
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return self._stdout, b""
+
+
+def _patch_exec(proc: FakeProc) -> Any:
+    async def impl(*_args: Any, **_kwargs: Any) -> FakeProc:
+        return proc
+
+    return patch(
+        "cog.runners.docker_sandbox.asyncio.create_subprocess_exec",
+        new=AsyncMock(side_effect=impl),
+    )
+
+
+def _patch_which(has_security: bool = True) -> Any:
+    def which(name: str) -> str | None:
+        return "/usr/bin/security" if name == "security" and has_security else None
+
+    return patch("cog.runners.docker_sandbox.shutil.which", side_effect=which)
+
+
+def _write_valid_creds(home: Path, expires_offset_ms: int = 60 * 60 * 1000) -> None:
+    """Write a credentials file with expiresAt = now + offset (default 1h)."""
+    creds_dir = home / ".claude"
+    creds_dir.mkdir(parents=True, exist_ok=True)
+    expires_at = int(time.time() * 1000) + expires_offset_ms
+    data = {"claudeAiOauth": {"expiresAt": expires_at}}
+    (creds_dir / ".credentials.json").write_text(json.dumps(data))
+
+
+# ---------------------------------------------------------------------------
+# ANTHROPIC_API_KEY short-circuit
+# ---------------------------------------------------------------------------
+
+
+async def test_api_key_set_returns_immediately(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    security_called = False
+
+    async def no_security(*_args: Any, **_kwargs: Any) -> FakeProc:
+        nonlocal security_called
+        security_called = True
+        return FakeProc(0)
+
+    with (
+        _patch_which(),
+        patch(
+            "cog.runners.docker_sandbox.asyncio.create_subprocess_exec",
+            new=AsyncMock(side_effect=no_security),
+        ),
+        patch("cog.runners.docker_sandbox.Path.home", return_value=tmp_path),
+    ):
+        result = await ensure_credentials()
+
+    assert result == "api_key_set"
+    assert not security_called
+
+
+async def test_api_key_set_force_true_still_returns_immediately(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    security_called = False
+
+    async def no_security(*_args: Any, **_kwargs: Any) -> FakeProc:
+        nonlocal security_called
+        security_called = True
+        return FakeProc(0)
+
+    with (
+        _patch_which(),
+        patch(
+            "cog.runners.docker_sandbox.asyncio.create_subprocess_exec",
+            new=AsyncMock(side_effect=no_security),
+        ),
+        patch("cog.runners.docker_sandbox.Path.home", return_value=tmp_path),
+    ):
+        result = await ensure_credentials(force=True)
+
+    assert result == "api_key_set"
+    assert not security_called
+
+
+# ---------------------------------------------------------------------------
+# Skip-when-valid logic (force=False)
+# ---------------------------------------------------------------------------
+
+
+async def test_valid_creds_skips_security_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    _write_valid_creds(tmp_path)
+    security_called = False
+
+    async def no_security(*_args: Any, **_kwargs: Any) -> FakeProc:
+        nonlocal security_called
+        security_called = True
+        return FakeProc(0)
+
+    with (
+        _patch_which(),
+        patch(
+            "cog.runners.docker_sandbox.asyncio.create_subprocess_exec",
+            new=AsyncMock(side_effect=no_security),
+        ),
+        patch("cog.runners.docker_sandbox.Path.home", return_value=tmp_path),
+    ):
+        result = await ensure_credentials(force=False)
+
+    assert result == "skipped"
+    assert not security_called
+
+
+async def test_valid_creds_force_true_invokes_security(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    _write_valid_creds(tmp_path)
+    creds_data = b'{"claudeAiOauth": {"expiresAt": 9999999999999}}'
+
+    with (
+        _patch_which(),
+        _patch_exec(FakeProc(0, creds_data)),
+        patch("cog.runners.docker_sandbox._write_credentials") as mock_write,
+        patch("cog.runners.docker_sandbox.Path.home", return_value=tmp_path),
+    ):
+        result = await ensure_credentials(force=True)
+
+    assert result == "refreshed"
+    mock_write.assert_called_once_with(creds_data)
+
+
+async def test_expired_creds_invokes_security(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    # expires 1 minute ago
+    _write_valid_creds(tmp_path, expires_offset_ms=-60 * 1000)
+    creds_data = b'{"claudeAiOauth": {"expiresAt": 9999999999999}}'
+
+    with (
+        _patch_which(),
+        _patch_exec(FakeProc(0, creds_data)),
+        patch("cog.runners.docker_sandbox._write_credentials") as mock_write,
+        patch("cog.runners.docker_sandbox.Path.home", return_value=tmp_path),
+    ):
+        result = await ensure_credentials()
+
+    assert result == "refreshed"
+    mock_write.assert_called_once_with(creds_data)
+
+
+@pytest.mark.parametrize(
+    "bad_content",
+    [
+        pytest.param(b"not json at all", id="malformed_json"),
+        pytest.param(b"{}", id="missing_claudeAiOauth_key"),
+        pytest.param(b'{"claudeAiOauth": {}}', id="missing_expiresAt_key"),
+        pytest.param(b'{"claudeAiOauth": {"expiresAt": "not-an-int"}}', id="expiresAt_not_int"),
+    ],
+)
+async def test_invalid_creds_file_falls_through_to_refresh(
+    bad_content: bytes, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    creds_dir = tmp_path / ".claude"
+    creds_dir.mkdir(parents=True)
+    (creds_dir / ".credentials.json").write_bytes(bad_content)
+    creds_data = b'{"claudeAiOauth": {"expiresAt": 9999999999999}}'
+
+    with (
+        _patch_which(),
+        _patch_exec(FakeProc(0, creds_data)),
+        patch("cog.runners.docker_sandbox._write_credentials") as mock_write,
+        patch("cog.runners.docker_sandbox.Path.home", return_value=tmp_path),
+    ):
+        result = await ensure_credentials()
+
+    assert result == "refreshed"
+    mock_write.assert_called_once()
+
+
+async def test_missing_creds_file_falls_through_to_refresh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    # No credentials file written
+    creds_data = b'{"claudeAiOauth": {"expiresAt": 9999999999999}}'
+
+    with (
+        _patch_which(),
+        _patch_exec(FakeProc(0, creds_data)),
+        patch("cog.runners.docker_sandbox._write_credentials") as mock_write,
+        patch("cog.runners.docker_sandbox.Path.home", return_value=tmp_path),
+    ):
+        result = await ensure_credentials()
+
+    assert result == "refreshed"
+    mock_write.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# security binary / keychain errors
+# ---------------------------------------------------------------------------
+
+
+async def test_security_missing_returns_sentinel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    with (
+        _patch_which(has_security=False),
+        patch("cog.runners.docker_sandbox.Path.home", return_value=tmp_path),
+    ):
+        result = await ensure_credentials()
+
+    assert result == "security_missing"
+
+
+async def test_keychain_missing_returns_sentinel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    with (
+        _patch_which(),
+        _patch_exec(FakeProc(1)),  # security exits non-zero
+        patch("cog.runners.docker_sandbox.Path.home", return_value=tmp_path),
+    ):
+        result = await ensure_credentials()
+
+    assert result == "keychain_missing"
+
+
+# ---------------------------------------------------------------------------
+# stderr output
+# ---------------------------------------------------------------------------
+
+
+async def test_refresh_path_prints_refreshing_line(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    creds_data = b'{"claudeAiOauth": {"expiresAt": 9999999999999}}'
+
+    with (
+        _patch_which(),
+        _patch_exec(FakeProc(0, creds_data)),
+        patch("cog.runners.docker_sandbox._write_credentials"),
+        patch("cog.runners.docker_sandbox.Path.home", return_value=tmp_path),
+    ):
+        result = await ensure_credentials()
+
+    assert result == "refreshed"
+    assert "refreshing Claude Code credentials from keychain" in capsys.readouterr().err
+
+
+async def test_skip_path_is_silent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    _write_valid_creds(tmp_path)
+
+    with (
+        _patch_which(),
+        patch("cog.runners.docker_sandbox.Path.home", return_value=tmp_path),
+    ):
+        result = await ensure_credentials()
+
+    assert result == "skipped"
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out == ""


### PR DESCRIPTION
## Summary

Extracts credential-refresh logic from `DockerSandbox._refresh_keychain_credentials` into a module-level `ensure_credentials(force: bool = False) -> str` function. On the skip path (valid token with >5 min remaining), the function returns immediately without touching the keychain or triggering macOS privacy prompts. On the refresh path, it prints a single `refreshing Claude Code credentials from keychain` line to stderr before invoking `security`. `DockerSandbox.prepare()` calls `ensure_credentials()` and maps the sentinel return value to the existing warning messages. A new `cog auth refresh` subcommand allows manual keychain→file copy when needed.

## Key changes

- `_existing_credentials_still_valid()` in `docker_sandbox.py`: reads `~/.claude/.credentials.json`, parses `claudeAiOauth.expiresAt`, returns `True` if token has >5 min headroom; swallows all parse errors and returns `False`
- `ensure_credentials(force)` replaces `DockerSandbox._refresh_keychain_credentials`; returns a sentinel string (`"api_key_set"`, `"skipped"`, `"security_missing"`, `"keychain_missing"`, `"refreshed"`) so callers control output
- `DockerSandbox.prepare()` now calls `await ensure_credentials()` and maps the result to the existing warning messages
- `cog auth refresh` CLI subcommand in `cli.py`: calls `ensure_credentials(force=True)`, maps sentinels to the exit codes and messages specified in the issue
- New test files: `tests/test_sandbox/test_ensure_credentials.py` (14 tests covering all branches) and `tests/test_sandbox/test_auth_refresh_cli.py` (11 tests covering all CLI behavior)

## Closes

Closes #135

## Test plan

- [ ] Run `cog auth refresh` with a valid `~/.claude/.credentials.json` — verify it prints the refresh message and expiry timestamp
- [ ] Run `cog auth refresh` with `ANTHROPIC_API_KEY` set — verify exit 0 and "ANTHROPIC_API_KEY is set" message
- [ ] Run `cog auth refresh` on Linux (no `security` binary) — verify exit 1 with appropriate message
- [ ] Run `cog ralph` or `cog refine` repeatedly: verify the `refreshing Claude Code credentials from keychain` stderr line only appears on the first run (when the token is fresh) or after expiry, not on every iteration

---
🤖 Generated by cog. Iteration cost: $3.721
