### PR TITLE
Drop unconditional `@me` filter from picker-flow surfaces; add `assignees` to Item and picker UI (#136)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -101,6 +101,12 @@ ctx)` per iteration with a fresh `ExecutionContext`.
 - **Deferred items aren't labels.** Ralph parses `blocked by #N` /
   `depends on #N` from body + comments; defers via `state.json` until
   blockers close. No tracker-visible state change.
+- **`@me` filter is intentionally split.** Interactive picker-flow
+  surfaces (ralph queue list, refine queue list, dashboard counts) show
+  team-wide items so users can see shared work. The autonomous ralph
+  selection loop (`RalphWorkflow.select_item`) and its state-recovery
+  counterpart (`state.py:recover_from_remote`) keep `assignee="@me"` so
+  ralph never auto-implements a teammate's item without explicit opt-in.
 - **Refine runs only in Textual mode.** Requires an ItemPicker. Headless
   refine errors out by design (no way to do interactive chat without a
   UI).

--- a/docs/workflows/ralph.md
+++ b/docs/workflows/ralph.md
@@ -108,8 +108,12 @@ cog ralph --item 42 --restart
 
 Within the shell, **Ctrl+3** opens the Ralph view:
 
-- Idle: queue list with per-item history badges (prior run count +
-  outcome + total cost, pulled from `runs.jsonl`).
+- Idle: queue list showing all `agent-ready` items (team-wide, not
+  filtered to `@me`). Each row shows the item title, an assignee suffix
+  `(@login)` when assigned, and a history badge (prior run count +
+  outcome + total cost from `runs.jsonl`). The autonomous run loop
+  still only picks items assigned to you — the broader queue list is
+  for visibility, not auto-selection.
 - Running: live log pane + footer showing cost and elapsed time.
 - Post-run: completion / failure panel with per-stage cost breakdown.
 

--- a/docs/workflows/refine.md
+++ b/docs/workflows/refine.md
@@ -110,7 +110,9 @@ the picker.
 
 Within the shell, **Ctrl+2** opens the Refine view:
 
-- Idle: queue list. Enter to start.
+- Idle: queue list showing all `needs-refinement` items (team-wide,
+  not filtered to `@me`). Each row shows the item title and an
+  assignee suffix `(@login)` when assigned. Enter to start.
 - Running: chat pane. Interview streams inline; `Ctrl+I` toggles the
   issue body pane.
 - Review: original vs. proposed panes; `a / e / shift+q` as above.

--- a/src/cog/core/item.py
+++ b/src/cog/core/item.py
@@ -21,3 +21,4 @@ class Item:
     created_at: datetime
     updated_at: datetime
     url: str
+    assignees: tuple[str, ...] = ()

--- a/src/cog/trackers/github.py
+++ b/src/cog/trackers/github.py
@@ -34,7 +34,7 @@ class GitHubIssueTracker(IssueTracker):
             "--state",
             "open",
             "--json",
-            "number,title,body,labels,state,createdAt,updatedAt,url",
+            "number,title,body,labels,assignees,state,createdAt,updatedAt,url",
         ]
         if assignee is not None:
             args += ["--assignee", assignee]
@@ -50,7 +50,7 @@ class GitHubIssueTracker(IssueTracker):
                 "view",
                 item_id,
                 "--json",
-                "number,title,body,labels,comments,state,createdAt,updatedAt,url",
+                "number,title,body,labels,assignees,comments,state,createdAt,updatedAt,url",
             ]
         )
         tracker_id = await self._tracker_id_cached()
@@ -152,4 +152,5 @@ class GitHubIssueTracker(IssueTracker):
             created_at=datetime.fromisoformat(record["createdAt"].replace("Z", "+00:00")),
             updated_at=datetime.fromisoformat(record["updatedAt"].replace("Z", "+00:00")),
             url=record["url"],
+            assignees=tuple(a["login"] for a in record.get("assignees", [])),
         )

--- a/src/cog/ui/picker.py
+++ b/src/cog/ui/picker.py
@@ -91,6 +91,14 @@ def _format_history_badge(h: PickerHistory) -> str:
     )
 
 
+def _format_assignees(assignees: tuple[str, ...]) -> str:
+    if not assignees:
+        return ""
+    if len(assignees) == 1:
+        return f" [dim](@{assignees[0]})[/dim]"
+    return f" [dim](@{assignees[0]} +{len(assignees) - 1})[/dim]"
+
+
 class PickerScreen(ModalScreen[Item | None]):
     BINDINGS = [Binding("q", "cancel", "Cancel")]
 
@@ -124,12 +132,16 @@ class PickerScreen(ModalScreen[Item | None]):
                     if len(item.title) <= _TITLE_MAX
                     else item.title[: _TITLE_MAX - 1] + "…"
                 )
+                assignees_suffix = _format_assignees(item.assignees)
                 badge = ""
                 hist = self._history.get(item.item_id)
                 if hist is not None:
                     badge = _format_history_badge(hist)
                 list_items.append(
-                    ListItem(Label(f"#{item.item_id} — {title}{badge}"), id=f"pick-{i}")
+                    ListItem(
+                        Label(f"#{item.item_id} — {title}{assignees_suffix}{badge}"),
+                        id=f"pick-{i}",
+                    )
                 )
         list_items.append(ListItem(Label("Other — enter item number"), id="pick-other"))
         yield ListView(*list_items, id="picker-list")

--- a/src/cog/ui/views/dashboard.py
+++ b/src/cog/ui/views/dashboard.py
@@ -135,7 +135,7 @@ class DashboardView(Widget):
         widget.update("\n".join(lines))
 
     async def _safe_count(self, label: str) -> int:
-        items = await self._tracker.list_by_label(label, assignee="@me")
+        items = await self._tracker.list_by_label(label)
         return len(items)
 
     async def _refresh_cost_totals(self) -> None:

--- a/src/cog/ui/views/ralph.py
+++ b/src/cog/ui/views/ralph.py
@@ -35,7 +35,12 @@ from cog.state import JsonFileStateCache
 from cog.state_paths import project_state_dir
 from cog.telemetry import TelemetryWriter
 from cog.ui.messages import ViewAttention
-from cog.ui.picker import PickerHistory, load_picker_history
+from cog.ui.picker import (
+    PickerHistory,
+    _format_assignees,
+    _format_history_badge,
+    load_picker_history,
+)
 from cog.ui.screens.run import StageCountingSink, stage_breakdown_line
 from cog.ui.widgets.log_pane import LogPaneWidget
 from cog.workflows.ralph import RalphWorkflow
@@ -185,7 +190,7 @@ class RalphView(Widget, can_focus=True):
 
     async def refresh_queue(self) -> None:
         try:
-            items = await self._tracker.list_by_label("agent-ready", assignee="@me")
+            items = await self._tracker.list_by_label("agent-ready")
         except TrackerError as e:
             self._set_status(f"[red]error listing queue: {e}[/red]")
             return
@@ -206,15 +211,14 @@ class RalphView(Widget, can_focus=True):
             return
         for i, item in enumerate(items):
             title = item.title if len(item.title) <= 80 else item.title[:79] + "…"
-            badge = ""
+            assignees_suffix = _format_assignees(item.assignees)
             hist = self._history.get(item.item_id)
-            if hist is not None:
-                badge = (
-                    f" [dim]\\[{hist.workflow} ×{hist.count}: "
-                    f"last {hist.last_outcome}, ${hist.total_cost_usd:.2f}][/dim]"
-                )
+            badge = _format_history_badge(hist) if hist is not None else ""
             await list_view.append(
-                ListItem(Label(f"#{item.item_id} — {title}{badge}"), id=f"queue-{i}")
+                ListItem(
+                    Label(f"#{item.item_id} — {title}{assignees_suffix}{badge}"),
+                    id=f"queue-{i}",
+                )
             )
         list_view.index = 0
         self._set_status(f"{len(items)} item(s) in queue")

--- a/src/cog/ui/views/refine.py
+++ b/src/cog/ui/views/refine.py
@@ -33,6 +33,7 @@ from cog.state_paths import project_state_dir
 from cog.telemetry import TelemetryWriter
 from cog.ui.editor import suspend_and_edit
 from cog.ui.messages import ViewAttention
+from cog.ui.picker import _format_assignees
 from cog.ui.widgets.chat_pane import ChatPaneWidget
 from cog.workflows.refine import RefineWorkflow, ReviewDecision, ReviewOutcome
 
@@ -216,7 +217,7 @@ class RefineView(Widget, can_focus=True):
 
     async def refresh_queue(self) -> None:
         try:
-            items = await self._tracker.list_by_label("needs-refinement", assignee="@me")
+            items = await self._tracker.list_by_label("needs-refinement")
         except Exception as e:  # noqa: BLE001 — surface any list-failure
             self._set_status(f"[red]error listing queue: {e}[/red]")
             return
@@ -232,7 +233,10 @@ class RefineView(Widget, can_focus=True):
             return
         for i, item in enumerate(items):
             title = item.title if len(item.title) <= 80 else item.title[:79] + "…"
-            await list_view.append(ListItem(Label(f"#{item.item_id} — {title}"), id=f"queue-{i}"))
+            assignees_suffix = _format_assignees(item.assignees)
+            await list_view.append(
+                ListItem(Label(f"#{item.item_id} — {title}{assignees_suffix}"), id=f"queue-{i}")
+            )
         list_view.index = 0
         self._set_status(f"{len(items)} item(s) in queue")
 

--- a/src/cog/workflows/refine.py
+++ b/src/cog/workflows/refine.py
@@ -119,7 +119,7 @@ class RefineWorkflow(Workflow):
         path.unlink(missing_ok=True)
 
     async def select_item(self, ctx: ExecutionContext) -> Item | None:
-        items = await self._tracker.list_by_label("needs-refinement", assignee="@me")
+        items = await self._tracker.list_by_label("needs-refinement")
         if not items:
             return None
         items.sort(key=lambda i: i.created_at)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -61,6 +61,7 @@ def make_item(
     created_at: datetime | None = None,
     updated_at: datetime | None = None,
     url: str = "https://github.com/org/repo/issues/1",
+    assignees: tuple[str, ...] = (),
 ) -> Item:
     return Item(
         tracker_id=tracker_id,
@@ -73,6 +74,7 @@ def make_item(
         created_at=created_at or _EPOCH,
         updated_at=updated_at or _EPOCH,
         url=url,
+        assignees=assignees,
     )
 
 

--- a/tests/test_trackers/test_github_dates.py
+++ b/tests/test_trackers/test_github_dates.py
@@ -7,7 +7,7 @@ from cog.trackers.github import GitHubIssueTracker
 from tests.fakes import FakeSubprocessRegistry
 from tests.test_trackers.conftest import register_repo
 
-GET_FIELDS = "number,title,body,labels,comments,state,createdAt,updatedAt,url"
+GET_FIELDS = "number,title,body,labels,assignees,comments,state,createdAt,updatedAt,url"
 
 SINGLE_ISSUE_WITH_Z = b"""{
   "number": 99,

--- a/tests/test_trackers/test_github_errors.py
+++ b/tests/test_trackers/test_github_errors.py
@@ -7,7 +7,7 @@ from cog.trackers.github import GitHubIssueTracker
 from tests.fakes import FakeSubprocessRegistry
 from tests.test_trackers.conftest import register_repo
 
-LIST_FIELDS = "number,title,body,labels,state,createdAt,updatedAt,url"
+LIST_FIELDS = "number,title,body,labels,assignees,state,createdAt,updatedAt,url"
 LIST_ARGV = (
     "gh",
     "issue",

--- a/tests/test_trackers/test_github_get.py
+++ b/tests/test_trackers/test_github_get.py
@@ -6,7 +6,7 @@ from cog.trackers.github import GitHubIssueTracker
 from tests.fakes import FakeSubprocessRegistry
 from tests.test_trackers.conftest import load_fixture, register_repo
 
-GET_FIELDS = "number,title,body,labels,comments,state,createdAt,updatedAt,url"
+GET_FIELDS = "number,title,body,labels,assignees,comments,state,createdAt,updatedAt,url"
 
 
 async def get_item(

--- a/tests/test_trackers/test_github_list.py
+++ b/tests/test_trackers/test_github_list.py
@@ -142,8 +142,15 @@ async def test_list_by_label_state_lowercased(
     "raw_assignees, expected",
     [
         ([], ()),
-        ([{"login": "alice"}], ("alice",)),
-        ([{"login": "alice"}, {"login": "bob"}, {"login": "carol"}], ("alice", "bob", "carol")),
+        ([{"login": "alice", "name": "Alice Liddell"}], ("alice",)),
+        (
+            [
+                {"login": "alice", "name": "Alice Liddell"},
+                {"login": "bob", "name": "Robert Builder"},
+                {"login": "carol", "name": "Carol Singer"},
+            ],
+            ("alice", "bob", "carol"),
+        ),
     ],
 )
 async def test_to_item_populates_assignees(

--- a/tests/test_trackers/test_github_list.py
+++ b/tests/test_trackers/test_github_list.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -6,7 +7,18 @@ from cog.trackers.github import GitHubIssueTracker
 from tests.fakes import FakeSubprocessRegistry
 from tests.test_trackers.conftest import load_fixture, register_repo
 
-LIST_FIELDS = "number,title,body,labels,state,createdAt,updatedAt,url"
+_BASE_RECORD = {
+    "number": 1,
+    "title": "t",
+    "body": "b",
+    "labels": [],
+    "state": "OPEN",
+    "createdAt": "2026-01-01T00:00:00Z",
+    "updatedAt": "2026-01-01T00:00:00Z",
+    "url": "https://github.com/o/r/issues/1",
+}
+
+LIST_FIELDS = "number,title,body,labels,assignees,state,createdAt,updatedAt,url"
 LIST_BASE_ARGV = (
     "gh",
     "issue",
@@ -95,7 +107,17 @@ async def test_list_by_label_json_fields(
     json_idx = list(list_call).index("--json")
     field_str = list_call[json_idx + 1]
     fields = set(field_str.split(","))
-    assert fields == {"number", "title", "body", "labels", "state", "createdAt", "updatedAt", "url"}
+    assert fields == {
+        "number",
+        "title",
+        "body",
+        "labels",
+        "assignees",
+        "state",
+        "createdAt",
+        "updatedAt",
+        "url",
+    }
 
 
 async def test_list_by_label_json_field_list_includes_state(
@@ -114,6 +136,29 @@ async def test_list_by_label_state_lowercased(
     registry.expect(LIST_BASE_ARGV, stdout=load_fixture("list_by_label_happy.json"))
     items = await list_by_label(registry, tmp_path, monkeypatch=monkeypatch)
     assert all(item.state == item.state.lower() for item in items)
+
+
+@pytest.mark.parametrize(
+    "raw_assignees, expected",
+    [
+        ([], ()),
+        ([{"login": "alice"}], ("alice",)),
+        ([{"login": "alice"}, {"login": "bob"}, {"login": "carol"}], ("alice", "bob", "carol")),
+    ],
+)
+async def test_to_item_populates_assignees(
+    registry: FakeSubprocessRegistry,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    raw_assignees: list,
+    expected: tuple,
+) -> None:
+    register_repo(registry)
+    record = {**_BASE_RECORD, "assignees": raw_assignees}
+    registry.expect(LIST_BASE_ARGV, stdout=json.dumps([record]).encode())
+    items = await list_by_label(registry, tmp_path, monkeypatch=monkeypatch)
+    assert len(items) == 1
+    assert items[0].assignees == expected
 
 
 async def test_list_by_label_label_normalization(

--- a/tests/test_trackers/test_github_tracker_id.py
+++ b/tests/test_trackers/test_github_tracker_id.py
@@ -6,7 +6,7 @@ from cog.trackers.github import GitHubIssueTracker
 from tests.fakes import FakeSubprocessRegistry
 from tests.test_trackers.conftest import register_repo
 
-LIST_FIELDS = "number,title,body,labels,state,createdAt,updatedAt,url"
+LIST_FIELDS = "number,title,body,labels,assignees,state,createdAt,updatedAt,url"
 LIST_ARGV = (
     "gh",
     "issue",

--- a/tests/test_ui/test_picker.py
+++ b/tests/test_ui/test_picker.py
@@ -11,7 +11,13 @@ from cog.core.errors import TrackerError
 from cog.core.item import Item
 from cog.core.tracker import IssueTracker
 from cog.state_paths import project_state_dir
-from cog.ui.picker import OtherInputScreen, PickerHistory, PickerScreen, load_picker_history
+from cog.ui.picker import (
+    OtherInputScreen,
+    PickerHistory,
+    PickerScreen,
+    _format_assignees,
+    load_picker_history,
+)
 from tests.fakes import make_item, make_needs_refinement_items
 
 
@@ -306,3 +312,15 @@ async def test_picker_screen_empty_row_is_disabled():
         empty_row = list_view.get_child_by_id("pick-empty")
         assert empty_row is not None
         assert empty_row.disabled is True
+
+
+@pytest.mark.parametrize(
+    "assignees, expected",
+    [
+        ((), ""),
+        (("alice",), " [dim](@alice)[/dim]"),
+        (("alice", "bob", "carol"), " [dim](@alice +2)[/dim]"),
+    ],
+)
+def test_format_assignees(assignees: tuple, expected: str) -> None:
+    assert _format_assignees(assignees) == expected

--- a/tests/test_ui/test_ralph_view.py
+++ b/tests/test_ui/test_ralph_view.py
@@ -235,3 +235,25 @@ async def test_ralph_view_failure_marks_running_stages_failed(
         view._sink._stage_starts["build"] = 0.0
         view._sink.mark_running_stages_failed()
         assert view._sink.stages[0].status == "failed"
+
+
+async def test_ralph_view_renders_assignee_suffix(tmp_path: Path, xdg_state: Path) -> None:
+    item = Item(
+        tracker_id="gh",
+        item_id="7",
+        title="item 7",
+        body="",
+        labels=("agent-ready",),
+        comments=(),
+        state="open",
+        created_at=datetime(2026, 4, 20, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 20, tzinfo=UTC),
+        url="",
+        assignees=("alice",),
+    )
+    tracker = _tracker_with([item])
+    async with _RalphApp(tmp_path, tracker).run_test(headless=True) as pilot:
+        await pilot.pause()
+        queue = pilot.app.query_one("#ralph-queue", ListView)
+        label_text = str(queue.children[0].query_one("Label").renderable)
+        assert "(@alice)" in label_text

--- a/tests/test_ui/test_refine_view.py
+++ b/tests/test_ui/test_refine_view.py
@@ -312,3 +312,25 @@ async def test_refine_view_title_strip_marks_unchanged_when_titles_match(
         strip = view.query_one("#review-title-strip", Static)
         assert "unchanged" in str(strip.renderable)
         await task
+
+
+async def test_refine_view_renders_assignee_suffix(tmp_path: Path, xdg_state: Path) -> None:
+    item = Item(
+        tracker_id="gh",
+        item_id="3",
+        title="item 3",
+        body="body",
+        labels=(),
+        comments=(),
+        state="open",
+        created_at=datetime(2026, 4, 20, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 20, tzinfo=UTC),
+        url="",
+        assignees=("bob",),
+    )
+    tracker = _tracker_with([item])
+    async with _RefineApp(tmp_path, tracker).run_test(headless=True) as pilot:
+        await pilot.pause()
+        queue = pilot.app.query_one("#refine-queue", ListView)
+        label_text = str(queue.children[0].query_one("Label").renderable)
+        assert "(@bob)" in label_text


### PR DESCRIPTION
## Summary

Removes the unconditional `assignee="@me"` filter from cog's interactive item-list surfaces — refine queue, ralph queue, dashboard counts, and the refine picker — so users can see and trigger work on items assigned to teammates. Autonomous paths (headless ralph, state recovery) keep the `@me` filter so unattended runs still only act on the user's own assignments. `Item` gains an `assignees` field populated from the GitHub API; the picker and queue views render it inline.

## Key changes

- `Item` dataclass gains `assignees: tuple[str, ...] = ()` at the end — empty-tuple default keeps all existing call sites working without changes
- `GitHubIssueTracker` adds `assignees` to the `--json` field list for both `list_by_label` and `get`, and `_to_item` populates it from `a["login"]` for each entry
- Four interactive/browsing call sites drop `assignee="@me"`: `RefineWorkflow.select_item`, `RefineView.refresh_queue`, `RalphView.refresh_queue`, and `DashboardView._safe_count`; two autonomous call sites (`RalphWorkflow.select_item`, `state.recover_from_remote`) are unchanged
- `picker.py` gains `_format_assignees` (renders `(@login)` or `(@first +N)` or empty string) and the `PickerScreen`, `RalphView`, and `RefineView` queue renderers all use it; `RalphView` also switches from its inline badge logic to the shared `_format_history_badge` from `picker.py`

## Closes

Closes #136

## Test plan

- [ ] Start cog in Textual mode connected to a multi-developer repo — verify the refine queue, ralph queue, and dashboard counts show items assigned to teammates, not just `@me`
- [ ] In the ralph queue or refine queue, verify items with an assignee show `(@login)` after the title, and unassigned items show no suffix
- [ ] Verify `cog ralph --headless` still only picks up items assigned to `@me` (autonomous loop must not touch teammate items)
- [ ] Open the PickerScreen (e.g. refine with multiple items) and verify assignees render correctly in the modal list
- [ ] Items with multiple assignees should show `(@first +N)` in all three queue views

---
🤖 Generated by cog. Iteration cost: \$3.740