### PR TITLE
Fix pytest hang at 73%: empty PrChecks fakes never break _wait_for_ci

### DIFF
--- a/tests/test_workflows/test_ralph_finalization.py
+++ b/tests/test_workflows/test_ralph_finalization.py
@@ -9,7 +9,7 @@ import pytest
 
 from cog.core.context import ExecutionContext
 from cog.core.errors import HostError, StageError
-from cog.core.host import GitHost, PrChecks, PullRequest
+from cog.core.host import CheckRun, GitHost, PrChecks, PullRequest
 from cog.core.tracker import IssueTracker
 from cog.workflows.ralph import RalphWorkflow, _split_final_message
 from tests.fakes import InMemoryStateCache, RecordingEventSink, make_item, make_stage_result
@@ -57,8 +57,12 @@ def _make_host(*, pr: PullRequest | None = None, push_error: HostError | None = 
     host.create_pr.return_value = _make_pr()
     host.update_pr.return_value = None
     host.comment_on_pr.return_value = None
-    # Default: all checks pass so CI wait resolves immediately
-    host.get_pr_checks.return_value = PrChecks(runs=())
+    # Default: one passed check so CI wait resolves immediately. Empty runs
+    # would now poll forever — _wait_for_ci treats no-runs-yet as "still
+    # waiting for CI to start" since the #144 race fix.
+    host.get_pr_checks.return_value = PrChecks(
+        runs=(CheckRun(name="ci", state="passed", link="https://ci.example/ci"),)
+    )
     return host
 
 

--- a/tests/test_workflows/test_ralph_integration.py
+++ b/tests/test_workflows/test_ralph_integration.py
@@ -105,13 +105,15 @@ async def test_end_to_end_with_real_git(git_env: Path) -> None:
         created_at=datetime(2024, 1, 1, tzinfo=UTC),
     )
 
-    from cog.core.host import PrChecks
+    from cog.core.host import CheckRun, PrChecks
 
     tracker_mock = AsyncMock(spec=IssueTracker)
     tracker_mock.list_by_label = AsyncMock(return_value=[item])
     tracker_mock.get = AsyncMock(return_value=item)
     host_mock = AsyncMock(spec=GitHost)
-    host_mock.get_pr_checks.return_value = PrChecks(runs=())
+    host_mock.get_pr_checks.return_value = PrChecks(
+        runs=(CheckRun(name="ci", state="passed", link="https://ci.example/ci"),)
+    )
 
     wf = RalphWorkflow(runner=EchoRunner(), tracker=tracker_mock, host=host_mock)
 
@@ -172,6 +174,7 @@ def _make_pr(number: int = 1, url: str = "https://github.com/org/repo/pull/1") -
 
 async def test_finalize_success_pr_body_with_structured_final_message(tmp_path: Path) -> None:
     """ScriptedFinalMessageRunner emitting structured output → all three sections in PR body."""
+    from cog.core.host import CheckRun as _CheckRun
     from cog.core.host import PrChecks as _PrChecks
 
     final_message = (_FIXTURE_DIR / "final_message_structured.md").read_text()
@@ -180,7 +183,9 @@ async def test_finalize_success_pr_body_with_structured_final_message(tmp_path: 
     host = AsyncMock(spec=GitHost)
     host.push_branch.return_value = None
     host.get_pr_for_branch.return_value = None
-    host.get_pr_checks.return_value = _PrChecks(runs=())
+    host.get_pr_checks.return_value = _PrChecks(
+        runs=(_CheckRun(name="ci", state="passed", link="https://ci.example/ci"),)
+    )
     pr = _make_pr()
     host.create_pr.return_value = pr
 
@@ -220,6 +225,7 @@ async def test_finalize_success_pr_body_with_structured_final_message(tmp_path: 
 
 async def test_finalize_success_pr_body_with_unstructured_final_message(tmp_path: Path) -> None:
     """Terse final message → Summary = full message, no Key changes, test-plan fallback."""
+    from cog.core.host import CheckRun as _CheckRun
     from cog.core.host import PrChecks as _PrChecks
 
     final_message = (_FIXTURE_DIR / "final_message_terse.md").read_text().strip()
@@ -228,7 +234,9 @@ async def test_finalize_success_pr_body_with_unstructured_final_message(tmp_path
     host = AsyncMock(spec=GitHost)
     host.push_branch.return_value = None
     host.get_pr_for_branch.return_value = None
-    host.get_pr_checks.return_value = _PrChecks(runs=())
+    host.get_pr_checks.return_value = _PrChecks(
+        runs=(_CheckRun(name="ci", state="passed", link="https://ci.example/ci"),)
+    )
     host.create_pr.return_value = _make_pr()
 
     wf = RalphWorkflow(

--- a/tests/test_workflows/test_ralph_resume.py
+++ b/tests/test_workflows/test_ralph_resume.py
@@ -9,7 +9,7 @@ import pytest
 
 from cog.core.context import ExecutionContext
 from cog.core.errors import HostError, TrackerError
-from cog.core.host import GitHost, PrChecks, PullRequest
+from cog.core.host import CheckRun, GitHost, PrChecks, PullRequest
 from cog.core.tracker import IssueTracker
 from cog.workflows.ralph import RalphWorkflow
 from tests.fakes import InMemoryStateCache, RecordingEventSink, make_item, make_stage_result
@@ -60,7 +60,11 @@ def _make_host(*, pr: PullRequest | None = None) -> AsyncMock:
     )
     host.update_pr.return_value = None
     host.comment_on_pr.return_value = None
-    host.get_pr_checks.return_value = PrChecks(runs=())
+    # One passed check so _wait_for_ci resolves immediately. Empty runs would
+    # poll forever since the #144 race fix.
+    host.get_pr_checks.return_value = PrChecks(
+        runs=(CheckRun(name="ci", state="passed", link="https://ci.example/ci"),)
+    )
     return host
 
 


### PR DESCRIPTION
## Summary

- `uv run pytest` was hanging at 73% (specifically `test_finalize_success_pushes_branch` in `tests/test_workflows/test_ralph_finalization.py`) and never finishing.
- Root cause: after #144 ('Tolerate "no checks reported" race in ralph CI wait'), `_wait_for_ci` no longer breaks on empty `PrChecks(runs=())` — that case now means "checks haven't started yet, keep polling until timeout."
- Several `finalize_success`-exercising tests still used `PrChecks(runs=())` as their fake host's "all checks pass" default. Pre-#144 that short-circuited via `not checks.pending`; post-#144 the fixture polls on a 15s interval until the 1800s timeout. First hit hangs the suite.
- Fix: replace the empty-runs default with a single passed `CheckRun` so the fakes once again model "all checks pass" and resolve immediately.

## Files touched

- `tests/test_workflows/test_ralph_finalization.py::_make_host`
- `tests/test_workflows/test_ralph_resume.py::_make_host`
- `tests/test_workflows/test_ralph_integration.py` (×2 inline host setups)

`test_ralph_rebase.py` and `test_ralph_ci_wait.py` also use `PrChecks(runs=())` but either patch `_wait_for_ci` directly or are testing the polling loop, so they're untouched.

## Test plan

- [x] `uv run pytest` completes in ~35s with 1060 passed, 3 skipped (was hanging at 73% before).
- [x] `uv run ruff check` and `uv run ruff format --check` clean for the three changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)