### PR TITLE
Tolerate 'no checks reported' race in ralph CI wait (#144)

### DIFF
--- a/src/cog/hosts/github.py
+++ b/src/cog/hosts/github.py
@@ -8,6 +8,8 @@ from cog.core.errors import HostError
 from cog.core.host import CheckRun, GitHost, PrChecks, PullRequest
 from cog.core.item import Item
 
+_NO_CHECKS_REPORTED_MARKER = "no checks reported"
+
 _GH_STATE_MAP: dict[str, Literal["pending", "passed", "failed", "skipped"]] = {
     "SUCCESS": "passed",
     "FAILURE": "failed",
@@ -67,9 +69,14 @@ class GitHubGitHost(GitHost):
         return data["body"] or ""
 
     async def get_pr_checks(self, number: int) -> PrChecks:
-        stdout = await self._gh_json(
-            ["pr", "checks", str(number), "--json", "name,state,link,description"]
-        )
+        try:
+            stdout = await self._gh_json(
+                ["pr", "checks", str(number), "--json", "name,state,link,description"]
+            )
+        except HostError as exc:
+            if _NO_CHECKS_REPORTED_MARKER in str(exc):
+                return PrChecks(runs=())
+            raise
         runs = tuple(
             CheckRun(
                 name=r["name"],

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -354,24 +354,23 @@ class RalphWorkflow(Workflow):
             async with asyncio.timeout(ci_timeout):
                 while True:
                     checks = await self._host.get_pr_checks(pr.number)  # type: ignore[union-attr]
-                    if not checks.pending:
+                    if checks.runs and not checks.pending:
                         break
 
                     now = time.monotonic()
                     if now - last_heartbeat >= _HEARTBEAT_INTERVAL:
-                        passed = sum(1 for r in checks.runs if r.state == "passed")
-                        total = len(checks.runs)
-                        pending = sum(1 for r in checks.runs if r.state == "pending")
                         elapsed_m = int((now - started) / 60)
-                        await self._emit(
-                            ctx,
-                            StatusEvent(
-                                message=(
-                                    f"⏳ CI: {passed}/{total} passed, "
-                                    f"{pending} pending ({elapsed_m}m elapsed)"
-                                )
-                            ),
-                        )
+                        if not checks.runs:
+                            message = f"⏳ CI: waiting for checks to begin ({elapsed_m}m elapsed)"
+                        else:
+                            passed = sum(1 for r in checks.runs if r.state == "passed")
+                            total = len(checks.runs)
+                            pending = sum(1 for r in checks.runs if r.state == "pending")
+                            message = (
+                                f"⏳ CI: {passed}/{total} passed, "
+                                f"{pending} pending ({elapsed_m}m elapsed)"
+                            )
+                        await self._emit(ctx, StatusEvent(message=message))
                         last_heartbeat = now
 
                     await asyncio.sleep(poll_interval)

--- a/tests/test_hosts/test_github_checks.py
+++ b/tests/test_hosts/test_github_checks.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from cog.core.errors import HostError
+from cog.core.host import PrChecks
 from cog.hosts.github import GitHubGitHost
 from tests.fakes import FakeSubprocessRegistry
 
@@ -128,6 +129,34 @@ async def test_get_pr_checks_raises_host_error_on_gh_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     registry.expect(_CHECKS_ARGV, returncode=1, stderr=b"gh: not found")
+    monkeypatch.setattr("asyncio.create_subprocess_exec", registry.create_subprocess_exec)
+    host = GitHubGitHost(project_dir)
+    with pytest.raises(HostError):
+        await host.get_pr_checks(42)
+
+
+# Literal from real gh output — if gh changes the wording this test breaks loudly.
+_NO_CHECKS_STDERR = b"no checks reported on the 'feature-branch' branch"
+
+
+async def test_get_pr_checks_swallows_no_checks_reported(
+    registry: FakeSubprocessRegistry,
+    project_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry.expect(_CHECKS_ARGV, returncode=1, stderr=_NO_CHECKS_STDERR, stdout=b"[]\n")
+    monkeypatch.setattr("asyncio.create_subprocess_exec", registry.create_subprocess_exec)
+    host = GitHubGitHost(project_dir)
+    checks = await host.get_pr_checks(42)
+    assert checks == PrChecks(runs=())
+
+
+async def test_get_pr_checks_reraises_other_exit1_failures(
+    registry: FakeSubprocessRegistry,
+    project_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry.expect(_CHECKS_ARGV, returncode=1, stderr=b"no pull requests found")
     monkeypatch.setattr("asyncio.create_subprocess_exec", registry.create_subprocess_exec)
     host = GitHubGitHost(project_dir)
     with pytest.raises(HostError):

--- a/tests/test_workflows/test_ralph_ci_wait.py
+++ b/tests/test_workflows/test_ralph_ci_wait.py
@@ -550,3 +550,134 @@ async def test_finalize_success_ci_timeout_writes_telemetry_with_cause_class_ci_
     record = tel.write.call_args.args[0]
     assert record.outcome == "ci-failed"
     assert record.cause_class == "CiTimeoutError"
+
+
+# ---------------------------------------------------------------------------
+# _wait_for_ci: empty PrChecks / no-checks-reported tolerance
+# ---------------------------------------------------------------------------
+
+_EMPTY_CHECKS = PrChecks(runs=())
+
+
+async def test_wait_polls_past_empty_checks_until_passed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.001")
+    monkeypatch.setenv("COG_CI_TIMEOUT_SECONDS", "10")
+    sequence = [_EMPTY_CHECKS, _EMPTY_CHECKS, _passed_checks("ci")]
+    host = _make_host(checks_sequence=sequence)
+    wf = _make_wf(host=host)
+    ctx = _make_ctx(tmp_path)
+
+    result = await wf._wait_for_ci(ctx, _make_pr())
+
+    assert result.all_passed is True
+    assert host.get_pr_checks.call_count == 3
+
+
+async def test_wait_flake_tolerance_empty_between_nonempty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Empty response between non-empty responses must not break early."""
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.001")
+    monkeypatch.setenv("COG_CI_TIMEOUT_SECONDS", "10")
+    sequence = [
+        _EMPTY_CHECKS,
+        _pending_checks("ci"),
+        _EMPTY_CHECKS,
+        _passed_checks("ci"),
+    ]
+    host = _make_host(checks_sequence=sequence)
+    wf = _make_wf(host=host)
+    ctx = _make_ctx(tmp_path)
+
+    result = await wf._wait_for_ci(ctx, _make_pr())
+
+    assert result.all_passed is True
+    assert host.get_pr_checks.call_count == 4
+
+
+async def test_wait_empty_checks_persisting_raises_ci_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.001")
+    monkeypatch.setenv("COG_CI_TIMEOUT_SECONDS", "0.01")
+
+    async def always_empty(_: int) -> PrChecks:
+        await asyncio.sleep(0.001)
+        return _EMPTY_CHECKS
+
+    host = _make_host()
+    host.get_pr_checks.side_effect = always_empty
+    wf = _make_wf(host=host)
+    ctx = _make_ctx(tmp_path)
+
+    with pytest.raises(CiTimeoutError):
+        await wf._wait_for_ci(ctx, _make_pr())
+
+
+async def test_wait_heartbeat_empty_phase_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.001")
+    monkeypatch.setenv("COG_CI_TIMEOUT_SECONDS", "10")
+
+    async def fake_sleep(_: float) -> None:
+        pass
+
+    time_values = [0.0, 0.0, 61.0, 61.0, 61.0]
+    time_idx = [0]
+
+    def fake_monotonic() -> float:
+        val = time_values[min(time_idx[0], len(time_values) - 1)]
+        time_idx[0] += 1
+        return val
+
+    sequence = [_EMPTY_CHECKS, _EMPTY_CHECKS, _passed_checks("ci")]
+    host = _make_host(checks_sequence=sequence)
+    wf = _make_wf(host=host)
+    sink = RecordingEventSink()
+    ctx = _make_ctx(tmp_path, event_sink=sink)
+
+    with (
+        patch("asyncio.sleep", side_effect=fake_sleep),
+        patch("cog.workflows.ralph.time.monotonic", side_effect=fake_monotonic),
+    ):
+        await wf._wait_for_ci(ctx, _make_pr())
+
+    messages = [e.message for e in sink.events if isinstance(e, StatusEvent)]
+    assert any("waiting for checks to begin" in m for m in messages)
+
+
+async def test_wait_heartbeat_reverts_to_count_format_once_runs_appear(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COG_CI_POLL_INTERVAL_SECONDS", "0.001")
+    monkeypatch.setenv("COG_CI_TIMEOUT_SECONDS", "10")
+
+    async def fake_sleep(_: float) -> None:
+        pass
+
+    # advance time past heartbeat interval twice: once for empty phase, once for runs phase
+    time_values = [0.0, 0.0, 61.0, 61.0, 122.0, 122.0, 122.0]
+    time_idx = [0]
+
+    def fake_monotonic() -> float:
+        val = time_values[min(time_idx[0], len(time_values) - 1)]
+        time_idx[0] += 1
+        return val
+
+    sequence = [_EMPTY_CHECKS, _pending_checks("ci"), _pending_checks("ci"), _passed_checks("ci")]
+    host = _make_host(checks_sequence=sequence)
+    wf = _make_wf(host=host)
+    sink = RecordingEventSink()
+    ctx = _make_ctx(tmp_path, event_sink=sink)
+
+    with (
+        patch("asyncio.sleep", side_effect=fake_sleep),
+        patch("cog.workflows.ralph.time.monotonic", side_effect=fake_monotonic),
+    ):
+        await wf._wait_for_ci(ctx, _make_pr())
+
+    messages = [e.message for e in sink.events if isinstance(e, StatusEvent)]
+    assert any("passed," in m and "pending" in m for m in messages)


### PR DESCRIPTION
When GitHub hasn't surfaced check runs yet, `gh pr checks` exits 1 with stderr "no checks reported on the '<branch>' branch". Previously this HostError propagated immediately out of _wait_for_ci, failing the run.

Now get_pr_checks catches HostError containing the known marker and returns PrChecks(runs=()), and _wait_for_ci continues polling on empty runs (guarding `if checks.runs and not checks.pending` so vacuous all_passed doesn't short-circuit). CiTimeoutError fires if checks never appear, preserving the existing timeout behavior for no-CI repos.