### PR TITLE
Tests: install session-scoped event loop in conftest to plug pytest-asyncio leak

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,23 @@
+import asyncio
+import atexit
 import subprocess
 
 import pytest
 
 from cog.core.context import ExecutionContext
 from tests.fakes import EchoRunner, InMemoryStateCache
+
+# pytest-asyncio 1.3.0's `_temporary_event_loop_policy` calls
+# `asyncio.get_event_loop()` once per test setup; on Python 3.12 with the
+# default policy this auto-creates a fresh `_UnixSelectorEventLoop` (with a
+# self-pipe socketpair) every test and never closes it. With many async tests
+# the leaked loops/sockets eventually trip a gc'd `ResourceWarning` mid-suite,
+# which `filterwarnings = ["error"]` promotes to a failure on whichever test
+# happens to be running gc. Installing a session-wide current loop here makes
+# `get_event_loop()` return this one instead of creating per-test.
+_session_loop = asyncio.new_event_loop()
+asyncio.set_event_loop(_session_loop)
+atexit.register(_session_loop.close)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Each async test in cog's suite leaks a `_UnixSelectorEventLoop` (plus its self-pipe socketpair). The leak is benign on small suites — it accumulates silently and shows up only when gc runs late enough that `pyproject.toml`'s `filterwarnings = ["error"]` promotes the resulting `ResourceWarning` to a real test failure. With ~1060 tests today the leak typically stays under threshold; on the in-flight #152 branch (24 new async tests) it pushes past and one CLI test fails order-dependently with `unclosed event loop / unclosed <socket.socket>`.

This pre-emptively fixes the leak on `main` so it doesn't bite any branch that pushes the test count higher.

## Root cause

`pytest-asyncio` 1.3.0's `_temporary_event_loop_policy` ([plugin.py:618](https://github.com/pytest-dev/pytest-asyncio/blob/v1.3.0/pytest_asyncio/plugin.py#L618)) calls `asyncio.get_event_loop()` per test setup. On Python 3.12 with the default policy and no current loop set, that auto-creates a fresh `_UnixSelectorEventLoop` (allocating a self-pipe socketpair via `selector_events.py:120`), captures it as `old_loop`, and restores it after the test — without ever closing it. Tracemalloc traceback confirms the allocation site at `asyncio/events.py:699 → unix_events.py:64 → selector_events.py:120`.

This is upstream pytest-asyncio behavior, not cog-specific.

## Fix

`tests/conftest.py` (new top-of-file block, ~14 lines): install a single session-scoped event loop at module import via `asyncio.new_event_loop()` + `asyncio.set_event_loop()`, registered for `loop.close()` via `atexit`. Once a current loop is already set, `get_event_loop()` returns that one instead of allocating per test.

## Verification

- `uv run pytest`: **1060 passed, 3 skipped** (docker integration), 0 failed. Stable across multiple runs.
- `uv run mypy src`: clean.
- `uv run ruff check .` and `uv run ruff format --check .`: clean.

## Why not push it upstream

Worth doing eventually — this is a real bug in pytest-asyncio's event-loop-policy handling, not cog's code. But a conftest workaround unblocks us today; the upstream fix can ride a separate timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)