### PR TITLE
Refine: save raw rewrite output in the report for forensics (#140)

### DIFF
--- a/docs/workflows/refine.md
+++ b/docs/workflows/refine.md
@@ -90,8 +90,10 @@ Exiting without saving returns to the review prompt — **not** abandon.
 
 After each iteration (accept or abandon) a markdown report is written
 to `~/.local/state/cog/<slug>/reports/<ts>-refine-<item-slug>.md`. It
-contains the full original body, the proposed/applied body, the complete
-interview transcript, and a per-stage cost table.
+contains the full original body, the proposed/applied body, the raw rewrite
+output (verbatim from the rewrite stage, useful for forensics when the
+parsed title/body differs from what was generated), the complete interview
+transcript, and a per-stage cost table.
 
 ## Commands
 

--- a/src/cog/workflows/refine.py
+++ b/src/cog/workflows/refine.py
@@ -216,7 +216,11 @@ class RefineWorkflow(Workflow):
             ),
         )
         await ctx.telemetry.write(record)
-        await self._write_report(ctx, results, transcript, review, outcome="success")
+        rewrite_result = next((r for r in results if r.stage.name == "rewrite"), None)
+        raw = rewrite_result.final_message if rewrite_result is not None else ""
+        await self._write_report(
+            ctx, results, transcript, review, outcome="success", raw_rewrite_output=raw
+        )
         self._cleanup_transcript_file(ctx.project_dir, ctx.item.item_id)
 
     async def finalize_noop(self, ctx: ExecutionContext, results: list[StageResult]) -> None:
@@ -249,7 +253,11 @@ class RefineWorkflow(Workflow):
             await ctx.telemetry.write(record)
 
         if review is not None:
-            await self._write_report(ctx, results, transcript, review, outcome="noop")
+            rewrite_result = next((r for r in results if r.stage.name == "rewrite"), None)
+            raw = rewrite_result.final_message if rewrite_result is not None else ""
+            await self._write_report(
+                ctx, results, transcript, review, outcome="noop", raw_rewrite_output=raw
+            )
         self._cleanup_transcript_file(ctx.project_dir, ctx.item.item_id)
 
     async def finalize_error(
@@ -286,6 +294,7 @@ class RefineWorkflow(Workflow):
         transcript: list[InterviewTurn],
         review: ReviewOutcome,
         outcome: Literal["success", "noop"],
+        raw_rewrite_output: str = "",
     ) -> None:
         assert ctx.item is not None
         ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
@@ -319,6 +328,9 @@ class RefineWorkflow(Workflow):
             lines.append("```\n(Abandoned; body unchanged)\n```\n")
         else:
             lines.append(f"```\n{review.final_body}\n```\n")
+
+        lines.append("## Raw rewrite output\n")
+        lines.append(f"````\n{raw_rewrite_output}\n````\n")
 
         lines.append("## Interview transcript\n")
         n = len(transcript)

--- a/tests/test_workflows/test_refine_finalize.py
+++ b/tests/test_workflows/test_refine_finalize.py
@@ -249,6 +249,104 @@ async def test_finalize_noop_writes_report_with_body_after_placeholder(tmp_path,
     assert "body unchanged" in content
 
 
+# ---------------------------------------------------------------------------
+# Raw rewrite output section in report
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_finalize_success_report_contains_raw_rewrite_output(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    tracker = AsyncMock()
+    item = make_item(item_id="20", title="T", body="B")
+    review = ReviewOutcome(decision=ReviewDecision.ACCEPT, final_body="B2", final_title="T")
+    wf = _make_wf_with_data("20", transcript=_sentinel_transcript(), review=review, tracker=tracker)
+    telemetry = AsyncMock()
+    ctx = _make_ctx(tmp_path, item=item, telemetry=telemetry)
+    raw = "### Title\nFoo\n### Body\nBar"
+    await wf.finalize_success(ctx, [make_stage_result("rewrite", final_message=raw)])
+    from cog.state_paths import project_state_dir
+
+    reports_dir = project_state_dir(tmp_path) / "reports"
+    content = list(reports_dir.glob("*-refine-*.md"))[0].read_text()
+    assert "## Raw rewrite output" in content
+    assert raw in content
+
+
+@pytest.mark.asyncio
+async def test_finalize_noop_report_contains_raw_rewrite_output(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    tracker = AsyncMock()
+    item = make_item(item_id="21", title="T", body="B")
+    review = ReviewOutcome(decision=ReviewDecision.ABANDON, final_body="B", final_title="T")
+    wf = _make_wf_with_data("21", transcript=_sentinel_transcript(), review=review, tracker=tracker)
+    ctx = _make_ctx(tmp_path, item=item)
+    raw = "### Title\nFoo\n### Body\nBar"
+    await wf.finalize_noop(ctx, [make_stage_result("rewrite", final_message=raw)])
+    from cog.state_paths import project_state_dir
+
+    reports_dir = project_state_dir(tmp_path) / "reports"
+    content = list(reports_dir.glob("*-refine-*.md"))[0].read_text()
+    assert "## Raw rewrite output" in content
+    assert raw in content
+
+
+@pytest.mark.asyncio
+async def test_report_raw_rewrite_uses_quadruple_backtick_fence(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    tracker = AsyncMock()
+    item = make_item(item_id="22", title="T", body="B")
+    review = ReviewOutcome(decision=ReviewDecision.ACCEPT, final_body="B2", final_title="T")
+    wf = _make_wf_with_data("22", transcript=_sentinel_transcript(), review=review, tracker=tracker)
+    telemetry = AsyncMock()
+    ctx = _make_ctx(tmp_path, item=item, telemetry=telemetry)
+    raw = "```title\nFoo\n```\n```body\nBar\n```"
+    await wf.finalize_success(ctx, [make_stage_result("rewrite", final_message=raw)])
+    from cog.state_paths import project_state_dir
+
+    reports_dir = project_state_dir(tmp_path) / "reports"
+    content = list(reports_dir.glob("*-refine-*.md"))[0].read_text()
+    assert "````\n" in content
+    assert raw in content
+
+
+@pytest.mark.asyncio
+async def test_report_raw_rewrite_section_ordering(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    tracker = AsyncMock()
+    item = make_item(item_id="23", title="T", body="B")
+    review = ReviewOutcome(decision=ReviewDecision.ACCEPT, final_body="B2", final_title="T")
+    wf = _make_wf_with_data("23", transcript=_sentinel_transcript(), review=review, tracker=tracker)
+    telemetry = AsyncMock()
+    ctx = _make_ctx(tmp_path, item=item, telemetry=telemetry)
+    await wf.finalize_success(ctx, [make_stage_result("rewrite")])
+    from cog.state_paths import project_state_dir
+
+    reports_dir = project_state_dir(tmp_path) / "reports"
+    content = list(reports_dir.glob("*-refine-*.md"))[0].read_text()
+    body_after_pos = content.index("## Body after")
+    raw_pos = content.index("## Raw rewrite output")
+    transcript_pos = content.index("## Interview transcript")
+    assert body_after_pos < raw_pos < transcript_pos
+
+
+@pytest.mark.asyncio
+async def test_report_raw_rewrite_empty_when_no_rewrite_result(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    tracker = AsyncMock()
+    item = make_item(item_id="24", title="T", body="B")
+    review = ReviewOutcome(decision=ReviewDecision.ABANDON, final_body="B", final_title="T")
+    wf = _make_wf_with_data("24", transcript=_sentinel_transcript(), review=review, tracker=tracker)
+    ctx = _make_ctx(tmp_path, item=item)
+    await wf.finalize_noop(ctx, [])  # no rewrite result
+    from cog.state_paths import project_state_dir
+
+    reports_dir = project_state_dir(tmp_path) / "reports"
+    content = list(reports_dir.glob("*-refine-*.md"))[0].read_text()
+    assert "## Raw rewrite output" in content
+    assert "````\n\n````" in content
+
+
 @pytest.mark.parametrize(
     "outcome",
     [ReviewDecision.ACCEPT, ReviewDecision.ABANDON],


### PR DESCRIPTION
## Summary

Adds a `## Raw rewrite output` section to refine reports so the verbatim model output that `_extract_title_body` ran against is always preserved on disk. This forensic artifact makes it possible to debug future extraction failures (bad regex, model drift, prompt-format change) without hand-reconstructing the output from the transcript. The section appears on both success and noop report paths, uses a quadruple-backtick fence to survive inner triple-backtick blocks the rewrite prompt produces, and emits an empty fence when no rewrite result is available for consistent report shape.

## Key changes

- `_write_report` gains a `raw_rewrite_output: str = ""` parameter; the section is emitted unconditionally after `## Body after` and before `## Interview transcript`
- `finalize_success` and `finalize_noop` both extract `rewrite_result.final_message` (defaulting to `""` when no rewrite result is present) and thread it through to `_write_report`
- Five new tests in `test_refine_finalize.py` covering success-path, noop-path, quadruple-backtick fence safety (with realistic `\`\`\`title`/`\`\`\`body` content), section ordering, and the no-rewrite-result edge case

## Closes

Closes #140

## Test plan

- [ ] Run `cog refine` on a real item, accept the proposed rewrite, open the report file — confirm `## Raw rewrite output` appears between `## Body after` and `## Interview transcript` containing the model's raw response
- [ ] Run `cog refine`, reject the proposed rewrite — confirm noop report also contains the section
- [ ] Inspect a report where the rewrite prompt produced ` ```title ` / ` ```body ` blocks — confirm they render verbatim inside the quadruple-backtick fence and the fence closes correctly

---
🤖 Generated by cog. Iteration cost: $2.017
