### PR TITLE
Ralph: run each iteration in a git worktree under `.cog/worktrees/` (#152)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,9 +79,12 @@ strict).
   signal means adding an event type in `core/runner.py` and a handler
   in the widget's `emit()`.
 - **StageExecutor is the single iteration unit.** A workflow iteration =
-  `select_item → pre_stages → stages → post_stages → classify_outcome
-  → finalize_{success|noop|error}`. Don't replicate this shape inline;
-  extend the workflow interface.
+  `select_item → iteration_start → pre_stages → stages → post_stages
+  → classify_outcome → finalize_{success|noop|error} → iteration_end`.
+  `iteration_start`/`iteration_end` are optional hooks on `Workflow`
+  (default: no-op) for per-iteration setup/teardown (e.g. worktree create/
+  remove in ralph). Don't replicate this shape inline; extend the workflow
+  interface.
 - **Ralph failures are additive, not destructive.** On error, ralph
   keeps `agent-ready`, adds `agent-failed`. The item stays eligible for
   resume. `agent-failed` is a *signal*, not a terminal state.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,10 @@ src/cog/
 ├── state_paths.py    XDG-compliant state directory resolution
 ├── checks.py         Preflight checks + RALPH_CHECKS / REFINE_CHECKS bundles
 ├── telemetry.py      TelemetryRecord + TelemetryWriter (runs.jsonl)
-└── loop.py           Cross-iteration state primitives
+├── loop.py           Cross-iteration state primitives
+└── git/              Async git subprocess helpers
+    ├── __init__.py   Branch, status, fetch, merge helpers
+    └── worktree.py   git worktree lifecycle (create/remove/prune/scan_orphans)
 ```
 
 Two separate abstractions — don't conflate: **IssueTracker** (reads/writes

--- a/README.md
+++ b/README.md
@@ -201,3 +201,10 @@ Cog writes per-project state under
 - `runs.jsonl` — one telemetry record per run (schema in
   [ARCHITECTURE.md](docs/ARCHITECTURE.md#telemetry-runsjsonl))
 - `reports/<ts>-<workflow>-<item-slug>.md` — per-run markdown report
+
+Ralph also writes into the **project directory**:
+
+- `.cog/worktrees/<id>-<slug>/` — isolated git worktree per iteration.
+  Created at iteration start, removed after push. A surviving directory
+  indicates a stuck or crashed run; see
+  [ralph.md § Worktrees](docs/workflows/ralph.md#worktrees).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -253,6 +253,10 @@ end with a `ResultEvent`. See `ClaudeCliRunner` for the reference.
 
 1. Subclass `Workflow` (`src/cog/core/workflow.py`).
 2. Implement `select_item` / `stages` / `classify_outcome` at minimum.
-3. Register in `src/cog/workflows/__init__.py::WORKFLOWS`.
-4. For a TUI presence, create a view widget under `src/cog/ui/views/`
+3. Override `iteration_start` / `iteration_end` if you need per-iteration
+   setup or teardown (e.g. creating an isolated worktree). Both default to
+   no-op. `iteration_end` receives the `IterationOutcome` and is called
+   even on Ctrl+C / exception.
+4. Register in `src/cog/workflows/__init__.py::WORKFLOWS`.
+5. For a TUI presence, create a view widget under `src/cog/ui/views/`
    and add it to `CogShellScreen`'s compose.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,7 +40,9 @@ src/cog/
 ├── telemetry.py            TelemetryRecord + TelemetryWriter (runs.jsonl)
 ├── headless.py             Non-TUI event sink + iteration driver
 ├── loop.py                 Cross-iteration primitives
-└── git.py                  Async git subprocess helpers
+└── git/                    Async git subprocess helpers
+    ├── __init__.py         Branch, status, fetch, merge helpers
+    └── worktree.py         git worktree lifecycle (create/remove/prune/scan_orphans)
 ```
 
 **Two separate abstractions — don't conflate**: `IssueTracker` (reads /
@@ -92,6 +94,12 @@ ctx)` per iteration with a fresh `ExecutionContext`.
   `Status`) flow through `ctx.event_sink` to whichever widget is
   mounted. Adding a new UI signal means adding an event type in
   `core/runner.py` and a handler in the widget's `emit()`.
+- **Each ralph iteration runs in an isolated git worktree.** Ralph creates
+  `.cog/worktrees/<id>-<slug>/` per iteration via `git worktree add`
+  (`git/worktree.py`). The main checkout is never touched during a run.
+  On success the worktree is removed; on failure it is pushed if ahead of
+  origin, then removed. Orphaned worktrees from crashed runs are recovered
+  by `scan_orphans()` at startup.
 - **Ralph failures are additive, not destructive.** On error, ralph
   keeps `agent-ready`, adds `agent-failed`. `agent-failed` is a
   *signal*, not a terminal state — it clears on the next success.
@@ -151,6 +159,12 @@ directory name with non-alphanumerics replaced by `-`.
 | `state.json` | Processed / deferred item tracking. Processed entries are revived if the issue is edited after the record (`updated_at > ts`). |
 | `runs.jsonl` | One JSON line per workflow run — telemetry record. Append-only with fcntl locking. |
 | `reports/<ts>-<workflow>-<item-slug>.md` | Human-readable run report. Refine reports include the original body, proposed body, full interview transcript, and per-stage cost table. |
+
+Ralph also writes worktrees inside the **project directory** (not the state dir):
+
+| Path | Contents |
+|------|----------|
+| `.cog/worktrees/<id>-<slug>/` | Isolated git worktree per iteration. Created at `iteration_start`, removed after push. Survivors indicate a stuck run; see [ralph.md](workflows/ralph.md#worktrees). |
 
 ## Telemetry (runs.jsonl)
 

--- a/docs/workflows/ralph.md
+++ b/docs/workflows/ralph.md
@@ -13,8 +13,8 @@ hands off (or retries fixes) based on the result.
 flowchart TD
     Select[Select next agent-ready item] --> Blockers{Open blockers?}
     Blockers -->|yes| Defer[Defer — outcome: deferred-by-blocker]
-    Blockers -->|no| Prep[Fetch origin, checkout default,<br/>merge --ff-only]
-    Prep --> Branch[Create worktree at<br/>.cog/worktrees/N-slug/<br/>on cog/N-slug branch]
+    Blockers -->|no| Prep[Fetch origin]
+    Prep --> Branch[Create worktree at<br/>.cog/worktrees/N-slug/<br/>on cog/N-slug branch from origin/default]
     Branch --> Stages[Stages:<br/>build → review → document]
     Stages --> Commits{Commits<br/>created?}
     Commits -->|no| Noop[Outcome: no-op<br/>add agent-abandoned]

--- a/docs/workflows/ralph.md
+++ b/docs/workflows/ralph.md
@@ -14,7 +14,7 @@ flowchart TD
     Select[Select next agent-ready item] --> Blockers{Open blockers?}
     Blockers -->|yes| Defer[Defer — outcome: deferred-by-blocker]
     Blockers -->|no| Prep[Fetch origin, checkout default,<br/>merge --ff-only]
-    Prep --> Branch[Create or resume<br/>cog/N-slug branch]
+    Prep --> Branch[Create worktree at<br/>.cog/worktrees/N-slug/<br/>on cog/N-slug branch]
     Branch --> Stages[Stages:<br/>build → review → document]
     Stages --> Commits{Commits<br/>created?}
     Commits -->|no| Noop[Outcome: no-op<br/>add agent-abandoned]
@@ -80,13 +80,33 @@ If CI fails, ralph runs a fix-on-CI loop:
 Capped at `COG_CI_MAX_RETRIES` (default: 2). If all retries fail or CI
 times out, the outcome is `ci-failed` and the item gets `agent-failed`.
 
+## Worktrees
+
+Each iteration runs in an isolated git worktree under
+`.cog/worktrees/<id>-<slug>/` rather than the main checkout. This means
+ralph's file writes never touch your working tree.
+
+Worktree lifecycle:
+
+- **Created** at `iteration_start` via `git worktree add`. The main
+  checkout is never modified.
+- **Removed** at `iteration_end` once the branch is pushed (or is
+  already up-to-date with origin).
+- **Left in place** if the iteration ends with a dirty tree — the item
+  gets `agent-failed` and is skipped until the worktree is resolved
+  manually (or removed with `git worktree remove --force`).
+
+At startup ralph runs an orphan scan over `.cog/worktrees/` to recover
+worktrees from crashed runs: clean ones are pushed (if ahead) and
+removed; dirty ones surface as `agent-failed` comments on the item.
+
 ## Branch resume
 
-If ralph is interrupted (cancelled, error) while on `cog/N-<slug>`, the
-next run on that same item can resume the branch rather than recreating
-it. Ralph detects an existing branch with unpushed commits and resumes
-from there; otherwise it restarts from a fresh default branch. Pass
-`--restart` to force recreation.
+If ralph is interrupted while on `cog/N-<slug>`, the next run resumes
+the existing branch in a fresh worktree rather than recreating it from
+scratch. Ralph detects an existing local or remote branch with commits
+and resumes from there. Pass `--restart` to force recreation from the
+default branch.
 
 ## Commands
 

--- a/src/cog/core/context.py
+++ b/src/cog/core/context.py
@@ -22,6 +22,8 @@ class ExecutionContext:
     headless: bool
     item: Item | None = None
     work_branch: str | None = None
+    worktree_path: Path | None = None
+    resumed: bool = False
     event_sink: RunEventSink | None = None
     input_provider: UserInputProvider | None = None
     item_picker: ItemPicker | None = None

--- a/src/cog/core/runner.py
+++ b/src/cog/core/runner.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass
@@ -53,7 +55,7 @@ class StatusEvent:
 
 @dataclass(frozen=True)
 class ItemSelectedEvent:
-    item: "Item"
+    item: Item
 
 
 RunEvent = (
@@ -69,12 +71,14 @@ RunEvent = (
 
 class AgentRunner(ABC):
     @abstractmethod
-    def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]: ...
+    def stream(
+        self, prompt: str, *, model: str, cwd: Path | None = None
+    ) -> AsyncIterator[RunEvent]: ...
 
-    async def run(self, prompt: str, *, model: str) -> RunResult:
+    async def run(self, prompt: str, *, model: str, cwd: Path | None = None) -> RunResult:
         """Default impl — drain stream() and return the final RunResult."""
         result: RunResult | None = None
-        async for event in self.stream(prompt, model=model):
+        async for event in self.stream(prompt, model=model, cwd=cwd):
             if isinstance(event, ResultEvent):
                 result = event.result
         assert result is not None, "runner must emit a ResultEvent before finishing"

--- a/src/cog/core/sandbox.py
+++ b/src/cog/core/sandbox.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping, Sequence
+from pathlib import Path
 from typing import Protocol
 
 
@@ -10,9 +11,12 @@ class Sandbox(Protocol):
         Called before each wrap_* cycle. Implementations may cache internally."""
         ...
 
-    def wrap_argv(self, argv: Sequence[str]) -> list[str]:
+    def wrap_argv(self, argv: Sequence[str], cwd: Path | None = None) -> list[str]:
         """Transform claude's argv into the argv actually passed to create_subprocess_exec.
-        DockerSandbox wraps with docker run args; NullSandbox returns list(argv)."""
+
+        `cwd` is the host-absolute working directory for the subprocess (the active
+        worktree path for ralph stages). DockerSandbox maps it to a container path
+        via `--workdir`; NullSandbox ignores it."""
         ...
 
     def wrap_env(self, env: Mapping[str, str]) -> dict[str, str]:

--- a/src/cog/core/stage.py
+++ b/src/cog/core/stage.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 
 from cog.core.context import ExecutionContext
 from cog.core.runner import AgentRunner
@@ -14,6 +17,8 @@ class Stage:
     interactive: bool = False
     # True → failures stored in StageResult.error; executor continues to next stage
     tolerate_failure: bool = False
+    # Host-absolute path to pass as working directory to the sandbox
+    cwd: Path | None = None
 
 
 def static_prompt(resource: str) -> Callable[[ExecutionContext], str]:

--- a/src/cog/core/workflow.py
+++ b/src/cog/core/workflow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import enum
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
@@ -26,6 +27,13 @@ if TYPE_CHECKING:
     from textual.widget import Widget
 
 
+class IterationOutcome(enum.Enum):
+    success = "success"
+    noop = "noop"
+    error = "error"
+    exception = "exception"
+
+
 class Workflow(ABC):
     name: ClassVar[str]
     queue_label: ClassVar[str]  # "agent-ready" / "needs-refinement"
@@ -37,6 +45,14 @@ class Workflow(ABC):
     @abstractmethod
     async def select_item(self, ctx: ExecutionContext) -> Item | None:
         """Return next item to process. None = queue empty → executor exits."""
+
+    async def iteration_start(self, ctx: ExecutionContext) -> None:
+        """Called after select_item, before pre_stages. Default: no-op."""
+        return
+
+    async def iteration_end(self, ctx: ExecutionContext, outcome: IterationOutcome) -> None:
+        """Called after the iteration completes (success/noop/error/exception). Default: no-op."""
+        return
 
     async def pre_stages(self, ctx: ExecutionContext) -> None:
         return
@@ -90,6 +106,7 @@ class StageExecutor:
             await ctx.event_sink.emit(ItemSelectedEvent(item=ctx.item))
         results: list[StageResult] = []
         try:
+            await workflow.iteration_start(ctx)
             await workflow.pre_stages(ctx)
             for stage in workflow.stages(ctx):
                 results.append(await self._run_stage(stage, ctx))
@@ -114,9 +131,12 @@ class StageExecutor:
         if sink is not None:
             await sink.emit(StageStartEvent(stage_name=stage.name, model=stage.model))
 
+        # Use worktree path for HEAD-relative operations when available
+        git_dir = ctx.worktree_path or ctx.project_dir
+
         head_before: str | None = None
         try:
-            head_before = await git.current_head_sha(ctx.project_dir)
+            head_before = await git.current_head_sha(git_dir)
         except GitError:
             pass  # not a git repo; commits_created stays 0
 
@@ -125,7 +145,7 @@ class StageExecutor:
         run_result: RunResult | None = None
         try:
             prompt = stage.prompt_source(ctx)
-            async for event in stage.runner.stream(prompt, model=stage.model):
+            async for event in stage.runner.stream(prompt, model=stage.model, cwd=stage.cwd):
                 if isinstance(event, ResultEvent):
                     run_result = event.result
                 elif sink is not None:
@@ -142,7 +162,7 @@ class StageExecutor:
         commits_created = 0
         if head_before is not None:
             try:
-                commits_created = await git.commits_between(ctx.project_dir, head_before)
+                commits_created = await git.commits_between(git_dir, head_before)
             except GitError:
                 pass  # counting failed; leave 0
 
@@ -203,10 +223,11 @@ class StageExecutor:
     ) -> StageResult:
         """Best-effort StageResult for error paths."""
         duration = time.monotonic() - start
+        git_dir = ctx.worktree_path or ctx.project_dir
         commits_created = 0
         if head_before is not None:
             try:
-                commits_created = await git.commits_between(ctx.project_dir, head_before)
+                commits_created = await git.commits_between(git_dir, head_before)
             except GitError:
                 pass
         if run_result is not None:

--- a/src/cog/git/__init__.py
+++ b/src/cog/git/__init__.py
@@ -118,10 +118,19 @@ async def log_short_shas(project_dir: Path, revision_range: str) -> list[str]:
 async def rebase_in_progress(project_dir: Path) -> bool:
     """True if a git rebase is currently paused (conflict or interactive).
 
-    Checks for .git/rebase-merge/ or .git/rebase-apply/ — git's canonical
-    mid-rebase markers.
+    Works for both main checkouts (.git is a directory) and worktrees (.git
+    is a gitdir file pointing to the real git directory).
     """
-    git_dir = project_dir / ".git"
+    git_path = project_dir / ".git"
+    if git_path.is_file():
+        # worktree: .git is a file like "gitdir: <abs-path>"
+        content = git_path.read_text().strip()
+        if content.startswith("gitdir: "):
+            git_dir = Path(content.removeprefix("gitdir: "))
+        else:
+            return False
+    else:
+        git_dir = git_path
     return (git_dir / "rebase-merge").is_dir() or (git_dir / "rebase-apply").is_dir()
 
 

--- a/src/cog/git/worktree.py
+++ b/src/cog/git/worktree.py
@@ -1,0 +1,310 @@
+"""Pure functions over the `git worktree` CLI.
+
+All functions shell to git via the async helpers in `cog.git`; no direct
+subprocess calls inline. Errors raise typed exceptions from `cog.core.errors`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from subprocess import PIPE
+
+from cog.core.errors import GitError
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WorktreeInfo:
+    path: Path
+    branch: str | None  # None if detached HEAD
+    head: str
+    is_locked: bool
+    is_prunable: bool
+
+
+@dataclass(frozen=True)
+class StuckWorktree:
+    path: Path
+    branch: str | None
+    item_id: int | None  # parsed from dir name "<id>-<slug>"
+    reason: str  # "dirty", "push failed: ...", "not registered with git"
+
+
+@dataclass
+class OrphanScanResult:
+    cleaned: list[Path]
+    pushed: list[tuple[Path, str]]  # (path, branch)
+    dirty: list[StuckWorktree]
+    unregistered: list[Path]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_WORKTREE_DIR_RE = re.compile(r"^\d+-[a-z0-9-]+$")
+_ITEM_ID_RE = re.compile(r"^(\d+)-")
+
+
+async def _run(args: list[str], cwd: Path) -> str:
+    proc = await asyncio.create_subprocess_exec(*args, cwd=cwd, stdout=PIPE, stderr=PIPE)
+    stdout, stderr = await proc.communicate()
+    if proc.returncode != 0:
+        raise GitError(
+            f"{' '.join(args)} failed (exit {proc.returncode}): {stderr.decode().strip()}"
+        )
+    return stdout.decode().strip()
+
+
+def _parse_item_id(dirname: str) -> int | None:
+    m = _ITEM_ID_RE.match(dirname)
+    return int(m.group(1)) if m else None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def create_worktree(
+    repo: Path,
+    path: Path,
+    branch: str,
+    *,
+    start_point: str,
+    create_branch: bool,
+) -> None:
+    """`git worktree add [-b <branch>] <path> <start_point>`."""
+    if create_branch:
+        await _run(["git", "worktree", "add", "-b", branch, str(path), start_point], repo)
+    else:
+        await _run(["git", "worktree", "add", str(path), branch], repo)
+
+
+async def remove_worktree(repo: Path, path: Path, *, force: bool = False) -> None:
+    """`git worktree remove [--force] <path>`."""
+    args = ["git", "worktree", "remove"]
+    if force:
+        args.append("--force")
+    args.append(str(path))
+    await _run(args, repo)
+
+
+async def list_worktrees(repo: Path) -> list[WorktreeInfo]:
+    """`git worktree list --porcelain` → list of WorktreeInfo."""
+    out = await _run(["git", "worktree", "list", "--porcelain"], repo)
+    entries: list[WorktreeInfo] = []
+    current: dict[str, str] = {}
+    for line in out.splitlines():
+        if not line:
+            if current:
+                entries.append(_parse_worktree_entry(current))
+                current = {}
+        else:
+            if " " in line:
+                key, _, val = line.partition(" ")
+                current[key] = val
+            else:
+                current[line] = ""
+    if current:
+        entries.append(_parse_worktree_entry(current))
+    return entries
+
+
+def _parse_worktree_entry(entry: dict[str, str]) -> WorktreeInfo:
+    raw_branch = entry.get("branch", "")
+    branch = raw_branch.removeprefix("refs/heads/") if raw_branch else None
+    return WorktreeInfo(
+        path=Path(entry.get("worktree", "")),
+        branch=branch or None,
+        head=entry.get("HEAD", ""),
+        is_locked="locked" in entry,
+        is_prunable="prunable" in entry,
+    )
+
+
+async def prune(repo: Path) -> None:
+    """`git worktree prune`."""
+    await _run(["git", "worktree", "prune"], repo)
+
+
+async def is_dirty(path: Path) -> bool:
+    """True iff `git -C <path> status --porcelain` produces any output.
+
+    Staged, unstaged tracked changes, and non-ignored untracked files all
+    count. Gitignored files do not.
+    """
+    out = await _run(
+        ["git", "-C", str(path), "status", "--porcelain", "--untracked-files=normal"],
+        path,
+    )
+    return bool(out.strip())
+
+
+async def remote_branch_exists(repo: Path, branch: str) -> bool:
+    """True if `origin/<branch>` exists."""
+    try:
+        await _run(
+            ["git", "rev-parse", "--verify", f"refs/remotes/origin/{branch}"],
+            repo,
+        )
+        return True
+    except GitError:
+        return False
+
+
+async def is_ahead_of_origin(path: Path, branch: str) -> bool:
+    """True if `branch` has commits not on `origin/<branch>` (or origin lacks it)."""
+    repo = _find_repo_root(path)
+    try:
+        count_str = await _run(
+            ["git", "rev-list", "--count", f"origin/{branch}..{branch}"],
+            repo,
+        )
+        return int(count_str) > 0
+    except GitError:
+        # origin/branch doesn't exist — we're ahead by definition
+        return True
+
+
+def _find_repo_root(path: Path) -> Path:
+    """Walk up from path to find the repo root (where .git lives)."""
+    current = path if path.is_dir() else path.parent
+    while True:
+        git_path = current / ".git"
+        if git_path.exists():
+            return current
+        parent = current.parent
+        if parent == current:
+            return path  # fallback: use path itself
+        current = parent
+
+
+async def push_branch(path: Path, branch: str) -> None:
+    """`git -C <path> push origin <branch>`."""
+    await _run(["git", "-C", str(path), "push", "origin", branch], path)
+
+
+async def push_with_retry(
+    path: Path,
+    branch: str,
+    *,
+    attempts: int = 2,
+    backoff_seconds: float = 5.0,
+) -> None:
+    """Push branch, retrying on failure with a short backoff."""
+    last_exc: GitError | None = None
+    for i in range(attempts):
+        try:
+            await push_branch(path, branch)
+            return
+        except GitError as e:
+            last_exc = e
+            if i < attempts - 1:
+                await asyncio.sleep(backoff_seconds)
+    raise last_exc  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Orphan scan
+# ---------------------------------------------------------------------------
+
+
+async def scan_orphans(project_dir: Path) -> OrphanScanResult:
+    """Scan .cog/worktrees/ for orphaned worktrees and recover what we can.
+
+    Steps:
+    1. git worktree prune
+    2. List entries under <project_dir>/.cog/worktrees/
+    3. Filter to those matching <id>-<slug> pattern
+    4. Classify each against `git worktree list --porcelain` and act
+
+    Returns an OrphanScanResult describing what happened.
+    """
+    result = OrphanScanResult(cleaned=[], pushed=[], dirty=[], unregistered=[])
+    worktrees_dir = project_dir / ".cog" / "worktrees"
+    if not worktrees_dir.is_dir():
+        return result
+
+    await prune(project_dir)
+
+    try:
+        registered = await list_worktrees(project_dir)
+    except GitError:
+        return result
+
+    registered_paths = {wt.path for wt in registered}
+    registered_by_path = {wt.path: wt for wt in registered}
+
+    for entry in worktrees_dir.iterdir():
+        if not entry.is_dir():
+            continue
+        if not _WORKTREE_DIR_RE.match(entry.name):
+            continue
+
+        item_id = _parse_item_id(entry.name)
+
+        if entry not in registered_paths:
+            result.unregistered.append(entry)
+            continue
+
+        wt = registered_by_path[entry]
+        branch = wt.branch
+
+        dirty = await is_dirty(entry)
+        if dirty:
+            result.dirty.append(
+                StuckWorktree(
+                    path=entry,
+                    branch=branch,
+                    item_id=item_id,
+                    reason="dirty",
+                )
+            )
+            continue
+
+        if branch and await is_ahead_of_origin(entry, branch):
+            try:
+                await push_with_retry(entry, branch)
+                result.pushed.append((entry, branch))
+            except GitError as e:
+                result.dirty.append(
+                    StuckWorktree(
+                        path=entry,
+                        branch=branch,
+                        item_id=item_id,
+                        reason=f"push failed: {e}",
+                    )
+                )
+                continue
+
+        try:
+            await remove_worktree(project_dir, entry)
+            result.cleaned.append(entry)
+        except GitError as e:
+            result.dirty.append(
+                StuckWorktree(
+                    path=entry,
+                    branch=branch,
+                    item_id=item_id,
+                    reason=f"remove failed: {e}",
+                )
+            )
+
+    return result
+
+
+async def discard_worktree(project_dir: Path, path: Path) -> None:
+    """Force-remove a worktree. Falls back to shutil.rmtree if git fails."""
+    try:
+        await remove_worktree(project_dir, path, force=True)
+    except GitError:
+        if path.exists():
+            shutil.rmtree(path, ignore_errors=True)

--- a/src/cog/headless.py
+++ b/src/cog/headless.py
@@ -11,7 +11,7 @@ from cog.core.runner import (
     StatusEvent,
     ToolUseEvent,
 )
-from cog.core.workflow import StageExecutor, Workflow
+from cog.core.workflow import IterationOutcome, StageExecutor, Workflow
 from cog.loop import LoopState, fresh_iteration_context
 
 
@@ -63,12 +63,14 @@ async def run_headless(
         try:
             results = await StageExecutor().run(workflow, ctx)
         except StageError as e:
+            await workflow.iteration_end(ctx, IterationOutcome.error)
             duration = time.monotonic() - start
             sys.stderr.write(
                 f"\niteration FAILED: stage {e.stage.name!r} failed after {duration:.0f}s\n"
             )
             return 1
         except Exception as e:  # noqa: BLE001 - surface any unexpected failure
+            await workflow.iteration_end(ctx, IterationOutcome.exception)
             duration = time.monotonic() - start
             sys.stderr.write(
                 f"\niteration FAILED: {type(e).__name__}: {e} (after {duration:.0f}s)\n"
@@ -77,9 +79,12 @@ async def run_headless(
         if not results:
             state.iteration -= 1  # empty-queue probe: don't count as an iteration
             break
+        commits = sum(r.commits_created for r in results)
+        it_outcome = IterationOutcome.success if commits > 0 else IterationOutcome.noop
+        await workflow.iteration_end(ctx, it_outcome)
         state.cumulative_cost_usd += sum(r.cost_usd for r in results)
         iter_duration = sum(r.duration_seconds for r in results)
-        outcome = "success" if any(r.commits_created > 0 for r in results) else "no-op"
+        outcome = "success" if commits > 0 else "no-op"
         sys.stderr.write(
             f"iteration complete: outcome={outcome}, "
             f"cost=${sum(r.cost_usd for r in results):.3f}, "

--- a/src/cog/runners/claude_cli.py
+++ b/src/cog/runners/claude_cli.py
@@ -91,7 +91,9 @@ class ClaudeCliRunner(AgentRunner):
         )
         self._sigterm_grace_seconds = 5.0
 
-    async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+    async def stream(
+        self, prompt: str, *, model: str, cwd: Path | None = None
+    ) -> AsyncIterator[RunEvent]:
         await self._sandbox.prepare()
 
         _fd, tmp = tempfile.mkstemp(suffix=".jsonl", prefix="cog-claude-")
@@ -109,7 +111,8 @@ class ClaudeCliRunner(AgentRunner):
                 "--model",
                 model,
                 prompt,
-            ]
+            ],
+            cwd=cwd,
         )
         env = self._sandbox.wrap_env(dict(os.environ))
 

--- a/src/cog/runners/docker_sandbox.py
+++ b/src/cog/runners/docker_sandbox.py
@@ -74,9 +74,10 @@ async def ensure_credentials(force: bool = False) -> str:
 
 
 class DockerSandbox:
-    def __init__(self, image: str = "cog:latest") -> None:
+    def __init__(self, image: str = "cog:latest", project_dir: Path | None = None) -> None:
         self._image = image
         self._built = False
+        self._project_dir = project_dir
 
     async def prepare(self) -> None:
         state_dir = Path.home() / ".local" / "state" / "cog"
@@ -94,7 +95,8 @@ class DockerSandbox:
         elif result == "keychain_missing":
             print("warning: Claude Code credentials not found in keychain", file=sys.stderr)
 
-    def wrap_argv(self, argv: Sequence[str]) -> list[str]:
+    def wrap_argv(self, argv: Sequence[str], cwd: Path | None = None) -> list[str]:
+        workdir = self._container_workdir(cwd)
         return [
             "docker",
             "run",
@@ -106,10 +108,19 @@ class DockerSandbox:
             *self._mount_args(),
             *self._passthrough_env_args(),
             "-w",
-            "/work",
+            workdir,
             self._image,
             *argv,
         ]
+
+    def _container_workdir(self, cwd: Path | None) -> str:
+        if cwd is None:
+            return "/work"
+        project_dir = self._project_dir or Path.cwd()
+        try:
+            return str(Path("/work") / cwd.relative_to(project_dir))
+        except ValueError:
+            return "/work"
 
     def wrap_env(self, env: Mapping[str, str]) -> dict[str, str]:
         return {k: env[k] for k in ("PATH", "HOME", "USER") if k in env}
@@ -192,8 +203,8 @@ class DockerSandbox:
 
     def _mount_args(self) -> list[str]:
         home = Path.home()
-        cwd = Path.cwd()
-        # cwd is always present; other paths mounted only when they exist on the host
+        project_dir = self._project_dir or Path.cwd()
+        # project_dir is always mounted; other paths mounted only when they exist on the host
         conditional = [
             (home / ".claude", "/tmp/cog-home/.claude", "rw"),
             (home / ".claude.json", "/tmp/cog-home/.claude.json", "rw"),
@@ -201,7 +212,7 @@ class DockerSandbox:
             (home / ".gitconfig", "/tmp/cog-home/.gitconfig", "ro"),
             (home / ".local" / "state" / "cog", "/tmp/cog-home/.local/state/cog", "rw"),
         ]
-        args = ["-v", f"{cwd}:/work:rw"]
+        args = ["-v", f"{project_dir}:/work:rw"]
         for host, container, mode in conditional:
             if host.exists():
                 args.extend(["-v", f"{host}:{container}:{mode}"])

--- a/src/cog/runners/sandbox.py
+++ b/src/cog/runners/sandbox.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping, Sequence
+from pathlib import Path
 
 
 class NullSandbox:
@@ -7,7 +8,7 @@ class NullSandbox:
     async def prepare(self) -> None:
         return
 
-    def wrap_argv(self, argv: Sequence[str]) -> list[str]:
+    def wrap_argv(self, argv: Sequence[str], cwd: Path | None = None) -> list[str]:
         return list(argv)
 
     def wrap_env(self, env: Mapping[str, str]) -> dict[str, str]:

--- a/src/cog/ui/screens/run.py
+++ b/src/cog/ui/screens/run.py
@@ -233,12 +233,11 @@ class RunScreen(Screen):
                 )
                 try:
                     results = await StageExecutor().run(self._workflow, ctx)
-                except Exception as exc:
+                except BaseException as exc:
                     it_outcome = (
-                        IterationOutcome.error
-                        if isinstance(exc, Exception)
-                        and not isinstance(exc, asyncio.CancelledError)
-                        else IterationOutcome.exception
+                        IterationOutcome.exception
+                        if isinstance(exc, asyncio.CancelledError)
+                        else IterationOutcome.error
                     )
                     await self._workflow.iteration_end(ctx, it_outcome)
                     raise

--- a/src/cog/ui/screens/run.py
+++ b/src/cog/ui/screens/run.py
@@ -20,7 +20,7 @@ from textual.worker import Worker
 
 from cog.core.context import ExecutionContext
 from cog.core.runner import RunEvent, StageEndEvent, StageStartEvent
-from cog.core.workflow import StageExecutor, Workflow
+from cog.core.workflow import IterationOutcome, StageExecutor, Workflow
 from cog.loop import LoopState, fresh_iteration_context
 
 
@@ -231,10 +231,23 @@ class RunScreen(Screen):
                     preserve_item=self._loop_state.iteration == 1
                     and self._base_ctx.item is not None,
                 )
-                results = await StageExecutor().run(self._workflow, ctx)
+                try:
+                    results = await StageExecutor().run(self._workflow, ctx)
+                except Exception as exc:
+                    it_outcome = (
+                        IterationOutcome.error
+                        if isinstance(exc, Exception)
+                        and not isinstance(exc, asyncio.CancelledError)
+                        else IterationOutcome.exception
+                    )
+                    await self._workflow.iteration_end(ctx, it_outcome)
+                    raise
                 if not results:
                     self._loop_state.iteration -= 1  # empty-queue probe: don't count
                     break
+                commits = sum(r.commits_created for r in results)
+                it_outcome = IterationOutcome.success if commits > 0 else IterationOutcome.noop
+                await self._workflow.iteration_end(ctx, it_outcome)
                 self._refresh_footer()
         except asyncio.CancelledError:
             self._state = "cancelled"

--- a/src/cog/ui/views/ralph.py
+++ b/src/cog/ui/views/ralph.py
@@ -23,14 +23,16 @@ from typing import Literal
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container
+from textual.screen import ModalScreen
 from textual.widget import Widget
-from textual.widgets import Label, ListItem, ListView, Static
+from textual.widgets import Button, Label, ListItem, ListView, Static
 from textual.worker import Worker
 
 from cog.core.context import ExecutionContext
 from cog.core.errors import TrackerError
 from cog.core.item import Item
 from cog.core.tracker import IssueTracker
+from cog.git.worktree import discard_worktree, is_dirty
 from cog.state import JsonFileStateCache
 from cog.state_paths import project_state_dir
 from cog.telemetry import TelemetryWriter
@@ -46,6 +48,50 @@ from cog.ui.widgets.log_pane import LogPaneWidget
 from cog.workflows.ralph import RalphWorkflow
 
 _SubState = Literal["idle", "running", "post_run"]
+
+
+class DirtyWorktreeModal(ModalScreen[bool]):
+    """Confirm discard of a dirty worktree before starting a fresh iteration."""
+
+    DEFAULT_CSS = """
+    DirtyWorktreeModal {
+        align: center middle;
+    }
+    DirtyWorktreeModal > Container {
+        width: 60;
+        height: auto;
+        padding: 1 2;
+        border: solid $warning;
+        background: $surface;
+    }
+    DirtyWorktreeModal #modal-buttons {
+        layout: horizontal;
+        height: auto;
+        margin-top: 1;
+        align-horizontal: right;
+    }
+    DirtyWorktreeModal Button {
+        margin-left: 1;
+    }
+    """
+
+    def __init__(self, worktree_path: Path) -> None:
+        super().__init__()
+        self._worktree_path = worktree_path
+
+    def compose(self) -> ComposeResult:
+        with Container():
+            yield Label(
+                f"Worktree at [bold]{self._worktree_path}[/bold] has uncommitted changes "
+                f"from a previous iteration.\n\nDiscard and start fresh?",
+                id="modal-text",
+            )
+            with Container(id="modal-buttons"):
+                yield Button("Discard", variant="warning", id="btn-discard")
+                yield Button("Cancel", variant="default", id="btn-cancel")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(event.button.id == "btn-discard")
 
 
 class RalphView(Widget, can_focus=True):
@@ -235,7 +281,26 @@ class RalphView(Widget, can_focus=True):
             return
         if idx >= len(self._items):
             return
-        self._worker = self.run_worker(self._run_ralph(self._items[idx]), exclusive=True)
+        self._worker = self.run_worker(
+            self._pick_with_worktree_check(self._items[idx]), exclusive=True
+        )
+
+    async def _pick_with_worktree_check(self, item: Item) -> None:
+        from cog.workflows.ralph import _slugify
+
+        slug = _slugify(item.title)
+        wt_path = self._project_dir / ".cog" / "worktrees" / f"{item.item_id}-{slug}"
+        if wt_path.exists():
+            try:
+                dirty = await is_dirty(wt_path)
+            except Exception:
+                dirty = False
+            if dirty:
+                discard = await self.app.push_screen_wait(DirtyWorktreeModal(wt_path))
+                if not discard:
+                    return
+                await discard_worktree(self._project_dir, wt_path)
+        await self._run_ralph(item)
 
     async def _run_ralph(self, item: Item) -> None:
         self._active_item = item
@@ -275,24 +340,29 @@ class RalphView(Widget, can_focus=True):
         from cog.runners.claude_cli import ClaudeCliRunner
         from cog.runners.docker_sandbox import DockerSandbox
 
-        sandbox = DockerSandbox()
+        sandbox = DockerSandbox(project_dir=self._project_dir)
         runner = ClaudeCliRunner(sandbox)
         host = GitHubGitHost(self._project_dir)
         workflow = RalphWorkflow(runner=runner, tracker=self._tracker, host=host)
 
-        from cog.core.workflow import StageExecutor
+        from cog.core.workflow import IterationOutcome, StageExecutor
 
         header: str
+        results: list = []
         try:
             results = await StageExecutor().run(workflow, ctx)
             if not results:
                 header = "[yellow]No eligible items — queue drained or deferred.[/yellow]"
             else:
+                commits = sum(r.commits_created for r in results)
+                it_outcome = IterationOutcome.success if commits > 0 else IterationOutcome.noop
+                await workflow.iteration_end(ctx, it_outcome)
                 header = (
                     f"[green]✓ Complete[/green] — ${self._cumulative_cost:.3f} · "
                     f"{self._elapsed()} total"
                 )
         except asyncio.CancelledError:
+            await workflow.iteration_end(ctx, IterationOutcome.exception)
             if self._sink is not None:
                 self._sink.mark_running_stages_failed()
             header = "[yellow]Cancelled[/yellow]"
@@ -300,6 +370,7 @@ class RalphView(Widget, can_focus=True):
             self._switch_to("post_run")
             raise
         except Exception as e:  # noqa: BLE001 — surface any unexpected failure
+            await workflow.iteration_end(ctx, IterationOutcome.error)
             if self._sink is not None:
                 self._sink.mark_running_stages_failed()
             header = f"[red]✗ Failed:[/red] {e!s}"

--- a/src/cog/ui/wire.py
+++ b/src/cog/ui/wire.py
@@ -34,7 +34,7 @@ async def build_run_screen(
 
     Does NOT run preflight — caller handles that separately.
     """
-    sandbox = DockerSandbox()
+    sandbox = DockerSandbox(project_dir=project_dir)
     runner = ClaudeCliRunner(sandbox)
     tracker = GitHubIssueTracker(project_dir)
     state_dir = project_state_dir(project_dir)
@@ -92,7 +92,7 @@ async def build_and_run(
         return 2
 
     # 3. Assemble dependencies
-    sandbox = DockerSandbox()
+    sandbox = DockerSandbox(project_dir=project_dir)
     runner = ClaudeCliRunner(sandbox)
     tracker = GitHubIssueTracker(project_dir)
     state_dir = project_state_dir(project_dir)
@@ -124,6 +124,9 @@ async def build_and_run(
             return 1
 
     if headless:
+        # Scan for orphaned worktrees from prior crashes before iterating
+        if hasattr(workflow, "_apply_orphan_scan"):
+            await workflow._apply_orphan_scan(project_dir)
         return await run_headless(workflow, ctx, loop=loop, max_iterations=max_iterations)
 
     from cog.ui.app import run_textual

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -9,6 +9,7 @@ import sys
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
+from enum import Enum
 from importlib.resources import files
 from pathlib import Path
 from typing import ClassVar, Literal
@@ -121,6 +122,21 @@ _SECTION_RE = re.compile(
     r"^###\s+(Summary|Key changes|Test plan)\s*\n(.*?)(?=\n###\s|\Z)",
     re.MULTILINE | re.DOTALL | re.IGNORECASE,
 )
+
+
+class _BranchCase(Enum):
+    RESTART = "restart"
+    RESUME_LOCAL = "resume_local"
+    RECREATE_STALE = "recreate_stale"
+    RESUME_REMOTE = "resume_remote"
+    FRESH_START = "fresh_start"
+
+
+class _TeardownAction(Enum):
+    REMOVE = "remove"
+    PUSH_THEN_REMOVE_OR_STUCK = "push_then_remove"
+    PUSH_BEST_EFFORT_THEN_STUCK = "push_then_stuck"
+    LEAVE_STUCK = "leave_stuck"
 
 
 def _priority_tier(item: Item) -> int:
@@ -317,6 +333,18 @@ class RalphWorkflow(Workflow):
             return False
         return True
 
+    async def _classify_branch(
+        self, ctx: ExecutionContext, branch: str, default: str
+    ) -> _BranchCase:
+        if self._restart:
+            return _BranchCase.RESTART
+        if await git.branch_exists(ctx.project_dir, branch):
+            ahead = await git.commits_between(ctx.project_dir, f"origin/{default}", branch)
+            return _BranchCase.RESUME_LOCAL if ahead > 0 else _BranchCase.RECREATE_STALE
+        if await remote_branch_exists(ctx.project_dir, branch):
+            return _BranchCase.RESUME_REMOTE
+        return _BranchCase.FRESH_START
+
     async def iteration_start(self, ctx: ExecutionContext) -> None:
         assert ctx.item is not None, "RalphWorkflow.iteration_start requires ctx.item"
         item = ctx.item
@@ -327,24 +355,21 @@ class RalphWorkflow(Workflow):
         work_branch = f"cog/{item.item_id}-{slug}"
         wt_path = ctx.project_dir / ".cog" / "worktrees" / f"{item.item_id}-{slug}"
 
-        if self._restart:
-            # Force-remove any existing worktree and local branch
-            if wt_path.exists():
-                await discard_worktree(ctx.project_dir, wt_path)
-            if await git.branch_exists(ctx.project_dir, work_branch):
-                await git.delete_branch(ctx.project_dir, work_branch)
-            await create_worktree(
-                ctx.project_dir,
-                wt_path,
-                work_branch,
-                start_point=f"origin/{default}",
-                create_branch=True,
-            )
-            ctx.resumed = False
-        elif await git.branch_exists(ctx.project_dir, work_branch):
-            ahead = await git.commits_between(ctx.project_dir, f"origin/{default}", work_branch)
-            if ahead > 0:
-                # (a) local branch with commits — resume it
+        case = await self._classify_branch(ctx, work_branch, default)
+        match case:
+            case _BranchCase.RESTART:
+                if wt_path.exists():
+                    await discard_worktree(ctx.project_dir, wt_path)
+                if await git.branch_exists(ctx.project_dir, work_branch):
+                    await git.delete_branch(ctx.project_dir, work_branch)
+                await create_worktree(
+                    ctx.project_dir,
+                    wt_path,
+                    work_branch,
+                    start_point=f"origin/{default}",
+                    create_branch=True,
+                )
+            case _BranchCase.RESUME_LOCAL:
                 await create_worktree(
                     ctx.project_dir,
                     wt_path,
@@ -352,9 +377,7 @@ class RalphWorkflow(Workflow):
                     start_point=work_branch,
                     create_branch=False,
                 )
-                ctx.resumed = True
-            else:
-                # (c) stale empty branch — delete and recreate
+            case _BranchCase.RECREATE_STALE:
                 await git.delete_branch(ctx.project_dir, work_branch)
                 await create_worktree(
                     ctx.project_dir,
@@ -363,67 +386,67 @@ class RalphWorkflow(Workflow):
                     start_point=f"origin/{default}",
                     create_branch=True,
                 )
-                ctx.resumed = False
-        elif await remote_branch_exists(ctx.project_dir, work_branch):
-            # (b) branch on origin only — resume from remote
-            await create_worktree(
-                ctx.project_dir,
-                wt_path,
-                work_branch,
-                start_point=f"origin/{work_branch}",
-                create_branch=True,
-            )
-            ctx.resumed = True
-        else:
-            # (d) fresh start
-            await create_worktree(
-                ctx.project_dir,
-                wt_path,
-                work_branch,
-                start_point=f"origin/{default}",
-                create_branch=True,
-            )
-            ctx.resumed = False
+            case _BranchCase.RESUME_REMOTE:
+                await create_worktree(
+                    ctx.project_dir,
+                    wt_path,
+                    work_branch,
+                    start_point=f"origin/{work_branch}",
+                    create_branch=True,
+                )
+            case _BranchCase.FRESH_START:
+                await create_worktree(
+                    ctx.project_dir,
+                    wt_path,
+                    work_branch,
+                    start_point=f"origin/{default}",
+                    create_branch=True,
+                )
 
+        ctx.resumed = case in (_BranchCase.RESUME_LOCAL, _BranchCase.RESUME_REMOTE)
         ctx.work_branch = work_branch
         ctx.worktree_path = wt_path
-        # Clear stuck-worktree marker now that we have a live worktree
         self._stuck_worktree_item_ids.discard(item.item_id)
 
-    async def iteration_end(self, ctx: ExecutionContext, outcome: IterationOutcome) -> None:
-        wt_path = ctx.worktree_path
-        if wt_path is None or not wt_path.exists():
-            return
-        branch = ctx.work_branch
-        if branch is None:
-            return
-
+    async def _teardown_action(
+        self, wt_path: Path, branch: str, outcome: IterationOutcome
+    ) -> _TeardownAction:
         dirty = await is_dirty(wt_path)
         ahead = await is_ahead_of_origin(wt_path, branch)
+        if outcome is IterationOutcome.success:
+            return _TeardownAction.LEAVE_STUCK if dirty else _TeardownAction.REMOVE
+        if dirty:
+            if ahead and outcome is not IterationOutcome.noop:
+                return _TeardownAction.PUSH_BEST_EFFORT_THEN_STUCK
+            return _TeardownAction.LEAVE_STUCK
+        return _TeardownAction.PUSH_THEN_REMOVE_OR_STUCK if ahead else _TeardownAction.REMOVE
 
-        if outcome == IterationOutcome.success:
-            if dirty:
-                sys.stderr.write(
-                    f"warning: worktree {wt_path} is dirty after success; leaving in place\n"
-                )
-                self._mark_stuck(ctx)
-            else:
+    async def iteration_end(self, ctx: ExecutionContext, outcome: IterationOutcome) -> None:
+        wt_path, branch = ctx.worktree_path, ctx.work_branch
+        if wt_path is None or not wt_path.exists() or branch is None:
+            return
+
+        action = await self._teardown_action(wt_path, branch, outcome)
+        match action:
+            case _TeardownAction.REMOVE:
                 await self._remove_worktree_safe(ctx.project_dir, wt_path)
-        elif outcome in (IterationOutcome.noop, IterationOutcome.error, IterationOutcome.exception):
-            if dirty:
-                if outcome != IterationOutcome.noop:
-                    # Best-effort push any prior commits before giving up
-                    if ahead:
-                        await self._push_worktree_safe(ctx, wt_path, branch)
-                self._mark_stuck(ctx)
-            elif ahead:
-                pushed = await self._push_worktree_safe(ctx, wt_path, branch)
-                if pushed:
+            case _TeardownAction.PUSH_THEN_REMOVE_OR_STUCK:
+                if await self._push_worktree_safe(ctx, wt_path, branch):
                     await self._remove_worktree_safe(ctx.project_dir, wt_path)
                 else:
                     self._mark_stuck(ctx)
-            else:
-                await self._remove_worktree_safe(ctx.project_dir, wt_path)
+            case _TeardownAction.PUSH_BEST_EFFORT_THEN_STUCK:
+                await self._push_worktree_safe(ctx, wt_path, branch)
+                self._mark_stuck(ctx)
+            case _TeardownAction.LEAVE_STUCK:
+                if outcome is IterationOutcome.success:
+                    await self._emit(
+                        ctx,
+                        StatusEvent(
+                            message=f"⚠ worktree {wt_path} is dirty after success; leaving in place"
+                        ),
+                    )
+                self._mark_stuck(ctx)
 
     def _mark_stuck(self, ctx: ExecutionContext) -> None:
         if ctx.item is not None:

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -391,13 +391,14 @@ class RalphWorkflow(Workflow):
         self, ctx: ExecutionContext, wt_path: Path, branch: str, default: str
     ) -> None:
         await create_worktree(
-            ctx.project_dir, wt_path, branch,
-            start_point=f"origin/{default}", create_branch=True,
+            ctx.project_dir,
+            wt_path,
+            branch,
+            start_point=f"origin/{default}",
+            create_branch=True,
         )
 
-    async def _cleanup_for_restart(
-        self, ctx: ExecutionContext, wt_path: Path, branch: str
-    ) -> None:
+    async def _cleanup_for_restart(self, ctx: ExecutionContext, wt_path: Path, branch: str) -> None:
         if wt_path.exists():
             await discard_worktree(ctx.project_dir, wt_path)
         if await git.branch_exists(ctx.project_dir, branch):

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -342,9 +342,7 @@ class RalphWorkflow(Workflow):
             )
             ctx.resumed = False
         elif await git.branch_exists(ctx.project_dir, work_branch):
-            ahead = await git.commits_between(
-                ctx.project_dir, f"origin/{default}", work_branch
-            )
+            ahead = await git.commits_between(ctx.project_dir, f"origin/{default}", work_branch)
             if ahead > 0:
                 # (a) local branch with commits — resume it
                 await create_worktree(

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -32,7 +32,17 @@ from cog.core.outcomes import Outcome, StageResult
 from cog.core.runner import AgentRunner, StatusEvent
 from cog.core.stage import Stage
 from cog.core.tracker import IssueTracker
-from cog.core.workflow import StageExecutor, Workflow
+from cog.core.workflow import IterationOutcome, StageExecutor, Workflow
+from cog.git.worktree import (
+    create_worktree,
+    discard_worktree,
+    is_ahead_of_origin,
+    is_dirty,
+    push_with_retry,
+    remote_branch_exists,
+    remove_worktree,
+    scan_orphans,
+)
 from cog.state_paths import project_slug, project_state_dir
 from cog.telemetry import TelemetryRecord
 from cog.ui.widgets.log_pane import LogPaneWidget
@@ -106,6 +116,7 @@ _PRIORITY_RE = re.compile(r"^p(\d+)$")
 _SLUG_RE = re.compile(r"[^a-z0-9-]+")
 _COLLAPSE_RE = re.compile(r"-+")
 _BLOCKER_RE = re.compile(r"\b(?:blocked by|depends on)\s+#(\d+)", re.IGNORECASE)
+_ITEM_ID_FROM_PATH_RE = re.compile(r"^(\d+)-")
 _SECTION_RE = re.compile(
     r"^###\s+(Summary|Key changes|Test plan)\s*\n(.*?)(?=\n###\s|\Z)",
     re.MULTILINE | re.DOTALL | re.IGNORECASE,
@@ -178,8 +189,52 @@ class RalphWorkflow(Workflow):
         self._host = host
         self._restart = restart
         self._processed_this_loop: set[tuple[str, str]] = set()
-        self._resumed_this_iteration: dict[str, bool] = {}
         self._ci_retries: dict[str, int] = {}
+        # item_ids with known stuck (dirty/unregistered) worktrees — skipped during pick
+        self._stuck_worktree_item_ids: set[str] = set()
+
+    async def _apply_orphan_scan(self, project_dir: Path) -> None:
+        """Run orphan scan, label stuck items, and populate _stuck_worktree_item_ids."""
+        try:
+            result = await scan_orphans(project_dir)
+        except Exception as e:
+            sys.stderr.write(f"warning: orphan scan failed: {e}\n")
+            return
+
+        if result.cleaned or result.pushed:
+            cleaned = len(result.cleaned)
+            pushed = len(result.pushed)
+            sys.stderr.write(
+                f"-- Cleaned {cleaned} orphan worktree(s), pushed {pushed} commit set(s)\n"
+            )
+
+        for stuck in result.dirty:
+            if stuck.item_id is not None:
+                item_id = str(stuck.item_id)
+                self._stuck_worktree_item_ids.add(item_id)
+                try:
+                    item = await self._tracker.get(item_id)
+                    await self._tracker.ensure_label(
+                        "agent-failed",
+                        color="d93f0b",
+                        description="Cog attempted this and hit an error; retry is still eligible",
+                    )
+                    await self._tracker.add_label(item, "agent-failed")
+                    await self._tracker.comment(
+                        item,
+                        f"🤖 Cog found a stuck worktree from a previous run:\n"
+                        f"- Path: `{stuck.path}`\n"
+                        f"- Branch: `{stuck.branch}`\n"
+                        f"- Reason: {stuck.reason}\n\n"
+                        f"Resolve the worktree manually to re-queue this item.",
+                    )
+                except Exception as e:
+                    sys.stderr.write(f"warning: could not label stuck item #{stuck.item_id}: {e}\n")
+
+        for path in result.unregistered:
+            item_id_str = _ITEM_ID_FROM_PATH_RE.match(path.name)
+            if item_id_str:
+                self._stuck_worktree_item_ids.add(item_id_str.group(1))
 
     async def select_item(self, ctx: ExecutionContext) -> Item | None:
         items = await self._tracker.list_by_label("agent-ready", assignee="@me")
@@ -190,6 +245,7 @@ class RalphWorkflow(Workflow):
             for item in items
             if (item.tracker_id, item.item_id) not in self._processed_this_loop
             and not ctx.state_cache.is_processed(item)
+            and not self._has_stuck_worktree(ctx, item)
         ]
         eligible.sort(key=lambda i: (_priority_tier(i), i.created_at))
 
@@ -247,30 +303,143 @@ class RalphWorkflow(Workflow):
         )
         await ctx.telemetry.write(record)
 
-    async def pre_stages(self, ctx: ExecutionContext) -> None:
-        assert ctx.item is not None, "RalphWorkflow.pre_stages requires ctx.item"
-        default = await git.default_branch(ctx.project_dir)
-        await git.checkout_branch(ctx.project_dir, default)
-        await git.fetch_origin(ctx.project_dir)
-        await git.merge_ff_only(ctx.project_dir, f"origin/{default}")
-        work_branch = f"cog/{ctx.item.item_id}-{_slugify(ctx.item.title)}"
+    def _has_stuck_worktree(self, ctx: ExecutionContext, item: Item) -> bool:
+        """True if a dirty/unregistered worktree exists for this item on disk."""
+        if item.item_id in self._stuck_worktree_item_ids:
+            return True
+        slug = _slugify(item.title)
+        wt_path = ctx.project_dir / ".cog" / "worktrees" / f"{item.item_id}-{slug}"
+        return wt_path.exists()
 
-        resumed = False
-        if await git.branch_exists(ctx.project_dir, work_branch):
-            ahead = await git.commits_between(ctx.project_dir, default, work_branch)
-            if ahead == 0 or self._restart:
+    async def iteration_start(self, ctx: ExecutionContext) -> None:
+        assert ctx.item is not None, "RalphWorkflow.iteration_start requires ctx.item"
+        item = ctx.item
+        default = await git.default_branch(ctx.project_dir)
+        await git.fetch_origin(ctx.project_dir)
+
+        slug = _slugify(item.title)
+        work_branch = f"cog/{item.item_id}-{slug}"
+        wt_path = ctx.project_dir / ".cog" / "worktrees" / f"{item.item_id}-{slug}"
+
+        if self._restart:
+            # Force-remove any existing worktree and local branch
+            if wt_path.exists():
+                await discard_worktree(ctx.project_dir, wt_path)
+            if await git.branch_exists(ctx.project_dir, work_branch):
                 await git.delete_branch(ctx.project_dir, work_branch)
-                await git.create_branch(ctx.project_dir, work_branch, start_point="HEAD")
+            await create_worktree(
+                ctx.project_dir,
+                wt_path,
+                work_branch,
+                start_point=f"origin/{default}",
+                create_branch=True,
+            )
+            ctx.resumed = False
+        elif await git.branch_exists(ctx.project_dir, work_branch):
+            ahead = await git.commits_between(ctx.project_dir, default, work_branch)
+            if ahead > 0:
+                # (a) local branch with commits — resume it
+                await create_worktree(
+                    ctx.project_dir,
+                    wt_path,
+                    work_branch,
+                    start_point=work_branch,
+                    create_branch=False,
+                )
+                ctx.resumed = True
             else:
-                await git.checkout_branch(ctx.project_dir, work_branch)
-                resumed = True
+                # (c) stale empty branch — delete and recreate
+                await git.delete_branch(ctx.project_dir, work_branch)
+                await create_worktree(
+                    ctx.project_dir,
+                    wt_path,
+                    work_branch,
+                    start_point=f"origin/{default}",
+                    create_branch=True,
+                )
+                ctx.resumed = False
+        elif await remote_branch_exists(ctx.project_dir, work_branch):
+            # (b) branch on origin only — resume from remote
+            await create_worktree(
+                ctx.project_dir,
+                wt_path,
+                work_branch,
+                start_point=f"origin/{work_branch}",
+                create_branch=True,
+            )
+            ctx.resumed = True
         else:
-            await git.create_branch(ctx.project_dir, work_branch, start_point="HEAD")
+            # (d) fresh start
+            await create_worktree(
+                ctx.project_dir,
+                wt_path,
+                work_branch,
+                start_point=f"origin/{default}",
+                create_branch=True,
+            )
+            ctx.resumed = False
 
         ctx.work_branch = work_branch
-        self._resumed_this_iteration[ctx.item.item_id] = resumed
+        ctx.worktree_path = wt_path
+        # Clear stuck-worktree marker now that we have a live worktree
+        self._stuck_worktree_item_ids.discard(item.item_id)
+
+    async def iteration_end(self, ctx: ExecutionContext, outcome: IterationOutcome) -> None:
+        wt_path = ctx.worktree_path
+        if wt_path is None or not wt_path.exists():
+            return
+        branch = ctx.work_branch
+        if branch is None:
+            return
+
+        dirty = await is_dirty(wt_path)
+        ahead = await is_ahead_of_origin(wt_path, branch)
+
+        if outcome == IterationOutcome.success:
+            if dirty:
+                sys.stderr.write(
+                    f"warning: worktree {wt_path} is dirty after success; leaving in place\n"
+                )
+                self._mark_stuck(ctx)
+            else:
+                await self._remove_worktree_safe(ctx.project_dir, wt_path)
+        elif outcome in (IterationOutcome.noop, IterationOutcome.error, IterationOutcome.exception):
+            if dirty:
+                if outcome != IterationOutcome.noop:
+                    # Best-effort push any prior commits before giving up
+                    if ahead:
+                        await self._push_worktree_safe(ctx, wt_path, branch)
+                self._mark_stuck(ctx)
+            elif ahead:
+                pushed = await self._push_worktree_safe(ctx, wt_path, branch)
+                if pushed:
+                    await self._remove_worktree_safe(ctx.project_dir, wt_path)
+                else:
+                    self._mark_stuck(ctx)
+            else:
+                await self._remove_worktree_safe(ctx.project_dir, wt_path)
+
+    def _mark_stuck(self, ctx: ExecutionContext) -> None:
+        if ctx.item is not None:
+            self._stuck_worktree_item_ids.add(ctx.item.item_id)
+
+    async def _push_worktree_safe(self, ctx: ExecutionContext, wt_path: Path, branch: str) -> bool:
+        """Push branch from worktree; returns True on success."""
+        try:
+            await push_with_retry(wt_path, branch)
+            return True
+        except GitError as e:
+            sys.stderr.write(f"warning: push failed for {branch}: {e}\n")
+            return False
+
+    async def _remove_worktree_safe(self, project_dir: Path, wt_path: Path) -> None:
+        try:
+            await remove_worktree(project_dir, wt_path)
+        except GitError as e:
+            sys.stderr.write(f"warning: could not remove worktree {wt_path}: {e}\n")
 
     def stages(self, ctx: ExecutionContext) -> list[Stage]:
+        cwd = ctx.worktree_path
         return [
             Stage(
                 name="build",
@@ -278,6 +447,7 @@ class RalphWorkflow(Workflow):
                 model=os.environ.get("COG_RALPH_BUILD_MODEL", "claude-sonnet-4-6"),
                 runner=self._runner,
                 tolerate_failure=False,
+                cwd=cwd,
             ),
             Stage(
                 name="review",
@@ -285,6 +455,7 @@ class RalphWorkflow(Workflow):
                 model=os.environ.get("COG_RALPH_REVIEW_MODEL", "claude-opus-4-7"),
                 runner=self._runner,
                 tolerate_failure=False,
+                cwd=cwd,
             ),
             Stage(
                 name="document",
@@ -293,6 +464,7 @@ class RalphWorkflow(Workflow):
                 runner=self._runner,
                 # document failures flagged for PR footer by #14; don't abort
                 tolerate_failure=True,
+                cwd=cwd,
             ),
         ]
 
@@ -504,6 +676,7 @@ class RalphWorkflow(Workflow):
             model=os.environ.get("COG_RALPH_BUILD_MODEL", "claude-sonnet-4-6"),
             runner=self._runner,
             tolerate_failure=False,
+            cwd=ctx.worktree_path,
         )
         return await StageExecutor()._run_stage(stage, ctx)
 
@@ -711,9 +884,10 @@ class RalphWorkflow(Workflow):
 
         if ctx.work_branch:
             try:
+                git_dir = ctx.worktree_path or ctx.project_dir
                 default = await git.default_branch(ctx.project_dir)
                 shas = await git.log_short_shas(
-                    ctx.project_dir,
+                    git_dir,
                     f"origin/{default}..HEAD",
                 )
                 if shas:
@@ -754,6 +928,7 @@ class RalphWorkflow(Workflow):
 
     async def _rebase_before_push(self, ctx: ExecutionContext) -> RebaseOutcome:
         assert ctx.work_branch is not None
+        git_dir = ctx.worktree_path or ctx.project_dir
         default = await git.default_branch(ctx.project_dir)
         await git.fetch_origin(ctx.project_dir)
 
@@ -761,9 +936,7 @@ class RalphWorkflow(Workflow):
         # contains everything from origin/<default>. Common no-op on quiet
         # iterations; saves ~$0.05-0.10 per iteration.
         try:
-            behind = await git.commits_between(
-                ctx.project_dir, ctx.work_branch, f"origin/{default}"
-            )
+            behind = await git.commits_between(git_dir, ctx.work_branch, f"origin/{default}")
         except GitError:
             # Transient git error — assume rebase is needed, fall through.
             behind = 1
@@ -777,12 +950,13 @@ class RalphWorkflow(Workflow):
             model=os.environ.get("COG_RALPH_BUILD_MODEL", "claude-sonnet-4-6"),
             runner=self._runner,
             tolerate_failure=False,
+            cwd=ctx.worktree_path,
         )
         result = await StageExecutor()._run_stage(stage, ctx)
 
-        if await git.rebase_in_progress(ctx.project_dir):
+        if await git.rebase_in_progress(git_dir):
             # Claude exited mid-rebase — safety net abort.
-            await git.rebase_abort(ctx.project_dir)
+            await git.rebase_abort(git_dir)
             return RebaseOutcome(status="conflict", final_message=result.final_message)
 
         return RebaseOutcome(status="clean")
@@ -884,7 +1058,6 @@ class RalphWorkflow(Workflow):
                 resolved_cause_class = type(error.cause).__name__
         if ctx.telemetry is None:
             return
-        resumed = self._resumed_this_iteration.get(ctx.item.item_id, False)  # type: ignore[union-attr]
         record = TelemetryRecord.build(
             project=project_slug(ctx.project_dir),
             workflow=self.name,
@@ -896,7 +1069,7 @@ class RalphWorkflow(Workflow):
             duration_seconds=sum(r.duration_seconds for r in results),
             error=error_str,
             cause_class=resolved_cause_class,
-            resumed=resumed,
+            resumed=ctx.resumed,
             retry_count=retry_count,
             ci_failed_checks=ci_failed_checks,
         )

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -358,17 +358,8 @@ class RalphWorkflow(Workflow):
         case = await self._classify_branch(ctx, work_branch, default)
         match case:
             case _BranchCase.RESTART:
-                if wt_path.exists():
-                    await discard_worktree(ctx.project_dir, wt_path)
-                if await git.branch_exists(ctx.project_dir, work_branch):
-                    await git.delete_branch(ctx.project_dir, work_branch)
-                await create_worktree(
-                    ctx.project_dir,
-                    wt_path,
-                    work_branch,
-                    start_point=f"origin/{default}",
-                    create_branch=True,
-                )
+                await self._cleanup_for_restart(ctx, wt_path, work_branch)
+                await self._create_fresh_worktree(ctx, wt_path, work_branch, default)
             case _BranchCase.RESUME_LOCAL:
                 await create_worktree(
                     ctx.project_dir,
@@ -379,13 +370,7 @@ class RalphWorkflow(Workflow):
                 )
             case _BranchCase.RECREATE_STALE:
                 await git.delete_branch(ctx.project_dir, work_branch)
-                await create_worktree(
-                    ctx.project_dir,
-                    wt_path,
-                    work_branch,
-                    start_point=f"origin/{default}",
-                    create_branch=True,
-                )
+                await self._create_fresh_worktree(ctx, wt_path, work_branch, default)
             case _BranchCase.RESUME_REMOTE:
                 await create_worktree(
                     ctx.project_dir,
@@ -395,18 +380,28 @@ class RalphWorkflow(Workflow):
                     create_branch=True,
                 )
             case _BranchCase.FRESH_START:
-                await create_worktree(
-                    ctx.project_dir,
-                    wt_path,
-                    work_branch,
-                    start_point=f"origin/{default}",
-                    create_branch=True,
-                )
+                await self._create_fresh_worktree(ctx, wt_path, work_branch, default)
 
         ctx.resumed = case in (_BranchCase.RESUME_LOCAL, _BranchCase.RESUME_REMOTE)
         ctx.work_branch = work_branch
         ctx.worktree_path = wt_path
         self._stuck_worktree_item_ids.discard(item.item_id)
+
+    async def _create_fresh_worktree(
+        self, ctx: ExecutionContext, wt_path: Path, branch: str, default: str
+    ) -> None:
+        await create_worktree(
+            ctx.project_dir, wt_path, branch,
+            start_point=f"origin/{default}", create_branch=True,
+        )
+
+    async def _cleanup_for_restart(
+        self, ctx: ExecutionContext, wt_path: Path, branch: str
+    ) -> None:
+        if wt_path.exists():
+            await discard_worktree(ctx.project_dir, wt_path)
+        if await git.branch_exists(ctx.project_dir, branch):
+            await git.delete_branch(ctx.project_dir, branch)
 
     async def _teardown_action(
         self, wt_path: Path, branch: str, outcome: IterationOutcome

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -304,12 +304,18 @@ class RalphWorkflow(Workflow):
         await ctx.telemetry.write(record)
 
     def _has_stuck_worktree(self, ctx: ExecutionContext, item: Item) -> bool:
-        """True if a dirty/unregistered worktree exists for this item on disk."""
-        if item.item_id in self._stuck_worktree_item_ids:
-            return True
+        """True if a dirty/unregistered worktree exists for this item on disk.
+
+        Re-checks disk each pick so externally resolving the worktree (deleting
+        the dir, finishing a manual cleanup) re-eligibles the item without
+        restarting cog.
+        """
         slug = _slugify(item.title)
         wt_path = ctx.project_dir / ".cog" / "worktrees" / f"{item.item_id}-{slug}"
-        return wt_path.exists()
+        if not wt_path.exists():
+            self._stuck_worktree_item_ids.discard(item.item_id)
+            return False
+        return True
 
     async def iteration_start(self, ctx: ExecutionContext) -> None:
         assert ctx.item is not None, "RalphWorkflow.iteration_start requires ctx.item"
@@ -336,7 +342,9 @@ class RalphWorkflow(Workflow):
             )
             ctx.resumed = False
         elif await git.branch_exists(ctx.project_dir, work_branch):
-            ahead = await git.commits_between(ctx.project_dir, default, work_branch)
+            ahead = await git.commits_between(
+                ctx.project_dir, f"origin/{default}", work_branch
+            )
             if ahead > 0:
                 # (a) local branch with commits — resume it
                 await create_worktree(

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -97,7 +97,9 @@ class RecordingEventSink:
 class EchoRunner(AgentRunner):
     """Returns the prompt as the final_message. Zero cost, zero duration."""
 
-    async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+    async def stream(
+        self, prompt: str, *, model: str, cwd: Path | None = None
+    ) -> AsyncIterator[RunEvent]:
         yield ResultEvent(
             result=RunResult(
                 final_message=prompt,
@@ -167,7 +169,9 @@ class ScriptedFinalMessageRunner(AgentRunner):
         self._final_message = final_message
         self._cost = cost
 
-    async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+    async def stream(
+        self, prompt: str, *, model: str, cwd: Path | None = None
+    ) -> AsyncIterator[RunEvent]:
         yield ResultEvent(
             result=RunResult(
                 final_message=self._final_message,
@@ -185,7 +189,9 @@ class FailingRunner(AgentRunner):
     def __init__(self, exc: Exception | None = None) -> None:
         self._exc = exc or RuntimeError("runner failed")
 
-    async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+    async def stream(
+        self, prompt: str, *, model: str, cwd: Path | None = None
+    ) -> AsyncIterator[RunEvent]:
         raise self._exc
         yield  # type: ignore[misc]
 
@@ -196,7 +202,9 @@ class ExitNonZeroRunner(AgentRunner):
     def __init__(self, exit_status: int = 1) -> None:
         self._exit_status = exit_status
 
-    async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+    async def stream(
+        self, prompt: str, *, model: str, cwd: Path | None = None
+    ) -> AsyncIterator[RunEvent]:
         yield ResultEvent(
             result=RunResult(
                 final_message="non-zero exit",
@@ -248,7 +256,9 @@ class ScriptedInterviewRunner(AgentRunner):
         self._iter: Iterator[tuple[str, float]] = iter([])
         self._call_count = 0
 
-    async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+    async def stream(
+        self, prompt: str, *, model: str, cwd: Path | None = None
+    ) -> AsyncIterator[RunEvent]:
         from cog.core.runner import AssistantTextEvent
 
         message, cost = self._responses[self._call_count % len(self._responses)]
@@ -287,7 +297,9 @@ class ScriptedRewriteRunner(AgentRunner):
         self._response = response
         self._cost = cost_usd
 
-    async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+    async def stream(
+        self, prompt: str, *, model: str, cwd: Path | None = None
+    ) -> AsyncIterator[RunEvent]:
         yield ResultEvent(
             result=RunResult(
                 final_message=self._response,

--- a/tests/git/conftest.py
+++ b/tests/git/conftest.py
@@ -1,0 +1,76 @@
+"""Fixtures for git/worktree tests that use real git repos."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def temp_git_repo(tmp_path: Path) -> Path:
+    """Real git repo with one commit and an `origin` bare remote.
+
+    Layout:
+        tmp_path/origin.git  — bare remote
+        tmp_path/repo        — working clone
+    Returns the path to the working clone.
+    """
+    origin = tmp_path / "origin.git"
+    repo = tmp_path / "repo"
+
+    # Init bare remote
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+
+    # Init working repo
+    subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "test@example.com"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.name", "Test User"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "remote", "add", "origin", str(origin)],
+        check=True,
+        capture_output=True,
+    )
+
+    # Seed commit
+    seed = repo / "README.md"
+    seed.write_text("seed")
+    subprocess.run(["git", "-C", str(repo), "add", "README.md"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", "Initial commit"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "push", "-u", "origin", "HEAD"],
+        check=True,
+        capture_output=True,
+    )
+
+    # Set up origin/HEAD
+    default = subprocess.run(
+        ["git", "-C", str(repo), "symbolic-ref", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "-C", str(origin), "symbolic-ref", "HEAD", f"refs/heads/{default}"],
+        check=True,
+        capture_output=True,
+    )
+    # Make origin/HEAD resolvable
+    subprocess.run(
+        ["git", "-C", str(repo), "remote", "set-head", "origin", default],
+        check=True,
+        capture_output=True,
+    )
+
+    return repo

--- a/tests/git/test_worktree.py
+++ b/tests/git/test_worktree.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import subprocess
 from pathlib import Path
 
@@ -22,24 +23,40 @@ from cog.git.worktree import (
 )
 
 # ---------------------------------------------------------------------------
-# create_worktree / remove_worktree
+# Helpers
 # ---------------------------------------------------------------------------
 
 
-async def test_create_worktree_new_branch(temp_git_repo: Path) -> None:
-    default = subprocess.run(
-        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
+def _run(coro):  # type: ignore[no-untyped-def]
+    """Run a coroutine synchronously to avoid pytest-asyncio event loop leaks."""
+    return asyncio.run(coro)
+
+
+def _default_branch(repo: Path) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), "symbolic-ref", "--short", "HEAD"],
         capture_output=True,
         text=True,
         check=True,
     ).stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# create_worktree / remove_worktree
+# ---------------------------------------------------------------------------
+
+
+def test_create_worktree_new_branch(temp_git_repo: Path) -> None:
+    default = _default_branch(temp_git_repo)
     wt_path = temp_git_repo.parent / "wt-new"
-    await create_worktree(
-        temp_git_repo,
-        wt_path,
-        "cog/1-test",
-        start_point=f"origin/{default}",
-        create_branch=True,
+    _run(
+        create_worktree(
+            temp_git_repo,
+            wt_path,
+            "cog/1-test",
+            start_point=f"origin/{default}",
+            create_branch=True,
+        )
     )
     assert wt_path.is_dir()
     assert (wt_path / ".git").exists()
@@ -52,26 +69,22 @@ async def test_create_worktree_new_branch(temp_git_repo: Path) -> None:
     assert current == "cog/1-test"
 
 
-async def test_create_worktree_existing_branch(temp_git_repo: Path) -> None:
-    default = subprocess.run(
-        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
-    # Create a branch first
+def test_create_worktree_existing_branch(temp_git_repo: Path) -> None:
+    default = _default_branch(temp_git_repo)
     subprocess.run(
         ["git", "-C", str(temp_git_repo), "branch", "cog/2-existing", f"origin/{default}"],
         capture_output=True,
         check=True,
     )
     wt_path = temp_git_repo.parent / "wt-existing"
-    await create_worktree(
-        temp_git_repo,
-        wt_path,
-        "cog/2-existing",
-        start_point="cog/2-existing",
-        create_branch=False,
+    _run(
+        create_worktree(
+            temp_git_repo,
+            wt_path,
+            "cog/2-existing",
+            start_point="cog/2-existing",
+            create_branch=False,
+        )
     )
     assert wt_path.is_dir()
     current = subprocess.run(
@@ -83,29 +96,28 @@ async def test_create_worktree_existing_branch(temp_git_repo: Path) -> None:
     assert current == "cog/2-existing"
 
 
-async def test_remove_worktree(temp_git_repo: Path) -> None:
-    default = subprocess.run(
-        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
+def test_remove_worktree(temp_git_repo: Path) -> None:
+    default = _default_branch(temp_git_repo)
     wt_path = temp_git_repo.parent / "wt-remove"
-    await create_worktree(
-        temp_git_repo,
-        wt_path,
-        "cog/3-remove",
-        start_point=f"origin/{default}",
-        create_branch=True,
-    )
-    assert wt_path.is_dir()
-    await remove_worktree(temp_git_repo, wt_path)
+
+    async def body() -> None:
+        await create_worktree(
+            temp_git_repo,
+            wt_path,
+            "cog/3-remove",
+            start_point=f"origin/{default}",
+            create_branch=True,
+        )
+        assert wt_path.is_dir()
+        await remove_worktree(temp_git_repo, wt_path)
+
+    _run(body())
     assert not wt_path.exists()
 
 
-async def test_remove_worktree_raises_on_nonexistent(temp_git_repo: Path) -> None:
+def test_remove_worktree_raises_on_nonexistent(temp_git_repo: Path) -> None:
     with pytest.raises(GitError):
-        await remove_worktree(temp_git_repo, temp_git_repo.parent / "does-not-exist")
+        _run(remove_worktree(temp_git_repo, temp_git_repo.parent / "does-not-exist"))
 
 
 # ---------------------------------------------------------------------------
@@ -113,32 +125,31 @@ async def test_remove_worktree_raises_on_nonexistent(temp_git_repo: Path) -> Non
 # ---------------------------------------------------------------------------
 
 
-async def test_list_worktrees_includes_main(temp_git_repo: Path) -> None:
-    worktrees = await list_worktrees(temp_git_repo)
+def test_list_worktrees_includes_main(temp_git_repo: Path) -> None:
+    worktrees = _run(list_worktrees(temp_git_repo))
     assert len(worktrees) >= 1
     paths = [wt.path for wt in worktrees]
     assert temp_git_repo in paths
 
 
-async def test_list_worktrees_includes_added(temp_git_repo: Path) -> None:
-    default = subprocess.run(
-        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
+def test_list_worktrees_includes_added(temp_git_repo: Path) -> None:
+    default = _default_branch(temp_git_repo)
     wt_path = temp_git_repo.parent / "wt-list"
-    await create_worktree(
-        temp_git_repo,
-        wt_path,
-        "cog/4-list",
-        start_point=f"origin/{default}",
-        create_branch=True,
-    )
-    worktrees = await list_worktrees(temp_git_repo)
-    paths = [wt.path for wt in worktrees]
-    assert wt_path in paths
-    await remove_worktree(temp_git_repo, wt_path)
+
+    async def body() -> None:
+        await create_worktree(
+            temp_git_repo,
+            wt_path,
+            "cog/4-list",
+            start_point=f"origin/{default}",
+            create_branch=True,
+        )
+        worktrees = await list_worktrees(temp_git_repo)
+        paths = [wt.path for wt in worktrees]
+        assert wt_path in paths
+        await remove_worktree(temp_git_repo, wt_path)
+
+    _run(body())
 
 
 # ---------------------------------------------------------------------------
@@ -146,9 +157,8 @@ async def test_list_worktrees_includes_added(temp_git_repo: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_prune_succeeds(temp_git_repo: Path) -> None:
-    # Should not raise even if nothing to prune
-    await prune(temp_git_repo)
+def test_prune_succeeds(temp_git_repo: Path) -> None:
+    _run(prune(temp_git_repo))
 
 
 # ---------------------------------------------------------------------------
@@ -156,21 +166,21 @@ async def test_prune_succeeds(temp_git_repo: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_is_dirty_clean_repo(temp_git_repo: Path) -> None:
-    assert await is_dirty(temp_git_repo) is False
+def test_is_dirty_clean_repo(temp_git_repo: Path) -> None:
+    assert _run(is_dirty(temp_git_repo)) is False
 
 
-async def test_is_dirty_with_untracked(temp_git_repo: Path) -> None:
+def test_is_dirty_with_untracked(temp_git_repo: Path) -> None:
     (temp_git_repo / "new_file.txt").write_text("untracked")
-    assert await is_dirty(temp_git_repo) is True
+    assert _run(is_dirty(temp_git_repo)) is True
 
 
-async def test_is_dirty_with_modified(temp_git_repo: Path) -> None:
+def test_is_dirty_with_modified(temp_git_repo: Path) -> None:
     (temp_git_repo / "README.md").write_text("modified")
-    assert await is_dirty(temp_git_repo) is True
+    assert _run(is_dirty(temp_git_repo)) is True
 
 
-async def test_is_dirty_ignores_gitignored(temp_git_repo: Path) -> None:
+def test_is_dirty_ignores_gitignored(temp_git_repo: Path) -> None:
     (temp_git_repo / ".gitignore").write_text("ignored.txt\n")
     subprocess.run(
         ["git", "-C", str(temp_git_repo), "add", ".gitignore"],
@@ -183,7 +193,7 @@ async def test_is_dirty_ignores_gitignored(temp_git_repo: Path) -> None:
         check=True,
     )
     (temp_git_repo / "ignored.txt").write_text("this is ignored")
-    assert await is_dirty(temp_git_repo) is False
+    assert _run(is_dirty(temp_git_repo)) is False
 
 
 # ---------------------------------------------------------------------------
@@ -191,23 +201,13 @@ async def test_is_dirty_ignores_gitignored(temp_git_repo: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_is_ahead_of_origin_false_when_in_sync(temp_git_repo: Path) -> None:
-    default = subprocess.run(
-        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
-    assert await is_ahead_of_origin(temp_git_repo, default) is False
+def test_is_ahead_of_origin_false_when_in_sync(temp_git_repo: Path) -> None:
+    default = _default_branch(temp_git_repo)
+    assert _run(is_ahead_of_origin(temp_git_repo, default)) is False
 
 
-async def test_is_ahead_of_origin_true_after_commit(temp_git_repo: Path) -> None:
-    default = subprocess.run(
-        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
+def test_is_ahead_of_origin_true_after_commit(temp_git_repo: Path) -> None:
+    default = _default_branch(temp_git_repo)
     (temp_git_repo / "new.txt").write_text("new")
     subprocess.run(
         ["git", "-C", str(temp_git_repo), "add", "new.txt"],
@@ -219,27 +219,26 @@ async def test_is_ahead_of_origin_true_after_commit(temp_git_repo: Path) -> None
         capture_output=True,
         check=True,
     )
-    assert await is_ahead_of_origin(temp_git_repo, default) is True
+    assert _run(is_ahead_of_origin(temp_git_repo, default)) is True
 
 
-async def test_is_ahead_of_origin_true_when_remote_lacks_branch(temp_git_repo: Path) -> None:
-    # Branch that doesn't exist on origin
-    default = subprocess.run(
-        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
+def test_is_ahead_of_origin_true_when_remote_lacks_branch(temp_git_repo: Path) -> None:
+    default = _default_branch(temp_git_repo)
     wt_path = temp_git_repo.parent / "wt-ahead"
-    await create_worktree(
-        temp_git_repo,
-        wt_path,
-        "cog/5-ahead",
-        start_point=f"origin/{default}",
-        create_branch=True,
-    )
-    assert await is_ahead_of_origin(wt_path, "cog/5-ahead") is True
-    await remove_worktree(temp_git_repo, wt_path)
+
+    async def body() -> bool:
+        await create_worktree(
+            temp_git_repo,
+            wt_path,
+            "cog/5-ahead",
+            start_point=f"origin/{default}",
+            create_branch=True,
+        )
+        result = await is_ahead_of_origin(wt_path, "cog/5-ahead")
+        await remove_worktree(temp_git_repo, wt_path)
+        return result
+
+    assert _run(body()) is True
 
 
 # ---------------------------------------------------------------------------
@@ -247,35 +246,33 @@ async def test_is_ahead_of_origin_true_when_remote_lacks_branch(temp_git_repo: P
 # ---------------------------------------------------------------------------
 
 
-async def test_push_branch_succeeds(temp_git_repo: Path) -> None:
-    default = subprocess.run(
-        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
+def test_push_branch_succeeds(temp_git_repo: Path) -> None:
+    default = _default_branch(temp_git_repo)
     wt_path = temp_git_repo.parent / "wt-push"
-    await create_worktree(
-        temp_git_repo,
-        wt_path,
-        "cog/6-push",
-        start_point=f"origin/{default}",
-        create_branch=True,
-    )
-    # Make a commit in the worktree
-    (wt_path / "pushed.txt").write_text("pushed")
-    subprocess.run(
-        ["git", "-C", str(wt_path), "add", "pushed.txt"],
-        capture_output=True,
-        check=True,
-    )
-    subprocess.run(
-        ["git", "-C", str(wt_path), "commit", "-m", "push me"],
-        capture_output=True,
-        check=True,
-    )
-    await push_branch(wt_path, "cog/6-push")
-    # Confirm remote has the branch
+
+    async def body() -> None:
+        await create_worktree(
+            temp_git_repo,
+            wt_path,
+            "cog/6-push",
+            start_point=f"origin/{default}",
+            create_branch=True,
+        )
+        (wt_path / "pushed.txt").write_text("pushed")
+        subprocess.run(
+            ["git", "-C", str(wt_path), "add", "pushed.txt"],
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(wt_path), "commit", "-m", "push me"],
+            capture_output=True,
+            check=True,
+        )
+        await push_branch(wt_path, "cog/6-push")
+        await remove_worktree(temp_git_repo, wt_path)
+
+    _run(body())
     result = subprocess.run(
         ["git", "-C", str(temp_git_repo), "ls-remote", "--heads", "origin", "cog/6-push"],
         capture_output=True,
@@ -283,14 +280,13 @@ async def test_push_branch_succeeds(temp_git_repo: Path) -> None:
         check=True,
     )
     assert "cog/6-push" in result.stdout
-    await remove_worktree(temp_git_repo, wt_path)
 
 
-async def test_push_with_retry_raises_after_exhausting_attempts(
+def test_push_with_retry_raises_after_exhausting_attempts(
     temp_git_repo: Path,
 ) -> None:
     with pytest.raises(GitError):
-        await push_with_retry(temp_git_repo, "nonexistent-branch", attempts=1, backoff_seconds=0)
+        _run(push_with_retry(temp_git_repo, "nonexistent-branch", attempts=1, backoff_seconds=0))
 
 
 # ---------------------------------------------------------------------------
@@ -298,83 +294,84 @@ async def test_push_with_retry_raises_after_exhausting_attempts(
 # ---------------------------------------------------------------------------
 
 
-async def test_scan_orphans_empty_when_no_worktrees_dir(temp_git_repo: Path) -> None:
-    result = await scan_orphans(temp_git_repo)
+def test_scan_orphans_empty_when_no_worktrees_dir(temp_git_repo: Path) -> None:
+    result = _run(scan_orphans(temp_git_repo))
     assert result.cleaned == []
     assert result.pushed == []
     assert result.dirty == []
     assert result.unregistered == []
 
 
-async def test_scan_orphans_cleans_registered_clean_worktree(temp_git_repo: Path) -> None:
-    default = subprocess.run(
-        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
+def test_scan_orphans_cleans_registered_clean_worktree(temp_git_repo: Path) -> None:
+    default = _default_branch(temp_git_repo)
     wt_dir = temp_git_repo / ".cog" / "worktrees"
     wt_dir.mkdir(parents=True)
     wt_path = wt_dir / "42-test-item"
-    await create_worktree(
-        temp_git_repo,
-        wt_path,
-        "cog/42-test-item",
-        start_point=f"origin/{default}",
-        create_branch=True,
-    )
-    result = await scan_orphans(temp_git_repo)
-    assert wt_path in result.cleaned
-    assert not wt_path.exists()
+
+    async def body() -> None:
+        await create_worktree(
+            temp_git_repo,
+            wt_path,
+            "cog/42-test-item",
+            start_point=f"origin/{default}",
+            create_branch=True,
+        )
+        result = await scan_orphans(temp_git_repo)
+        assert wt_path in result.cleaned
+        assert not wt_path.exists()
+
+    _run(body())
 
 
-async def test_scan_orphans_marks_dirty_worktree_as_stuck(temp_git_repo: Path) -> None:
-    default = subprocess.run(
-        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
+def test_scan_orphans_marks_dirty_worktree_as_stuck(temp_git_repo: Path) -> None:
+    default = _default_branch(temp_git_repo)
     wt_dir = temp_git_repo / ".cog" / "worktrees"
     wt_dir.mkdir(parents=True)
     wt_path = wt_dir / "43-dirty"
-    await create_worktree(
-        temp_git_repo,
-        wt_path,
-        "cog/43-dirty",
-        start_point=f"origin/{default}",
-        create_branch=True,
-    )
-    # Make it dirty
-    (wt_path / "dirty.txt").write_text("untracked")
-    result = await scan_orphans(temp_git_repo)
-    stuck_paths = [s.path for s in result.dirty]
-    assert wt_path in stuck_paths
-    assert wt_path.exists()
-    # Cleanup
-    await discard_worktree(temp_git_repo, wt_path)
+
+    async def body() -> None:
+        await create_worktree(
+            temp_git_repo,
+            wt_path,
+            "cog/43-dirty",
+            start_point=f"origin/{default}",
+            create_branch=True,
+        )
+        (wt_path / "dirty.txt").write_text("untracked")
+        result = await scan_orphans(temp_git_repo)
+        stuck_paths = [s.path for s in result.dirty]
+        assert wt_path in stuck_paths
+        assert wt_path.exists()
+        await discard_worktree(temp_git_repo, wt_path)
+
+    _run(body())
 
 
-async def test_scan_orphans_skips_non_matching_dirs(temp_git_repo: Path) -> None:
+def test_scan_orphans_skips_non_matching_dirs(temp_git_repo: Path) -> None:
     wt_dir = temp_git_repo / ".cog" / "worktrees"
     wt_dir.mkdir(parents=True)
-    # Non-matching directory name
     (wt_dir / "not-an-item").mkdir()
-    result = await scan_orphans(temp_git_repo)
-    # Not matched → no entry anywhere
-    unregistered_names = [p.name for p in result.unregistered]
-    assert "not-an-item" not in unregistered_names
+
+    async def body() -> None:
+        result = await scan_orphans(temp_git_repo)
+        unregistered_names = [p.name for p in result.unregistered]
+        assert "not-an-item" not in unregistered_names
+
+    _run(body())
 
 
-async def test_scan_orphans_unregistered_pattern_matching_dir(temp_git_repo: Path) -> None:
+def test_scan_orphans_unregistered_pattern_matching_dir(temp_git_repo: Path) -> None:
     wt_dir = temp_git_repo / ".cog" / "worktrees"
     wt_dir.mkdir(parents=True)
     orphan_path = wt_dir / "99-orphaned"
     orphan_path.mkdir()
-    # Not registered with git worktree
-    result = await scan_orphans(temp_git_repo)
-    assert orphan_path in result.unregistered
-    orphan_path.rmdir()
+
+    async def body() -> None:
+        result = await scan_orphans(temp_git_repo)
+        assert orphan_path in result.unregistered
+        orphan_path.rmdir()
+
+    _run(body())
 
 
 # ---------------------------------------------------------------------------
@@ -382,27 +379,26 @@ async def test_scan_orphans_unregistered_pattern_matching_dir(temp_git_repo: Pat
 # ---------------------------------------------------------------------------
 
 
-async def test_discard_worktree_removes_registered(temp_git_repo: Path) -> None:
-    default = subprocess.run(
-        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
+def test_discard_worktree_removes_registered(temp_git_repo: Path) -> None:
+    default = _default_branch(temp_git_repo)
     wt_path = temp_git_repo.parent / "wt-discard"
-    await create_worktree(
-        temp_git_repo,
-        wt_path,
-        "cog/7-discard",
-        start_point=f"origin/{default}",
-        create_branch=True,
-    )
-    await discard_worktree(temp_git_repo, wt_path)
+
+    async def body() -> None:
+        await create_worktree(
+            temp_git_repo,
+            wt_path,
+            "cog/7-discard",
+            start_point=f"origin/{default}",
+            create_branch=True,
+        )
+        await discard_worktree(temp_git_repo, wt_path)
+
+    _run(body())
     assert not wt_path.exists()
 
 
-async def test_discard_worktree_removes_unregistered(temp_git_repo: Path) -> None:
+def test_discard_worktree_removes_unregistered(temp_git_repo: Path) -> None:
     orphan = temp_git_repo.parent / "orphan-dir"
     orphan.mkdir()
-    await discard_worktree(temp_git_repo, orphan)
+    _run(discard_worktree(temp_git_repo, orphan))
     assert not orphan.exists()

--- a/tests/git/test_worktree.py
+++ b/tests/git/test_worktree.py
@@ -1,0 +1,408 @@
+"""Tests for cog.git.worktree module against real git repos."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from cog.core.errors import GitError
+from cog.git.worktree import (
+    create_worktree,
+    discard_worktree,
+    is_ahead_of_origin,
+    is_dirty,
+    list_worktrees,
+    prune,
+    push_branch,
+    push_with_retry,
+    remove_worktree,
+    scan_orphans,
+)
+
+# ---------------------------------------------------------------------------
+# create_worktree / remove_worktree
+# ---------------------------------------------------------------------------
+
+
+async def test_create_worktree_new_branch(temp_git_repo: Path) -> None:
+    default = subprocess.run(
+        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    wt_path = temp_git_repo.parent / "wt-new"
+    await create_worktree(
+        temp_git_repo,
+        wt_path,
+        "cog/1-test",
+        start_point=f"origin/{default}",
+        create_branch=True,
+    )
+    assert wt_path.is_dir()
+    assert (wt_path / ".git").exists()
+    current = subprocess.run(
+        ["git", "-C", str(wt_path), "symbolic-ref", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert current == "cog/1-test"
+
+
+async def test_create_worktree_existing_branch(temp_git_repo: Path) -> None:
+    default = subprocess.run(
+        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    # Create a branch first
+    subprocess.run(
+        ["git", "-C", str(temp_git_repo), "branch", "cog/2-existing", f"origin/{default}"],
+        capture_output=True,
+        check=True,
+    )
+    wt_path = temp_git_repo.parent / "wt-existing"
+    await create_worktree(
+        temp_git_repo,
+        wt_path,
+        "cog/2-existing",
+        start_point="cog/2-existing",
+        create_branch=False,
+    )
+    assert wt_path.is_dir()
+    current = subprocess.run(
+        ["git", "-C", str(wt_path), "symbolic-ref", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert current == "cog/2-existing"
+
+
+async def test_remove_worktree(temp_git_repo: Path) -> None:
+    default = subprocess.run(
+        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    wt_path = temp_git_repo.parent / "wt-remove"
+    await create_worktree(
+        temp_git_repo,
+        wt_path,
+        "cog/3-remove",
+        start_point=f"origin/{default}",
+        create_branch=True,
+    )
+    assert wt_path.is_dir()
+    await remove_worktree(temp_git_repo, wt_path)
+    assert not wt_path.exists()
+
+
+async def test_remove_worktree_raises_on_nonexistent(temp_git_repo: Path) -> None:
+    with pytest.raises(GitError):
+        await remove_worktree(temp_git_repo, temp_git_repo.parent / "does-not-exist")
+
+
+# ---------------------------------------------------------------------------
+# list_worktrees
+# ---------------------------------------------------------------------------
+
+
+async def test_list_worktrees_includes_main(temp_git_repo: Path) -> None:
+    worktrees = await list_worktrees(temp_git_repo)
+    assert len(worktrees) >= 1
+    paths = [wt.path for wt in worktrees]
+    assert temp_git_repo in paths
+
+
+async def test_list_worktrees_includes_added(temp_git_repo: Path) -> None:
+    default = subprocess.run(
+        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    wt_path = temp_git_repo.parent / "wt-list"
+    await create_worktree(
+        temp_git_repo,
+        wt_path,
+        "cog/4-list",
+        start_point=f"origin/{default}",
+        create_branch=True,
+    )
+    worktrees = await list_worktrees(temp_git_repo)
+    paths = [wt.path for wt in worktrees]
+    assert wt_path in paths
+    await remove_worktree(temp_git_repo, wt_path)
+
+
+# ---------------------------------------------------------------------------
+# prune
+# ---------------------------------------------------------------------------
+
+
+async def test_prune_succeeds(temp_git_repo: Path) -> None:
+    # Should not raise even if nothing to prune
+    await prune(temp_git_repo)
+
+
+# ---------------------------------------------------------------------------
+# is_dirty
+# ---------------------------------------------------------------------------
+
+
+async def test_is_dirty_clean_repo(temp_git_repo: Path) -> None:
+    assert await is_dirty(temp_git_repo) is False
+
+
+async def test_is_dirty_with_untracked(temp_git_repo: Path) -> None:
+    (temp_git_repo / "new_file.txt").write_text("untracked")
+    assert await is_dirty(temp_git_repo) is True
+
+
+async def test_is_dirty_with_modified(temp_git_repo: Path) -> None:
+    (temp_git_repo / "README.md").write_text("modified")
+    assert await is_dirty(temp_git_repo) is True
+
+
+async def test_is_dirty_ignores_gitignored(temp_git_repo: Path) -> None:
+    (temp_git_repo / ".gitignore").write_text("ignored.txt\n")
+    subprocess.run(
+        ["git", "-C", str(temp_git_repo), "add", ".gitignore"],
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(temp_git_repo), "commit", "-m", "add gitignore"],
+        capture_output=True,
+        check=True,
+    )
+    (temp_git_repo / "ignored.txt").write_text("this is ignored")
+    assert await is_dirty(temp_git_repo) is False
+
+
+# ---------------------------------------------------------------------------
+# is_ahead_of_origin
+# ---------------------------------------------------------------------------
+
+
+async def test_is_ahead_of_origin_false_when_in_sync(temp_git_repo: Path) -> None:
+    default = subprocess.run(
+        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert await is_ahead_of_origin(temp_git_repo, default) is False
+
+
+async def test_is_ahead_of_origin_true_after_commit(temp_git_repo: Path) -> None:
+    default = subprocess.run(
+        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    (temp_git_repo / "new.txt").write_text("new")
+    subprocess.run(
+        ["git", "-C", str(temp_git_repo), "add", "new.txt"],
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(temp_git_repo), "commit", "-m", "new commit"],
+        capture_output=True,
+        check=True,
+    )
+    assert await is_ahead_of_origin(temp_git_repo, default) is True
+
+
+async def test_is_ahead_of_origin_true_when_remote_lacks_branch(temp_git_repo: Path) -> None:
+    # Branch that doesn't exist on origin
+    default = subprocess.run(
+        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    wt_path = temp_git_repo.parent / "wt-ahead"
+    await create_worktree(
+        temp_git_repo,
+        wt_path,
+        "cog/5-ahead",
+        start_point=f"origin/{default}",
+        create_branch=True,
+    )
+    assert await is_ahead_of_origin(wt_path, "cog/5-ahead") is True
+    await remove_worktree(temp_git_repo, wt_path)
+
+
+# ---------------------------------------------------------------------------
+# push_branch
+# ---------------------------------------------------------------------------
+
+
+async def test_push_branch_succeeds(temp_git_repo: Path) -> None:
+    default = subprocess.run(
+        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    wt_path = temp_git_repo.parent / "wt-push"
+    await create_worktree(
+        temp_git_repo,
+        wt_path,
+        "cog/6-push",
+        start_point=f"origin/{default}",
+        create_branch=True,
+    )
+    # Make a commit in the worktree
+    (wt_path / "pushed.txt").write_text("pushed")
+    subprocess.run(
+        ["git", "-C", str(wt_path), "add", "pushed.txt"],
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(wt_path), "commit", "-m", "push me"],
+        capture_output=True,
+        check=True,
+    )
+    await push_branch(wt_path, "cog/6-push")
+    # Confirm remote has the branch
+    result = subprocess.run(
+        ["git", "-C", str(temp_git_repo), "ls-remote", "--heads", "origin", "cog/6-push"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "cog/6-push" in result.stdout
+    await remove_worktree(temp_git_repo, wt_path)
+
+
+async def test_push_with_retry_raises_after_exhausting_attempts(
+    temp_git_repo: Path,
+) -> None:
+    with pytest.raises(GitError):
+        await push_with_retry(temp_git_repo, "nonexistent-branch", attempts=1, backoff_seconds=0)
+
+
+# ---------------------------------------------------------------------------
+# scan_orphans
+# ---------------------------------------------------------------------------
+
+
+async def test_scan_orphans_empty_when_no_worktrees_dir(temp_git_repo: Path) -> None:
+    result = await scan_orphans(temp_git_repo)
+    assert result.cleaned == []
+    assert result.pushed == []
+    assert result.dirty == []
+    assert result.unregistered == []
+
+
+async def test_scan_orphans_cleans_registered_clean_worktree(temp_git_repo: Path) -> None:
+    default = subprocess.run(
+        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    wt_dir = temp_git_repo / ".cog" / "worktrees"
+    wt_dir.mkdir(parents=True)
+    wt_path = wt_dir / "42-test-item"
+    await create_worktree(
+        temp_git_repo,
+        wt_path,
+        "cog/42-test-item",
+        start_point=f"origin/{default}",
+        create_branch=True,
+    )
+    result = await scan_orphans(temp_git_repo)
+    assert wt_path in result.cleaned
+    assert not wt_path.exists()
+
+
+async def test_scan_orphans_marks_dirty_worktree_as_stuck(temp_git_repo: Path) -> None:
+    default = subprocess.run(
+        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    wt_dir = temp_git_repo / ".cog" / "worktrees"
+    wt_dir.mkdir(parents=True)
+    wt_path = wt_dir / "43-dirty"
+    await create_worktree(
+        temp_git_repo,
+        wt_path,
+        "cog/43-dirty",
+        start_point=f"origin/{default}",
+        create_branch=True,
+    )
+    # Make it dirty
+    (wt_path / "dirty.txt").write_text("untracked")
+    result = await scan_orphans(temp_git_repo)
+    stuck_paths = [s.path for s in result.dirty]
+    assert wt_path in stuck_paths
+    assert wt_path.exists()
+    # Cleanup
+    await discard_worktree(temp_git_repo, wt_path)
+
+
+async def test_scan_orphans_skips_non_matching_dirs(temp_git_repo: Path) -> None:
+    wt_dir = temp_git_repo / ".cog" / "worktrees"
+    wt_dir.mkdir(parents=True)
+    # Non-matching directory name
+    (wt_dir / "not-an-item").mkdir()
+    result = await scan_orphans(temp_git_repo)
+    # Not matched → no entry anywhere
+    unregistered_names = [p.name for p in result.unregistered]
+    assert "not-an-item" not in unregistered_names
+
+
+async def test_scan_orphans_unregistered_pattern_matching_dir(temp_git_repo: Path) -> None:
+    wt_dir = temp_git_repo / ".cog" / "worktrees"
+    wt_dir.mkdir(parents=True)
+    orphan_path = wt_dir / "99-orphaned"
+    orphan_path.mkdir()
+    # Not registered with git worktree
+    result = await scan_orphans(temp_git_repo)
+    assert orphan_path in result.unregistered
+    orphan_path.rmdir()
+
+
+# ---------------------------------------------------------------------------
+# discard_worktree
+# ---------------------------------------------------------------------------
+
+
+async def test_discard_worktree_removes_registered(temp_git_repo: Path) -> None:
+    default = subprocess.run(
+        ["git", "-C", str(temp_git_repo), "symbolic-ref", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    wt_path = temp_git_repo.parent / "wt-discard"
+    await create_worktree(
+        temp_git_repo,
+        wt_path,
+        "cog/7-discard",
+        start_point=f"origin/{default}",
+        create_branch=True,
+    )
+    await discard_worktree(temp_git_repo, wt_path)
+    assert not wt_path.exists()
+
+
+async def test_discard_worktree_removes_unregistered(temp_git_repo: Path) -> None:
+    orphan = temp_git_repo.parent / "orphan-dir"
+    orphan.mkdir()
+    await discard_worktree(temp_git_repo, orphan)
+    assert not orphan.exists()

--- a/tests/test_headless/test_run_headless.py
+++ b/tests/test_headless/test_run_headless.py
@@ -64,7 +64,9 @@ class _EmptyQueueWorkflow(_SimpleWorkflow):
 
 
 class _FailRunner(AgentRunner):
-    async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+    async def stream(
+        self, prompt: str, *, model: str, cwd: Path | None = None
+    ) -> AsyncIterator[RunEvent]:
         yield ResultEvent(
             result=RunResult(
                 final_message="failed",

--- a/tests/test_headless/test_run_headless_loop.py
+++ b/tests/test_headless/test_run_headless_loop.py
@@ -69,7 +69,9 @@ class _CostRunner(AgentRunner):
     def __init__(self, cost: float) -> None:
         self._cost = cost
 
-    async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+    async def stream(
+        self, prompt: str, *, model: str, cwd: Path | None = None
+    ) -> AsyncIterator[RunEvent]:
         yield ResultEvent(
             result=RunResult(
                 final_message="ok",
@@ -138,7 +140,9 @@ async def test_loop_stage_error_aborts_loop_with_exit_1(tmp_path: Path, capsys) 
     from cog.core.runner import AgentRunner, RunEvent
 
     class _FailRunner(AgentRunner):
-        async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+        async def stream(
+            self, prompt: str, *, model: str, cwd: Path | None = None
+        ) -> AsyncIterator[RunEvent]:
             yield ResultEvent(
                 result=RunResult(
                     final_message="failed",

--- a/tests/test_runners/helpers.py
+++ b/tests/test_runners/helpers.py
@@ -163,7 +163,7 @@ class RecordingSandbox:
     async def prepare(self) -> None:
         self.prepare_calls += 1
 
-    def wrap_argv(self, argv: Any) -> list[str]:
+    def wrap_argv(self, argv: Any, cwd: Any = None) -> list[str]:
         result = list(argv)
         self.wrap_argv_args.append(result)
         return result

--- a/tests/test_runners/test_claude_cli_line_limit.py
+++ b/tests/test_runners/test_claude_cli_line_limit.py
@@ -28,7 +28,7 @@ class _RealSubprocessSandbox(RecordingSandbox):
         super().__init__()
         self._snippet = python_snippet
 
-    def wrap_argv(self, argv):  # type: ignore[override]
+    def wrap_argv(self, argv, cwd=None):  # type: ignore[override]
         return ["python3", "-c", self._snippet]
 
 

--- a/tests/test_runners/test_claude_cli_stderr_drain.py
+++ b/tests/test_runners/test_claude_cli_stderr_drain.py
@@ -25,7 +25,7 @@ class _RealSubprocessSandbox(RecordingSandbox):
         super().__init__()
         self._snippet = python_snippet
 
-    def wrap_argv(self, argv):  # type: ignore[override]
+    def wrap_argv(self, argv, cwd=None):  # type: ignore[override]
         # Ignore the simulated claude argv entirely; invoke python3 -c <snippet>.
         return ["python3", "-c", self._snippet]
 

--- a/tests/test_stage_executor.py
+++ b/tests/test_stage_executor.py
@@ -23,7 +23,9 @@ class _ResultThenRaisingRunner(AgentRunner):
     def __init__(self, cost: float = 0.42) -> None:
         self._cost = cost
 
-    async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+    async def stream(
+        self, prompt: str, *, model: str, cwd: Path | None = None
+    ) -> AsyncIterator[RunEvent]:
         yield ResultEvent(
             result=RunResult(
                 final_message="partial",
@@ -97,7 +99,9 @@ class _EmptyQueueWorkflow(_SimpleWorkflow):
 
 
 class _FailRunner(AgentRunner):
-    async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+    async def stream(
+        self, prompt: str, *, model: str, cwd: Path | None = None
+    ) -> AsyncIterator[RunEvent]:
         yield ResultEvent(
             result=RunResult(
                 final_message="failed",
@@ -110,7 +114,9 @@ class _FailRunner(AgentRunner):
 
 
 class _RaisingRunner(AgentRunner):
-    async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+    async def stream(
+        self, prompt: str, *, model: str, cwd: Path | None = None
+    ) -> AsyncIterator[RunEvent]:
         raise RuntimeError("runner exploded")
         yield  # type: ignore[misc]
 
@@ -304,7 +310,9 @@ async def test_stage_executor_wraps_runner_stalled_in_stage_error(ctx_factory):
     stalled = RunnerStalledError(inactivity_seconds=120, last_event_summary="Bash: echo hi")
 
     class _StalledRunner(AgentRunner):
-        async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+        async def stream(
+            self, prompt: str, *, model: str, cwd: Path | None = None
+        ) -> AsyncIterator[RunEvent]:
             raise stalled
             yield  # type: ignore[misc]
 
@@ -319,7 +327,9 @@ async def test_stalled_error_cause_preserved_through_stage_error(ctx_factory):
     original = RunnerStalledError(inactivity_seconds=60, last_event_summary="Read: /tmp/x")
 
     class _StalledRunner(AgentRunner):
-        async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+        async def stream(
+            self, prompt: str, *, model: str, cwd: Path | None = None
+        ) -> AsyncIterator[RunEvent]:
             raise original
             yield  # type: ignore[misc]
 
@@ -333,7 +343,9 @@ async def test_stage_executor_stalled_path_has_exit_minus_one_and_error(ctx_fact
     stalled = RunnerStalledError(inactivity_seconds=120)
 
     class _StalledRunner(AgentRunner):
-        async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+        async def stream(
+            self, prompt: str, *, model: str, cwd: Path | None = None
+        ) -> AsyncIterator[RunEvent]:
             raise stalled
             yield  # type: ignore[misc]
 

--- a/tests/test_ui/test_run_screen.py
+++ b/tests/test_ui/test_run_screen.py
@@ -55,7 +55,7 @@ def _dummy_result() -> RunResult:
 class _SlowRunner:
     """Runner that blocks until cancelled — used to keep the workflow in 'running' state."""
 
-    def stream(self, prompt: str, *, model: str):  # type: ignore[return]
+    def stream(self, prompt: str, *, model: str, cwd=None):  # type: ignore[return]
         return self._slow_stream()
 
     async def _slow_stream(self):
@@ -177,7 +177,9 @@ async def test_run_screen_completion_panel_shows_per_stage_breakdown(tmp_path: P
     from cog.core.runner import AgentRunner, RunEvent
 
     class _CostRunner(AgentRunner):
-        async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+        async def stream(
+            self, prompt: str, *, model: str, cwd: Path | None = None
+        ) -> AsyncIterator[RunEvent]:
             yield ResultEvent(
                 result=RunResult(
                     final_message="done",
@@ -212,7 +214,7 @@ async def test_run_screen_failure_panel_marks_failing_stage_and_shows_prior_stag
                 yield  # generator
 
             class _ErrRunner:
-                def stream(self, prompt, *, model):
+                def stream(self, prompt, *, model, cwd=None):
                     return _err_stream(prompt, model=model)
 
                 async def run(self, prompt, *, model):  # pragma: no cover
@@ -273,7 +275,9 @@ async def test_run_screen_cost_accumulates_from_result_events(tmp_path: Path) ->
     class _CostRunner(AgentRunner):
         """Runner that yields a ResultEvent with non-zero cost."""
 
-        async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+        async def stream(
+            self, prompt: str, *, model: str, cwd: Path | None = None
+        ) -> AsyncIterator[RunEvent]:
             yield ResultEvent(
                 result=RunResult(
                     final_message="done",
@@ -345,7 +349,7 @@ async def test_run_screen_shows_error_panel_on_workflow_exception(tmp_path: Path
                 yield  # make it a generator
 
             class _ErrRunner:
-                def stream(self, prompt, *, model):
+                def stream(self, prompt, *, model, cwd=None):
                     return _err_stream(prompt, model=model)
 
                 async def run(self, prompt, *, model):  # pragma: no cover
@@ -509,7 +513,7 @@ async def test_run_screen_loop_mode_stage_error_shows_error_panel_and_exits(
                 yield  # type: ignore[misc]
 
             class _R:
-                def stream(self, prompt, *, model):
+                def stream(self, prompt, *, model, cwd=None):
                     return _err(prompt, model=model)
 
                 async def run(self, prompt, *, model):  # pragma: no cover

--- a/tests/test_workflows/test_ralph_ci_fix.py
+++ b/tests/test_workflows/test_ralph_ci_fix.py
@@ -215,7 +215,7 @@ async def test_retry_uses_ci_fix_not_build_prompt(
     captured_prompts: list[str] = []
 
     class CapturingRunner(AgentRunner):
-        async def stream(self, prompt: str, *, model: str):
+        async def stream(self, prompt: str, *, model: str, cwd: Path | None = None):
             captured_prompts.append(prompt)
             yield ResultEvent(
                 result=RunResult(

--- a/tests/test_workflows/test_ralph_finalization.py
+++ b/tests/test_workflows/test_ralph_finalization.py
@@ -32,6 +32,16 @@ def _clean_rebase(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(RalphWorkflow, "_rebase_before_push", _noop)
 
 
+@pytest.fixture(autouse=True)
+def _clean_iteration_start(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch iteration_start to noop so end-to-end tests don't hit real git."""
+
+    async def _noop(self: object, ctx: object) -> None:
+        return
+
+    monkeypatch.setattr(RalphWorkflow, "iteration_start", _noop)
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -809,7 +819,7 @@ async def test_full_iteration_end_to_end_success(tmp_path: Path) -> None:
 
     wf = RalphWorkflow(runner=EchoRunner(), tracker=tracker, host=host)
 
-    async def _pre(ctx: ExecutionContext) -> None:
+    async def _iteration_start(ctx: ExecutionContext) -> None:
         ctx.work_branch = "cog/42-fix"
 
     def _stages(ctx: ExecutionContext) -> list[Stage]:
@@ -826,7 +836,7 @@ async def test_full_iteration_end_to_end_success(tmp_path: Path) -> None:
     async def _classify(ctx: ExecutionContext, results: list) -> str:
         return "success"
 
-    wf.pre_stages = _pre  # type: ignore[method-assign]
+    wf.iteration_start = _iteration_start  # type: ignore[method-assign]
     wf.stages = _stages  # type: ignore[method-assign]
     wf.classify_outcome = _classify  # type: ignore[method-assign]
 
@@ -865,7 +875,7 @@ async def test_full_iteration_end_to_end_noop(tmp_path: Path) -> None:
 
     wf = RalphWorkflow(runner=EchoRunner(), tracker=tracker, host=host)
 
-    async def _pre(ctx: ExecutionContext) -> None:
+    async def _iteration_start(ctx: ExecutionContext) -> None:
         ctx.work_branch = "cog/42-fix"
 
     def _stages(ctx: ExecutionContext) -> list[Stage]:
@@ -882,7 +892,7 @@ async def test_full_iteration_end_to_end_noop(tmp_path: Path) -> None:
     async def _classify(ctx: ExecutionContext, results: list) -> str:
         return "noop"
 
-    wf.pre_stages = _pre  # type: ignore[method-assign]
+    wf.iteration_start = _iteration_start  # type: ignore[method-assign]
     wf.stages = _stages  # type: ignore[method-assign]
     wf.classify_outcome = _classify  # type: ignore[method-assign]
     wf.write_report = AsyncMock()  # type: ignore[method-assign]

--- a/tests/test_workflows/test_ralph_integration.py
+++ b/tests/test_workflows/test_ralph_integration.py
@@ -73,10 +73,10 @@ async def test_runs_all_three_stages_end_to_end(tmp_path):
 
     # Short-circuit pre_stages; this test isolates stage-sequence behavior
     # from git-setup concerns (which are covered by test_end_to_end_with_real_git).
-    async def _noop_pre_stages(ctx):
+    async def _noop_iteration_start(ctx):
         return
 
-    wf.pre_stages = _noop_pre_stages  # type: ignore[method-assign]
+    wf.iteration_start = _noop_iteration_start  # type: ignore[method-assign]
 
     ctx = ExecutionContext(
         project_dir=tmp_path,
@@ -195,10 +195,10 @@ async def test_finalize_success_pr_body_with_structured_final_message(tmp_path: 
         host=host,
     )
 
-    async def _noop_pre_stages(ctx: ExecutionContext) -> None:
+    async def _noop_iteration_start(ctx: ExecutionContext) -> None:
         return
 
-    wf.pre_stages = _noop_pre_stages  # type: ignore[method-assign]
+    wf.iteration_start = _noop_iteration_start  # type: ignore[method-assign]
 
     ctx = ExecutionContext(
         project_dir=tmp_path,
@@ -245,10 +245,10 @@ async def test_finalize_success_pr_body_with_unstructured_final_message(tmp_path
         host=host,
     )
 
-    async def _noop_pre_stages(ctx: ExecutionContext) -> None:
+    async def _noop_iteration_start(ctx: ExecutionContext) -> None:
         return
 
-    wf.pre_stages = _noop_pre_stages  # type: ignore[method-assign]
+    wf.iteration_start = _noop_iteration_start  # type: ignore[method-assign]
 
     ctx = ExecutionContext(
         project_dir=tmp_path,

--- a/tests/test_workflows/test_ralph_pre_stages.py
+++ b/tests/test_workflows/test_ralph_pre_stages.py
@@ -10,7 +10,8 @@ import pytest
 from cog.core.context import ExecutionContext
 from cog.core.errors import GitError
 from cog.core.tracker import IssueTracker
-from cog.workflows.ralph import RalphWorkflow
+from cog.core.workflow import IterationOutcome
+from cog.workflows.ralph import RalphWorkflow, _BranchCase, _TeardownAction
 from tests.fakes import InMemoryStateCache, make_item
 
 
@@ -254,3 +255,101 @@ async def test_iteration_start_propagates_git_error_from_fetch() -> None:
     ):
         with pytest.raises(GitError, match="fetch failed"):
             await wf.iteration_start(ctx)
+
+
+# ---------------------------------------------------------------------------
+# _classify_branch: one test per case
+# ---------------------------------------------------------------------------
+
+
+async def test_classify_branch_restart() -> None:
+    wf = _make_workflow(restart=True)
+    ctx = _make_ctx(make_item(item_id="1", title="t"))
+    with (
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=False)),
+        patch("cog.workflows.ralph.remote_branch_exists", AsyncMock(return_value=False)),
+        patch("cog.workflows.ralph.git.commits_between", AsyncMock(return_value=0)),
+    ):
+        result = await wf._classify_branch(ctx, "cog/1-t", "main")
+    assert result is _BranchCase.RESTART
+
+
+async def test_classify_branch_resume_local() -> None:
+    wf = _make_workflow()
+    ctx = _make_ctx(make_item(item_id="1", title="t"))
+    with (
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=True)),
+        patch("cog.workflows.ralph.git.commits_between", AsyncMock(return_value=2)),
+    ):
+        result = await wf._classify_branch(ctx, "cog/1-t", "main")
+    assert result is _BranchCase.RESUME_LOCAL
+
+
+async def test_classify_branch_recreate_stale() -> None:
+    wf = _make_workflow()
+    ctx = _make_ctx(make_item(item_id="1", title="t"))
+    with (
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=True)),
+        patch("cog.workflows.ralph.git.commits_between", AsyncMock(return_value=0)),
+    ):
+        result = await wf._classify_branch(ctx, "cog/1-t", "main")
+    assert result is _BranchCase.RECREATE_STALE
+
+
+async def test_classify_branch_resume_remote() -> None:
+    wf = _make_workflow()
+    ctx = _make_ctx(make_item(item_id="1", title="t"))
+    with (
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=False)),
+        patch("cog.workflows.ralph.remote_branch_exists", AsyncMock(return_value=True)),
+    ):
+        result = await wf._classify_branch(ctx, "cog/1-t", "main")
+    assert result is _BranchCase.RESUME_REMOTE
+
+
+async def test_classify_branch_fresh_start() -> None:
+    wf = _make_workflow()
+    ctx = _make_ctx(make_item(item_id="1", title="t"))
+    with (
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=False)),
+        patch("cog.workflows.ralph.remote_branch_exists", AsyncMock(return_value=False)),
+    ):
+        result = await wf._classify_branch(ctx, "cog/1-t", "main")
+    assert result is _BranchCase.FRESH_START
+
+
+# ---------------------------------------------------------------------------
+# _teardown_action: matrix of (outcome, dirty, ahead) -> _TeardownAction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "outcome,dirty,ahead,expected",
+    [
+        # success: clean → remove; dirty → leave_stuck
+        (IterationOutcome.success, False, False, _TeardownAction.REMOVE),
+        (IterationOutcome.success, True, False, _TeardownAction.LEAVE_STUCK),
+        # noop: clean+no-ahead → remove; clean+ahead → push_then_remove; dirty → leave_stuck
+        (IterationOutcome.noop, False, False, _TeardownAction.REMOVE),
+        (IterationOutcome.noop, False, True, _TeardownAction.PUSH_THEN_REMOVE_OR_STUCK),
+        (IterationOutcome.noop, True, True, _TeardownAction.LEAVE_STUCK),
+        # error: clean+no-ahead → remove; clean+ahead → push_then_remove; dirty+ahead → best_effort
+        (IterationOutcome.error, False, False, _TeardownAction.REMOVE),
+        (IterationOutcome.error, False, True, _TeardownAction.PUSH_THEN_REMOVE_OR_STUCK),
+        (IterationOutcome.error, True, True, _TeardownAction.PUSH_BEST_EFFORT_THEN_STUCK),
+    ],
+)
+async def test_teardown_action_matrix(
+    outcome: IterationOutcome,
+    dirty: bool,
+    ahead: bool,
+    expected: _TeardownAction,
+    tmp_path: Path,
+) -> None:
+    wf = _make_workflow()
+    with (
+        patch("cog.workflows.ralph.is_dirty", AsyncMock(return_value=dirty)),
+        patch("cog.workflows.ralph.is_ahead_of_origin", AsyncMock(return_value=ahead)),
+    ):
+        result = await wf._teardown_action(tmp_path, "cog/1-t", outcome)
+    assert result is expected

--- a/tests/test_workflows/test_ralph_pre_stages.py
+++ b/tests/test_workflows/test_ralph_pre_stages.py
@@ -1,4 +1,6 @@
-"""Tests for RalphWorkflow.pre_stages."""
+"""Tests for RalphWorkflow.iteration_start (was pre_stages)."""
+
+from __future__ import annotations
 
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -12,8 +14,8 @@ from cog.workflows.ralph import RalphWorkflow
 from tests.fakes import InMemoryStateCache, make_item
 
 
-def _make_workflow() -> RalphWorkflow:
-    return RalphWorkflow(runner=AsyncMock(), tracker=AsyncMock(spec=IssueTracker))
+def _make_workflow(*, restart: bool = False) -> RalphWorkflow:
+    return RalphWorkflow(runner=AsyncMock(), tracker=AsyncMock(spec=IssueTracker), restart=restart)
 
 
 def _make_ctx(item=None) -> ExecutionContext:
@@ -27,144 +29,228 @@ def _make_ctx(item=None) -> ExecutionContext:
     return ctx
 
 
-async def test_pre_stages_git_operations_in_order() -> None:
+def _worktree_patches(
+    *,
+    default_branch: str = "main",
+    branch_exists: bool = False,
+    commits_between: int = 0,
+    remote_exists: bool = False,
+):
+    """Build a context manager that patches all worktree-related functions."""
+    from unittest.mock import patch as _patch
+
+    class _PatchGroup:
+        def __init__(self):
+            self._patches = [
+                _patch(
+                    "cog.workflows.ralph.git.default_branch", AsyncMock(return_value=default_branch)
+                ),
+                _patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
+                _patch(
+                    "cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=branch_exists)
+                ),
+                _patch(
+                    "cog.workflows.ralph.git.commits_between",
+                    AsyncMock(return_value=commits_between),
+                ),
+                _patch("cog.workflows.ralph.git.delete_branch", AsyncMock()),
+                _patch("cog.workflows.ralph.create_worktree", AsyncMock()),
+                _patch(
+                    "cog.workflows.ralph.remote_branch_exists",
+                    AsyncMock(return_value=remote_exists),
+                ),
+                _patch("cog.workflows.ralph.discard_worktree", AsyncMock()),
+            ]
+            self._started: list = []
+
+        def __enter__(self):
+            mocks = {}
+            for p in self._patches:
+                m = p.start()
+                mocks[p.attribute] = m
+            self._started = self._patches
+            return mocks
+
+        def __exit__(self, *args):
+            for p in self._started:
+                p.stop()
+
+    return _PatchGroup()
+
+
+# ---------------------------------------------------------------------------
+# iteration_start: fresh start (no existing branch)
+# ---------------------------------------------------------------------------
+
+
+async def test_iteration_start_creates_worktree_for_new_branch() -> None:
     item = make_item(item_id="42", title="Fix the bug")
     ctx = _make_ctx(item)
     wf = _make_workflow()
-    call_order: list[str] = []
-
-    async def _default_branch(project_dir):
-        call_order.append("default_branch")
-        return "main"
-
-    async def _checkout(project_dir, branch):
-        call_order.append(f"checkout:{branch}")
-
-    async def _fetch(project_dir):
-        call_order.append("fetch")
-
-    async def _merge(project_dir, ref):
-        call_order.append(f"merge:{ref}")
-
-    async def _create(project_dir, name, start_point="HEAD"):
-        call_order.append(f"create:{name}")
+    create_mock = AsyncMock()
 
     with (
-        patch("cog.workflows.ralph.git.default_branch", new=_default_branch),
-        patch("cog.workflows.ralph.git.checkout_branch", new=_checkout),
-        patch("cog.workflows.ralph.git.fetch_origin", new=_fetch),
-        patch("cog.workflows.ralph.git.merge_ff_only", new=_merge),
+        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
+        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
         patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=False)),
-        patch("cog.workflows.ralph.git.create_branch", new=_create),
+        patch("cog.workflows.ralph.remote_branch_exists", AsyncMock(return_value=False)),
+        patch("cog.workflows.ralph.create_worktree", create_mock),
+        patch("cog.workflows.ralph.discard_worktree", AsyncMock()),
     ):
-        await wf.pre_stages(ctx)
+        await wf.iteration_start(ctx)
 
-    assert call_order == [
-        "default_branch",
-        "checkout:main",
-        "fetch",
-        "merge:origin/main",
-        "create:cog/42-fix-the-bug",
-    ]
+    create_mock.assert_awaited_once()
+    call_kwargs = create_mock.call_args
+    assert call_kwargs.kwargs["create_branch"] is True
+    assert call_kwargs.kwargs["start_point"] == "origin/main"
+    assert ctx.work_branch == "cog/42-fix-the-bug"
+    assert ctx.resumed is False
 
 
-async def test_pre_stages_sets_ctx_work_branch() -> None:
+async def test_iteration_start_sets_worktree_path() -> None:
     item = make_item(item_id="7", title="Add feature")
     ctx = _make_ctx(item)
     wf = _make_workflow()
 
     with (
         patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
-        patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
         patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
-        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
         patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=False)),
-        patch("cog.workflows.ralph.git.create_branch", AsyncMock()),
+        patch("cog.workflows.ralph.remote_branch_exists", AsyncMock(return_value=False)),
+        patch("cog.workflows.ralph.create_worktree", AsyncMock()),
+        patch("cog.workflows.ralph.discard_worktree", AsyncMock()),
     ):
-        await wf.pre_stages(ctx)
+        await wf.iteration_start(ctx)
 
-    assert ctx.work_branch == "cog/7-add-feature"
+    expected_wt = Path("/fake/project") / ".cog" / "worktrees" / "7-add-feature"
+    assert ctx.worktree_path == expected_wt
 
 
-async def test_pre_stages_branch_name_format() -> None:
-    item = make_item(item_id="99", title="Update deps")
+# ---------------------------------------------------------------------------
+# iteration_start: resume cases
+# ---------------------------------------------------------------------------
+
+
+async def test_iteration_start_resumes_local_branch_with_commits() -> None:
+    item = make_item(item_id="42", title="Fix the bug")
     ctx = _make_ctx(item)
     wf = _make_workflow()
+    create_mock = AsyncMock()
 
     with (
         patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
-        patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
         patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
-        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
-        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=False)),
-        patch("cog.workflows.ralph.git.create_branch", AsyncMock()) as mock_create,
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=True)),
+        patch("cog.workflows.ralph.git.commits_between", AsyncMock(return_value=3)),
+        patch("cog.workflows.ralph.create_worktree", create_mock),
+        patch("cog.workflows.ralph.discard_worktree", AsyncMock()),
+        patch("cog.workflows.ralph.remote_branch_exists", AsyncMock(return_value=False)),
     ):
-        await wf.pre_stages(ctx)
-        name_arg = mock_create.call_args[0][1]
+        await wf.iteration_start(ctx)
 
-    assert name_arg.startswith("cog/99-")
-    assert name_arg == "cog/99-update-deps"
+    # Should use create_branch=False to attach to existing branch
+    call_kwargs = create_mock.call_args
+    assert call_kwargs.kwargs["create_branch"] is False
+    assert ctx.resumed is True
 
 
-async def test_pre_stages_propagates_git_error_from_fetch() -> None:
+async def test_iteration_start_deletes_stale_branch_and_creates_fresh() -> None:
+    item = make_item(item_id="42", title="Fix the bug")
+    ctx = _make_ctx(item)
+    wf = _make_workflow()
+    delete_mock = AsyncMock()
+    create_mock = AsyncMock()
+
+    with (
+        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
+        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=True)),
+        patch("cog.workflows.ralph.git.commits_between", AsyncMock(return_value=0)),
+        patch("cog.workflows.ralph.git.delete_branch", delete_mock),
+        patch("cog.workflows.ralph.create_worktree", create_mock),
+        patch("cog.workflows.ralph.discard_worktree", AsyncMock()),
+        patch("cog.workflows.ralph.remote_branch_exists", AsyncMock(return_value=False)),
+    ):
+        await wf.iteration_start(ctx)
+
+    delete_mock.assert_awaited_once()
+    assert create_mock.call_args.kwargs["create_branch"] is True
+    assert ctx.resumed is False
+
+
+async def test_iteration_start_resumes_from_origin_when_no_local_branch() -> None:
+    item = make_item(item_id="42", title="Fix the bug")
+    ctx = _make_ctx(item)
+    wf = _make_workflow()
+    create_mock = AsyncMock()
+
+    with (
+        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
+        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=False)),
+        patch("cog.workflows.ralph.remote_branch_exists", AsyncMock(return_value=True)),
+        patch("cog.workflows.ralph.create_worktree", create_mock),
+        patch("cog.workflows.ralph.discard_worktree", AsyncMock()),
+    ):
+        await wf.iteration_start(ctx)
+
+    call_kwargs = create_mock.call_args
+    assert "origin/cog/42-fix-the-bug" in call_kwargs.kwargs["start_point"]
+    assert ctx.resumed is True
+
+
+# ---------------------------------------------------------------------------
+# iteration_start: restart flag
+# ---------------------------------------------------------------------------
+
+
+async def test_iteration_start_restart_force_cleans_and_creates_fresh() -> None:
+    item = make_item(item_id="42", title="Fix the bug")
+    ctx = _make_ctx(item)
+    wf = _make_workflow(restart=True)
+    discard_mock = AsyncMock()
+    delete_mock = AsyncMock()
+    create_mock = AsyncMock()
+
+    with (
+        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
+        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
+        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=True)),
+        patch("cog.workflows.ralph.git.delete_branch", delete_mock),
+        patch("cog.workflows.ralph.create_worktree", create_mock),
+        patch("cog.workflows.ralph.discard_worktree", discard_mock),
+        patch("pathlib.Path.exists", return_value=True),
+    ):
+        await wf.iteration_start(ctx)
+
+    delete_mock.assert_awaited_once()
+    assert create_mock.call_args.kwargs["create_branch"] is True
+    assert ctx.resumed is False
+
+
+async def test_iteration_start_asserts_item_is_set() -> None:
+    ctx = _make_ctx(item=None)
+    wf = _make_workflow()
+    with pytest.raises(AssertionError, match="requires ctx.item"):
+        await wf.iteration_start(ctx)
+
+
+# ---------------------------------------------------------------------------
+# iteration_start: propagates git errors
+# ---------------------------------------------------------------------------
+
+
+async def test_iteration_start_propagates_git_error_from_fetch() -> None:
     item = make_item(item_id="1", title="t")
     ctx = _make_ctx(item)
     wf = _make_workflow()
 
     with (
         patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
-        patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
         patch(
             "cog.workflows.ralph.git.fetch_origin",
             AsyncMock(side_effect=GitError("fetch failed")),
         ),
-        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
-        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=False)),
-        patch("cog.workflows.ralph.git.create_branch", AsyncMock()),
     ):
         with pytest.raises(GitError, match="fetch failed"):
-            await wf.pre_stages(ctx)
-
-
-async def test_pre_stages_propagates_git_error_from_merge() -> None:
-    item = make_item(item_id="1", title="t")
-    ctx = _make_ctx(item)
-    wf = _make_workflow()
-
-    with (
-        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
-        patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
-        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
-        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock(side_effect=GitError("not ff"))),
-        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=False)),
-        patch("cog.workflows.ralph.git.create_branch", AsyncMock()),
-    ):
-        with pytest.raises(GitError, match="not ff"):
-            await wf.pre_stages(ctx)
-
-
-async def test_pre_stages_propagates_git_error_from_create_branch() -> None:
-    item = make_item(item_id="1", title="t")
-    ctx = _make_ctx(item)
-    wf = _make_workflow()
-
-    with (
-        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
-        patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
-        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
-        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
-        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=False)),
-        patch(
-            "cog.workflows.ralph.git.create_branch",
-            AsyncMock(side_effect=GitError("branch already exists")),
-        ),
-    ):
-        with pytest.raises(GitError, match="branch already exists"):
-            await wf.pre_stages(ctx)
-
-
-async def test_pre_stages_asserts_item_is_set() -> None:
-    ctx = _make_ctx(item=None)
-    wf = _make_workflow()
-    with pytest.raises(AssertionError, match="requires ctx.item"):
-        await wf.pre_stages(ctx)
+            await wf.iteration_start(ctx)

--- a/tests/test_workflows/test_ralph_resume.py
+++ b/tests/test_workflows/test_ralph_resume.py
@@ -1,45 +1,21 @@
-"""Tests for RalphWorkflow resume / restart / agent-failed label logic."""
+"""Tests for RalphWorkflow resume / agent-failed label logic."""
 
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
 from cog.core.context import ExecutionContext
 from cog.core.errors import HostError, TrackerError
 from cog.core.host import CheckRun, GitHost, PrChecks, PullRequest
-from cog.core.tracker import IssueTracker
 from cog.workflows.ralph import RalphWorkflow
 from tests.fakes import InMemoryStateCache, RecordingEventSink, make_item, make_stage_result
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_workflow(*, restart: bool = False) -> RalphWorkflow:
-    return RalphWorkflow(
-        runner=AsyncMock(),
-        tracker=AsyncMock(spec=IssueTracker),
-        restart=restart,
-    )
-
-
-def _make_ctx(item=None) -> ExecutionContext:
-    ctx = ExecutionContext(
-        project_dir=Path("/fake/project"),
-        tmp_dir=Path("/tmp"),
-        state_cache=InMemoryStateCache(),
-        headless=True,
-    )
-    ctx.item = item
-    return ctx
-
 
 def _make_tracker() -> AsyncMock:
-    tracker = AsyncMock(spec=IssueTracker)
+    tracker = AsyncMock()
     tracker.comment.return_value = None
     tracker.add_label.return_value = None
     tracker.remove_label.return_value = None
@@ -77,188 +53,6 @@ def _make_wf_with_tracker_host(tracker=None, host=None, *, restart: bool = False
         host=host or _make_host(),
         restart=restart,
     )
-
-
-# ---------------------------------------------------------------------------
-# pre_stages branch-state logic
-# ---------------------------------------------------------------------------
-
-
-async def test_pre_stages_creates_branch_when_none_exists() -> None:
-    item = make_item(item_id="42", title="Fix the bug")
-    ctx = _make_ctx(item)
-    wf = _make_workflow()
-    create_mock = AsyncMock()
-
-    with (
-        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
-        patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
-        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
-        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
-        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=False)),
-        patch("cog.workflows.ralph.git.create_branch", create_mock),
-    ):
-        await wf.pre_stages(ctx)
-
-    create_mock.assert_awaited_once_with(
-        Path("/fake/project"), "cog/42-fix-the-bug", start_point="HEAD"
-    )
-    assert ctx.work_branch == "cog/42-fix-the-bug"
-
-
-async def test_pre_stages_silently_deletes_stale_empty_branch_and_recreates() -> None:
-    item = make_item(item_id="42", title="Fix the bug")
-    ctx = _make_ctx(item)
-    wf = _make_workflow()
-    delete_mock = AsyncMock()
-    create_mock = AsyncMock()
-
-    with (
-        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
-        patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
-        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
-        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
-        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=True)),
-        patch("cog.workflows.ralph.git.commits_between", AsyncMock(return_value=0)),
-        patch("cog.workflows.ralph.git.delete_branch", delete_mock),
-        patch("cog.workflows.ralph.git.create_branch", create_mock),
-    ):
-        await wf.pre_stages(ctx)
-
-    delete_mock.assert_awaited_once()
-    create_mock.assert_awaited_once()
-
-
-async def test_pre_stages_resumes_existing_branch_with_commits() -> None:
-    item = make_item(item_id="42", title="Fix the bug")
-    ctx = _make_ctx(item)
-    wf = _make_workflow()
-    checkout_calls: list[str] = []
-
-    async def _checkout(project_dir, branch):
-        checkout_calls.append(branch)
-
-    with (
-        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
-        patch("cog.workflows.ralph.git.checkout_branch", _checkout),
-        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
-        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
-        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=True)),
-        patch("cog.workflows.ralph.git.commits_between", AsyncMock(return_value=3)),
-        patch("cog.workflows.ralph.git.create_branch", AsyncMock()) as create_mock,
-        patch("cog.workflows.ralph.git.delete_branch", AsyncMock()) as delete_mock,
-    ):
-        await wf.pre_stages(ctx)
-
-    # Should have checked out work branch (not created or deleted)
-    assert "cog/42-fix-the-bug" in checkout_calls
-    create_mock.assert_not_awaited()
-    delete_mock.assert_not_awaited()
-
-
-async def test_pre_stages_sets_resumed_flag_on_resume() -> None:
-    item = make_item(item_id="42", title="Fix the bug")
-    ctx = _make_ctx(item)
-    wf = _make_workflow()
-
-    with (
-        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
-        patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
-        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
-        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
-        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=True)),
-        patch("cog.workflows.ralph.git.commits_between", AsyncMock(return_value=2)),
-        patch("cog.workflows.ralph.git.create_branch", AsyncMock()),
-        patch("cog.workflows.ralph.git.delete_branch", AsyncMock()),
-    ):
-        await wf.pre_stages(ctx)
-
-    assert wf._resumed_this_iteration.get("42") is True
-
-
-async def test_pre_stages_clears_resumed_flag_on_fresh_create() -> None:
-    item = make_item(item_id="42", title="Fix the bug")
-    ctx = _make_ctx(item)
-    wf = _make_workflow()
-
-    with (
-        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
-        patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
-        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
-        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
-        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=False)),
-        patch("cog.workflows.ralph.git.create_branch", AsyncMock()),
-    ):
-        await wf.pre_stages(ctx)
-
-    assert wf._resumed_this_iteration.get("42") is False
-
-
-async def test_pre_stages_honors_restart_flag_deletes_and_recreates() -> None:
-    item = make_item(item_id="42", title="Fix the bug")
-    ctx = _make_ctx(item)
-    wf = _make_workflow(restart=True)
-    delete_mock = AsyncMock()
-    create_mock = AsyncMock()
-
-    with (
-        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
-        patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
-        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
-        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
-        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=True)),
-        patch("cog.workflows.ralph.git.commits_between", AsyncMock(return_value=5)),
-        patch("cog.workflows.ralph.git.delete_branch", delete_mock),
-        patch("cog.workflows.ralph.git.create_branch", create_mock),
-    ):
-        await wf.pre_stages(ctx)
-
-    delete_mock.assert_awaited_once()
-    create_mock.assert_awaited_once()
-
-
-async def test_pre_stages_restart_flag_forces_delete_even_on_empty_branch_noop() -> None:
-    # --restart on a 0-commits branch still deletes + recreates (same as default, just explicit)
-    item = make_item(item_id="42", title="Fix the bug")
-    ctx = _make_ctx(item)
-    wf = _make_workflow(restart=True)
-    delete_mock = AsyncMock()
-    create_mock = AsyncMock()
-
-    with (
-        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
-        patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
-        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
-        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
-        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=True)),
-        patch("cog.workflows.ralph.git.commits_between", AsyncMock(return_value=0)),
-        patch("cog.workflows.ralph.git.delete_branch", delete_mock),
-        patch("cog.workflows.ralph.git.create_branch", create_mock),
-    ):
-        await wf.pre_stages(ctx)
-
-    delete_mock.assert_awaited_once()
-    create_mock.assert_awaited_once()
-
-
-async def test_pre_stages_with_restart_does_not_set_resumed_flag() -> None:
-    item = make_item(item_id="42", title="Fix the bug")
-    ctx = _make_ctx(item)
-    wf = _make_workflow(restart=True)
-
-    with (
-        patch("cog.workflows.ralph.git.default_branch", AsyncMock(return_value="main")),
-        patch("cog.workflows.ralph.git.checkout_branch", AsyncMock()),
-        patch("cog.workflows.ralph.git.fetch_origin", AsyncMock()),
-        patch("cog.workflows.ralph.git.merge_ff_only", AsyncMock()),
-        patch("cog.workflows.ralph.git.branch_exists", AsyncMock(return_value=True)),
-        patch("cog.workflows.ralph.git.commits_between", AsyncMock(return_value=3)),
-        patch("cog.workflows.ralph.git.delete_branch", AsyncMock()),
-        patch("cog.workflows.ralph.git.create_branch", AsyncMock()),
-    ):
-        await wf.pre_stages(ctx)
-
-    assert wf._resumed_this_iteration.get("42") is False
 
 
 # ---------------------------------------------------------------------------
@@ -402,7 +196,7 @@ async def test_write_telemetry_passes_resumed_true_when_branch_was_resumed(
     wf = _make_wf_with_tracker_host()
     ctx = _make_ctx_with_tmp(tmp_path)
     ctx.telemetry = tel
-    wf._resumed_this_iteration["42"] = True
+    ctx.resumed = True
     await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
     record = tel.write.call_args.args[0]
     assert record.resumed is True
@@ -415,7 +209,7 @@ async def test_write_telemetry_passes_resumed_false_when_branch_was_fresh(
     wf = _make_wf_with_tracker_host()
     ctx = _make_ctx_with_tmp(tmp_path)
     ctx.telemetry = tel
-    wf._resumed_this_iteration["42"] = False
+    ctx.resumed = False
     await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
     record = tel.write.call_args.args[0]
     assert record.resumed is False
@@ -428,7 +222,7 @@ async def test_write_telemetry_passes_resumed_true_on_error_when_resumed(
     wf = _make_wf_with_tracker_host()
     ctx = _make_ctx_with_tmp(tmp_path)
     ctx.telemetry = tel
-    wf._resumed_this_iteration["42"] = True
+    ctx.resumed = True
     await wf.finalize_error(ctx, RuntimeError("err"), [])
     record = tel.write.call_args.args[0]
     assert record.resumed is True
@@ -452,8 +246,8 @@ async def test_resume_then_success_updates_existing_pr_via_get_pr_for_branch(
     host = _make_host(pr=existing_pr)
     tracker = _make_tracker()
     wf = _make_wf_with_tracker_host(tracker=tracker, host=host)
-    wf._resumed_this_iteration["42"] = True
     ctx = _make_ctx_with_tmp(tmp_path)
+    ctx.resumed = True
     await wf.finalize_success(ctx, [make_stage_result("build", commits=1)])
 
     host.create_pr.assert_not_awaited()

--- a/tests/test_workflows/test_refine_integration_ext.py
+++ b/tests/test_workflows/test_refine_integration_ext.py
@@ -47,7 +47,7 @@ def _make_wf(
             self._call_count = 0
             self._total_interview_calls = len(interview_responses)
 
-        async def stream(self, prompt, *, model):
+        async def stream(self, prompt, *, model, cwd=None):
             # First N calls are interview turns; next is rewrite
             if self._call_count < self._total_interview_calls:
                 runner = self._interview

--- a/tests/test_workflows/test_refine_interview.py
+++ b/tests/test_workflows/test_refine_interview.py
@@ -356,7 +356,9 @@ async def test_interview_no_result_event_emitted_raises(tmp_path):
     from cog.core.runner import AgentRunner, RunEvent
 
     class NoResultRunner(AgentRunner):
-        async def stream(self, prompt: str, *, model: str) -> AsyncIterator[RunEvent]:
+        async def stream(
+            self, prompt: str, *, model: str, cwd: Path | None = None
+        ) -> AsyncIterator[RunEvent]:
             # yields nothing (no ResultEvent → final_message stays "")
             return
             yield  # type: ignore[misc]


### PR DESCRIPTION
## Summary

The branch `cog/152-ralph-run-each-iteration-in-a-git-worktree-under-c` already had the full worktree implementation and the `_BranchCase`/`_TeardownAction` refactor from the previous run. I applied the remaining simplifications requested in the last issue comment: extracted `_create_fresh_worktree` (deduplicates the identical `create_worktree` call in RESTART, RECREATE_STALE, and FRESH_START cases) and `_cleanup_for_restart` (names the restart teardown logic). All 1089 tests pass, mypy clean, ruff clean.

## Key changes

- `_create_fresh_worktree` helper on `RalphWorkflow` names the "fresh start from origin/<default>" intent, used by three branch cases
- `_cleanup_for_restart` helper names the restart teardown sequence (discard worktree + delete local branch)
- `iteration_start`'s match block is now ~25 lines shorter with each arm doing at most two named operations

## Closes

Closes #152

## Test plan

- [ ] Run `cog ralph` on an `agent-ready` item and verify a worktree is created under `.cog/worktrees/<id>-<slug>/`
- [ ] Kill ralph mid-run, restart — verify it resumes from the existing worktree (RESUME_LOCAL case)
- [ ] Run `cog ralph --restart` — verify it discards the old worktree and starts fresh
- [ ] Verify the main checkout stays on its current branch throughout all of the above
- [ ] Start ralph, let an item complete — verify the worktree is removed on success
- [ ] Introduce a stuck worktree manually, restart ralph — verify orphan scan labels the item `agent-failed` and skips it during pick

---
🤖 Generated by cog. Iteration cost: $5.202
