### PR TITLE
README: document Docker Desktop TCC prompt and the credsStore workaround on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,53 @@ production-ready for unattended use elsewhere yet.
   (`claude` on `PATH`), authenticated — either via macOS keychain
   (default on macOS) or `ANTHROPIC_API_KEY`
 
+### macOS: silencing the Docker Desktop privacy prompt
+
+On macOS Sequoia (15+), Docker Desktop's credential helper triggers a
+"would like to access data from other apps" prompt on every container
+start, regardless of cog. Cog can't suppress this directly — the prompt
+fires from `docker-credential-desktop` before cog's argv runs. Cog's
+credential refresh (#135) is a different code path and unrelated.
+
+Three workarounds, cheapest first:
+
+1. **Grant the access once in System Settings.** System Settings →
+   Privacy & Security → Files and Folders → enable for
+   `docker-credential-desktop` (and/or your terminal). Persists across
+   runs.
+
+2. **Disable Docker's credential store for your user.** Edit
+   `~/.docker/config.json` and remove the `credsStore` key. Cog only
+   uses local images, so no registry credentials are needed.
+
+   Before:
+
+   ```json
+   {
+     "auths": {},
+     "credsStore": "desktop"
+   }
+   ```
+
+   After:
+
+   ```json
+   {
+     "auths": {}
+   }
+   ```
+
+   Side effect: any `docker login` workflows you have elsewhere stop
+   storing registry credentials in the keychain.
+
+3. **Switch to a different container runtime** that doesn't have
+   Docker Desktop's TCC integration — e.g.
+   [colima](https://github.com/abiosoft/colima),
+   [OrbStack](https://orbstack.dev/), or
+   [podman](https://podman.io/). All expose a Docker-compatible socket,
+   so cog runs unchanged. Bigger change, but addresses other Docker
+   Desktop friction at the same time.
+
 ## Install
 
 Machine-wide, via `uv tool install`:


### PR DESCRIPTION
## Summary

- Documents the macOS Sequoia "would like to access data from other apps" prompt that fires from `docker-credential-desktop` on every container start.
- Adds three workarounds under `## Requirements` as an `### ` subsection: System Settings grant, removing `credsStore` from `~/.docker/config.json`, or switching to colima/OrbStack/podman.
- Notes that cog's credential refresh (#135) is a different code path and can't suppress this prompt.

Fixes #150

## Test plan

- [x] `uv run pytest` (1045 passed, 3 skipped)
- [x] `uv run ruff format --check .` (clean)
- [ ] Eyeball the rendered README on GitHub: new section sits under Requirements at h3 level, code blocks render, runtime links resolve.