### PR TITLE
is_ahead_of_origin: don't swallow arbitrary GitErrors as 'ahead' (#167)

### DIFF
--- a/src/cog/git/worktree.py
+++ b/src/cog/git/worktree.py
@@ -163,15 +163,13 @@ async def remote_branch_exists(repo: Path, branch: str) -> bool:
 async def is_ahead_of_origin(path: Path, branch: str) -> bool:
     """True if `branch` has commits not on `origin/<branch>` (or origin lacks it)."""
     repo = _find_repo_root(path)
-    try:
-        count_str = await _run(
-            ["git", "rev-list", "--count", f"origin/{branch}..{branch}"],
-            repo,
-        )
-        return int(count_str) > 0
-    except GitError:
-        # origin/branch doesn't exist — we're ahead by definition
+    if not await remote_branch_exists(repo, branch):
         return True
+    count_str = await _run(
+        ["git", "rev-list", "--count", f"origin/{branch}..{branch}"],
+        repo,
+    )
+    return int(count_str) > 0
 
 
 def _find_repo_root(path: Path) -> Path:

--- a/src/cog/git/worktree.py
+++ b/src/cog/git/worktree.py
@@ -173,7 +173,13 @@ async def is_ahead_of_origin(path: Path, branch: str) -> bool:
 
 
 def _find_repo_root(path: Path) -> Path:
-    """Walk up from path to find the repo root (where .git lives)."""
+    """Walk up from path to find the first directory containing `.git`.
+
+    Inside a worktree, `.git` is a pointer file (not a directory) referencing
+    the gitdir under the main repo's `.git/worktrees/<name>/`. Git resolves
+    refs through that pointer, so this is sufficient as a `cwd` for git
+    commands run against the worktree.
+    """
     current = path if path.is_dir() else path.parent
     while True:
         git_path = current / ".git"
@@ -268,20 +274,33 @@ async def scan_orphans(project_dir: Path) -> OrphanScanResult:
             )
             continue
 
-        if branch and await is_ahead_of_origin(entry, branch):
+        if branch:
             try:
-                await push_with_retry(entry, branch)
-                result.pushed.append((entry, branch))
+                ahead = await is_ahead_of_origin(entry, branch)
             except GitError as e:
                 result.dirty.append(
                     StuckWorktree(
                         path=entry,
                         branch=branch,
                         item_id=item_id,
-                        reason=f"push failed: {e}",
+                        reason=f"ahead check failed: {e}",
                     )
                 )
                 continue
+            if ahead:
+                try:
+                    await push_with_retry(entry, branch)
+                    result.pushed.append((entry, branch))
+                except GitError as e:
+                    result.dirty.append(
+                        StuckWorktree(
+                            path=entry,
+                            branch=branch,
+                            item_id=item_id,
+                            reason=f"push failed: {e}",
+                        )
+                    )
+                    continue
 
         try:
             await remove_worktree(project_dir, entry)

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -408,7 +408,15 @@ class RalphWorkflow(Workflow):
         self, wt_path: Path, branch: str, outcome: IterationOutcome
     ) -> _TeardownAction:
         dirty = await is_dirty(wt_path)
-        ahead = await is_ahead_of_origin(wt_path, branch)
+        try:
+            ahead = await is_ahead_of_origin(wt_path, branch)
+        except GitError as e:
+            # Ahead-state is unknown; refuse to guess whether to push.
+            sys.stderr.write(
+                f"warning: could not determine ahead-of-origin for {branch}: {e}; "
+                f"leaving worktree stuck\n"
+            )
+            return _TeardownAction.LEAVE_STUCK
         if outcome is IterationOutcome.success:
             return _TeardownAction.LEAVE_STUCK if dirty else _TeardownAction.REMOVE
         if dirty:

--- a/tests/git/test_worktree.py
+++ b/tests/git/test_worktree.py
@@ -338,6 +338,36 @@ def test_scan_orphans_cleans_registered_clean_worktree(temp_git_repo: Path) -> N
     _run(body())
 
 
+def test_scan_orphans_marks_stuck_when_ahead_check_raises(temp_git_repo: Path) -> None:
+    """A propagated GitError from is_ahead_of_origin must mark the worktree stuck,
+    not abort the whole scan or attempt a blind push."""
+    default = _default_branch(temp_git_repo)
+    wt_dir = temp_git_repo / ".cog" / "worktrees"
+    wt_dir.mkdir(parents=True)
+    wt_path = wt_dir / "44-ahead-fails"
+
+    async def body() -> None:
+        await create_worktree(
+            temp_git_repo,
+            wt_path,
+            "cog/44-ahead-fails",
+            start_point=f"origin/{default}",
+            create_branch=True,
+        )
+        with patch(
+            "cog.git.worktree.is_ahead_of_origin",
+            AsyncMock(side_effect=GitError("transient")),
+        ):
+            result = await scan_orphans(temp_git_repo)
+        stuck = [s for s in result.dirty if s.path == wt_path]
+        assert len(stuck) == 1
+        assert "ahead check failed" in stuck[0].reason
+        assert result.pushed == []
+        await discard_worktree(temp_git_repo, wt_path)
+
+    _run(body())
+
+
 def test_scan_orphans_marks_dirty_worktree_as_stuck(temp_git_repo: Path) -> None:
     default = _default_branch(temp_git_repo)
     wt_dir = temp_git_repo / ".cog" / "worktrees"

--- a/tests/git/test_worktree.py
+++ b/tests/git/test_worktree.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import subprocess
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -239,6 +240,20 @@ def test_is_ahead_of_origin_true_when_remote_lacks_branch(temp_git_repo: Path) -
         return result
 
     assert _run(body()) is True
+
+
+@pytest.mark.asyncio
+async def test_is_ahead_of_origin_propagates_git_error(tmp_path: Path) -> None:
+    """GitError from rev-list must propagate, not be swallowed as 'ahead'."""
+    with (
+        patch("cog.git.worktree.remote_branch_exists", AsyncMock(return_value=True)),
+        patch(
+            "cog.git.worktree._run",
+            AsyncMock(side_effect=GitError("corrupt object store")),
+        ),
+    ):
+        with pytest.raises(GitError, match="corrupt object store"):
+            await is_ahead_of_origin(tmp_path, "some-branch")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_workflows/test_ralph_pre_stages.py
+++ b/tests/test_workflows/test_ralph_pre_stages.py
@@ -353,3 +353,24 @@ async def test_teardown_action_matrix(
     ):
         result = await wf._teardown_action(tmp_path, "cog/1-t", outcome)
     assert result is expected
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [IterationOutcome.success, IterationOutcome.noop, IterationOutcome.error],
+)
+async def test_teardown_action_leaves_stuck_when_ahead_check_raises(
+    outcome: IterationOutcome,
+    tmp_path: Path,
+) -> None:
+    """If `is_ahead_of_origin` raises, we don't know whether to push — leave stuck."""
+    wf = _make_workflow()
+    with (
+        patch("cog.workflows.ralph.is_dirty", AsyncMock(return_value=False)),
+        patch(
+            "cog.workflows.ralph.is_ahead_of_origin",
+            AsyncMock(side_effect=GitError("transient failure")),
+        ),
+    ):
+        result = await wf._teardown_action(tmp_path, "cog/1-t", outcome)
+    assert result is _TeardownAction.LEAVE_STUCK


### PR DESCRIPTION
## Summary

`is_ahead_of_origin` previously caught all `GitError` exceptions and returned `True` (treating any failure as "the branch is ahead"). This masked real problems: network failures, corrupt object stores, or other git errors would silently cause cog to attempt a push (and then fail there), rather than propagating the underlying error. The fix replaces the broad catch with an explicit `remote_branch_exists` check — if the remote branch is absent, return `True`; otherwise run `rev-list` and let any `GitError` propagate normally.

## Key changes

- `is_ahead_of_origin` in `src/cog/git/worktree.py` now calls `remote_branch_exists` first; only returns `True` unconditionally when the remote branch is missing. All other `GitError` from `rev-list` propagate to the caller.
- New test `test_is_ahead_of_origin_propagates_git_error` verifies that a `GitError` from `rev-list` is not swallowed when the remote branch exists.

## Closes

Closes #167

## Test plan

- [ ] Run `cog ralph` on a worktree where the remote branch exists and is in sync — verify `is_ahead_of_origin` returns `False` and no push occurs.
- [ ] Run `cog ralph` on a new local branch not yet pushed — verify `is_ahead_of_origin` returns `True` and a push is attempted.
- [ ] Simulate a git error (e.g., by temporarily corrupting the git config) and verify the error surfaces instead of silently treating the worktree as "ahead".

---
🤖 Generated by cog. Iteration cost: $2.370
