### PR TITLE
Sidebar: show queue counts next to Refine and Ralph labels (#157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,9 @@ Running `cog` with no args launches a Textual shell with four views:
 Workers persist across view switches — start a ralph run, flip to
 refine mid-work, come back and the log is caught up. A yellow `●` on
 a sidebar row indicates that view needs attention (interview awaiting
-reply, run complete, etc.).
+reply, run complete, etc.). Refine and Ralph rows also show a dim
+right-aligned queue count (items in their respective queues) so you
+can see queue depth without opening the Dashboard.
 
 ## Commands
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -134,8 +134,8 @@ with the log caught up.
 ┌──────────┬──────────────────────────────────────────────────┐
 │ sidebar  │ active view (content area)                       │
 │ ^1 Dash  │                                                  │
-│ ^2 Ref●  │  <DashboardView / RefineView / RalphView / ChatView>
-│ ^3 Ral   │                                                  │
+│ ^2 Ref●  3│  <DashboardView / RefineView / RalphView / ChatView>
+│ ^3 Ral   1│                                                  │
 │ ^4 Chat  │                                                  │
 └──────────┴──────────────────────────────────────────────────┘
  ^Q Quit
@@ -145,6 +145,10 @@ with the log caught up.
 - **Ctrl+Q** — quit (confirm if workflows in-flight)
 - Sidebar yellow `●` — attention indicator (refine awaiting reply, run
   complete, etc.)
+- Sidebar dim count — queue depth for Refine (`needs-refinement`) and
+  Ralph (`agent-ready`), refreshed on mount and whenever a view posts
+  `QueueCountsStale`. Owned by `CogShellScreen.queue_counts` reactive;
+  the Dashboard reads the same reactive instead of fetching independently.
 - Each view exposes `focus_content()` and `busy_description()` hooks
   the shell uses
 

--- a/src/cog/core/workflow.py
+++ b/src/cog/core/workflow.py
@@ -41,6 +41,7 @@ class Workflow(ABC):
     needs_item_picker: ClassVar[bool] = False
     preflight_checks: ClassVar[Sequence[PreflightCheck]] = ()
     content_widget_cls: ClassVar[type[Widget] | None] = None
+    count_assignee: ClassVar[str | None] = "@me"  # assignee scope for sidebar counts
 
     @abstractmethod
     async def select_item(self, ctx: ExecutionContext) -> Item | None:

--- a/src/cog/ui/messages.py
+++ b/src/cog/ui/messages.py
@@ -21,3 +21,7 @@ class ViewAttention(Message):
         self.view_id = view_id
         self.reason = reason
         super().__init__()
+
+
+class QueueCountsStale(Message):
+    """Posted by views when queue counts may have changed; shell refreshes."""

--- a/src/cog/ui/screens/shell.py
+++ b/src/cog/ui/screens/shell.py
@@ -19,16 +19,18 @@ from pathlib import Path
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal
+from textual.reactive import reactive
 from textual.screen import Screen
 from textual.widget import Widget
 from textual.widgets import Footer, Header, Label, ListItem, ListView, Static
 
 from cog.core.tracker import IssueTracker
-from cog.ui.messages import ViewAttention
+from cog.ui.messages import QueueCountsStale, ViewAttention
 from cog.ui.views.chat import ChatView
 from cog.ui.views.dashboard import DashboardView
 from cog.ui.views.ralph import RalphView
 from cog.ui.views.refine import RefineView
+from cog.workflows import WORKFLOWS
 
 
 @dataclass(frozen=True)
@@ -100,19 +102,30 @@ class Sidebar(Widget):
         super().__init__()
         self._views = tuple(views)
         self._attention: set[str] = set()
+        self._counts: dict[str, int | None] = {}
+
+    def on_mount(self) -> None:
+        if hasattr(self.screen, "queue_counts"):
+            self.watch(self.screen, "queue_counts", self._on_counts_changed)
+
+    def _on_counts_changed(self, counts: dict[str, int | None]) -> None:
+        self._counts = counts
+        for v in self._views:
+            self._rerender_row(v.id)
 
     def _label_for(self, v: ShellView) -> str:
-        # Left: view name + optional attention dot.
-        # Right: dim keybind hint (e.g. ^1).
-        # Use string padding so keybinds right-align within the row.
+        # Layout: [name + dot][padding][count slot (3)][space][keybind]
         dot = " [yellow]●[/yellow]" if v.id in self._attention else "  "
         name = f"{v.label}{dot}"
-        # Left-pad the keybind so it ends at the right edge.
         keybind = v.keybind.replace("ctrl+", "^")
-        # Strip markup chars when measuring width.
         visible_len = len(v.label) + 2  # name + dot/spacer
-        pad = max(1, self._ROW_CONTENT_WIDTH - visible_len - len(keybind))
-        return f"{name}{' ' * pad}[dim]{keybind}[/dim]"
+
+        count = self._counts.get(v.id)
+        count_slot = f"[dim]{count:>3}[/dim]" if count is not None else "   "
+
+        # Reserve 4 chars for count_slot (3) + gap (1), then right-align keybind.
+        pad = max(1, self._ROW_CONTENT_WIDTH - visible_len - 4 - len(keybind))
+        return f"{name}{' ' * pad}{count_slot} [dim]{keybind}[/dim]"
 
     def compose(self) -> ComposeResult:
         yield ListView(
@@ -157,6 +170,9 @@ class CogShellScreen(Screen):
     stay in the tree.
     """
 
+    # key: workflow.name ("ralph", "refine") | value: count or None (error/loading)
+    queue_counts: reactive[dict[str, int | None]] = reactive({})
+
     DEFAULT_CSS = """
     CogShellScreen {
         layout: vertical;
@@ -181,6 +197,22 @@ class CogShellScreen(Screen):
         self._tracker = tracker
         self._active_view_id: str = _VIEWS[0].id
 
+    async def refresh_queue_counts(self) -> None:
+        new_counts: dict[str, int | None] = {}
+        for workflow_cls in WORKFLOWS:
+            try:
+                items = await self._tracker.list_by_label(
+                    workflow_cls.queue_label,
+                    assignee=workflow_cls.count_assignee,
+                )
+                new_counts[workflow_cls.name] = len(items)
+            except Exception:  # noqa: BLE001
+                new_counts[workflow_cls.name] = None
+        self.queue_counts = new_counts
+
+    def on_queue_counts_stale(self, message: QueueCountsStale) -> None:
+        self.run_worker(self.refresh_queue_counts(), exclusive=True, group="queue_counts")
+
     def compose(self) -> ComposeResult:
         yield Header()
         with Horizontal(id="shell-body"):
@@ -195,6 +227,7 @@ class CogShellScreen(Screen):
     def on_mount(self) -> None:
         self._apply_active_view()
         self._highlight_sidebar_row(self._active_view_id)
+        self.run_worker(self.refresh_queue_counts(), exclusive=True, group="queue_counts")
 
     def action_quit_app(self) -> None:
         busy: list[str] = []

--- a/src/cog/ui/views/dashboard.py
+++ b/src/cog/ui/views/dashboard.py
@@ -23,6 +23,7 @@ import cog.git as git
 from cog.core.errors import GitError
 from cog.core.tracker import IssueTracker
 from cog.state_paths import project_state_dir
+from cog.ui.messages import QueueCountsStale
 from cog.ui.widgets.recent_runs import RecentRunsWidget
 from cog.workflows import WORKFLOWS
 
@@ -74,14 +75,20 @@ class DashboardView(Widget):
         yield RecentRunsWidget(self._project_dir)
 
     async def on_mount(self) -> None:
+        if hasattr(self.screen, "queue_counts"):
+            self.watch(self.screen, "queue_counts", self._render_queues)
         await self.refresh_all()
 
     async def on_show(self) -> None:
         # Textual fires Show when display toggles from False → True — i.e.
-        # when the user switches back to the dashboard tab. Refresh so the
-        # queue counts, cost totals, and recent runs reflect the latest
-        # state (workflow runs that happened while the dashboard was hidden).
-        await self.refresh_all()
+        # when the user switches back to the dashboard tab. Post stale signal
+        # so the shell refreshes queue counts; refresh non-queue data directly.
+        self.post_message(QueueCountsStale())
+        await asyncio.gather(
+            self._refresh_project_status(),
+            self._refresh_cost_totals(),
+            self._refresh_recent_runs(),
+        )
 
     async def refresh_all(self) -> None:
         await asyncio.gather(
@@ -120,19 +127,37 @@ class DashboardView(Widget):
         widget = self.query_one("#dashboard-status", Static)
         widget.update(f"branch: [bold]{branch}[/bold]  ·  {tree_line}")
 
+    def _render_queues(self, counts: dict[str, int | None]) -> None:
+        # Empty dict = shell hasn't run its initial fetch yet (the reactive's
+        # default fires through watch on mount). Distinct from "fetched but
+        # got None (error)" — only the latter renders a red ?.
+        if not counts:
+            return
+        lines: list[str] = []
+        for cls in WORKFLOWS:
+            count = counts.get(cls.name)
+            if count is None:
+                lines.append(f"  [red]?[/red] {cls.name}: error reading {cls.queue_label}")
+            else:
+                lines.append(f"  [bold]{count}[/bold] {cls.queue_label}  ([dim]{cls.name}[/dim])")
+        try:
+            widget = self.query_one("#dashboard-queues", Static)
+        except Exception:  # noqa: BLE001 — not yet mounted
+            return
+        widget.update("\n".join(lines))
+
     async def _refresh_queue_counts(self) -> None:
+        # Used when not inside CogShellScreen (e.g. standalone tests).
+        if hasattr(self.screen, "queue_counts"):
+            return
         results = await asyncio.gather(
             *(self._safe_count(w.queue_label) for w in WORKFLOWS),
             return_exceptions=True,
         )
-        lines: list[str] = []
-        for cls, count in zip(WORKFLOWS, results, strict=False):
-            if isinstance(count, BaseException):
-                lines.append(f"  [red]?[/red] {cls.name}: error reading {cls.queue_label}")
-            else:
-                lines.append(f"  [bold]{count}[/bold] {cls.queue_label}  ([dim]{cls.name}[/dim])")
-        widget = self.query_one("#dashboard-queues", Static)
-        widget.update("\n".join(lines))
+        counts: dict[str, int | None] = {}
+        for cls, result in zip(WORKFLOWS, results, strict=False):
+            counts[cls.name] = None if isinstance(result, BaseException) else result
+        self._render_queues(counts)
 
     async def _safe_count(self, label: str) -> int:
         items = await self._tracker.list_by_label(label)

--- a/src/cog/ui/views/ralph.py
+++ b/src/cog/ui/views/ralph.py
@@ -36,7 +36,7 @@ from cog.git.worktree import discard_worktree, is_dirty
 from cog.state import JsonFileStateCache
 from cog.state_paths import project_state_dir
 from cog.telemetry import TelemetryWriter
-from cog.ui.messages import ViewAttention
+from cog.ui.messages import QueueCountsStale, ViewAttention
 from cog.ui.picker import (
     PickerHistory,
     _format_assignees,
@@ -434,6 +434,7 @@ class RalphView(Widget, can_focus=True):
         self.call_after_refresh(self.focus_content)
         if substate == "post_run":
             self.post_message(ViewAttention("ralph", reason="run complete"))
+            self.post_message(QueueCountsStale())
 
     def _set_status(self, text: str) -> None:
         self.query_one("#ralph-status", Static).update(text)

--- a/src/cog/ui/views/refine.py
+++ b/src/cog/ui/views/refine.py
@@ -33,7 +33,7 @@ from cog.state import JsonFileStateCache
 from cog.state_paths import project_state_dir
 from cog.telemetry import TelemetryWriter
 from cog.ui.editor import suspend_and_edit
-from cog.ui.messages import ViewAttention
+from cog.ui.messages import QueueCountsStale, ViewAttention
 from cog.ui.picker import _format_assignees
 from cog.ui.widgets.chat_pane import ChatPaneWidget
 from cog.workflows.refine import RefineWorkflow, ReviewDecision, ReviewOutcome
@@ -296,6 +296,7 @@ class RefineView(Widget, can_focus=True):
         try:
             await StageExecutor().run(workflow, ctx)
             self._set_status(self._format_status("Completed", item=item))
+            self.post_message(QueueCountsStale())
         except Exception as e:  # noqa: BLE001
             self._set_status(
                 f"[red]{self._format_status('Failed', item=item, suffix=f': {e}')}[/red]"

--- a/tests/test_ui/test_shell.py
+++ b/tests/test_ui/test_shell.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -9,8 +10,9 @@ from textual.app import App
 from textual.widget import Widget
 from textual.widgets import ListView
 
+from cog.core.item import Item
 from cog.core.tracker import IssueTracker
-from cog.ui.messages import ViewAttention
+from cog.ui.messages import QueueCountsStale, ViewAttention
 from cog.ui.screens.shell import CogShellScreen, Sidebar
 from cog.ui.views.dashboard import DashboardView
 from cog.ui.views.ralph import RalphView
@@ -23,13 +25,42 @@ def _fake_tracker() -> IssueTracker:
     return t  # type: ignore[return-value]
 
 
+def _make_items(count: int) -> list[Item]:
+    return [
+        Item(
+            tracker_id="gh",
+            item_id=str(i),
+            title=f"item {i}",
+            body="",
+            labels=(),
+            comments=(),
+            state="open",
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+            url="",
+        )
+        for i in range(count)
+    ]
+
+
+def _tracker_with_counts(**label_counts: int) -> IssueTracker:
+    t = AsyncMock(spec=IssueTracker)
+
+    async def list_by_label(label: str, *, assignee: str | None = None) -> list[Item]:
+        return _make_items(label_counts.get(label, 0))
+
+    t.list_by_label = AsyncMock(side_effect=list_by_label)
+    return t  # type: ignore[return-value]
+
+
 class _ShellApp(App):
-    def __init__(self, project_dir: Path) -> None:
+    def __init__(self, project_dir: Path, tracker: IssueTracker | None = None) -> None:
         super().__init__()
         self._project_dir = project_dir
+        self._tracker = tracker or _fake_tracker()
 
     def on_mount(self) -> None:
-        self.push_screen(CogShellScreen(self._project_dir, _fake_tracker()))
+        self.push_screen(CogShellScreen(self._project_dir, self._tracker))
 
 
 async def test_shell_mounts_all_views_on_startup(tmp_path: Path) -> None:
@@ -337,3 +368,117 @@ async def test_sidebar_label_shows_dot_marker_when_attention_set(tmp_path: Path)
         ralph_row = sidebar.query_one("#nav-ralph")
         label = ralph_row.query_one("Label")
         assert "●" in str(label.renderable)
+
+
+# ---------------------------------------------------------------------------
+# Queue counts in sidebar (#157)
+# ---------------------------------------------------------------------------
+
+
+async def test_shell_refresh_queue_counts_populates_reactive(tmp_path: Path) -> None:
+    tracker = _tracker_with_counts(**{"agent-ready": 3, "needs-refinement": 7})
+    async with _ShellApp(tmp_path, tracker).run_test(headless=True) as pilot:
+        # Wait for the on_mount worker to finish.
+        for _ in range(5):
+            await pilot.pause()
+        screen = pilot.app.screen
+        assert isinstance(screen, CogShellScreen)
+        assert screen.queue_counts.get("ralph") == 3
+        assert screen.queue_counts.get("refine") == 7
+
+
+async def test_shell_refresh_queue_counts_sets_none_on_error(tmp_path: Path) -> None:
+    from cog.core.errors import TrackerError
+
+    t: IssueTracker = AsyncMock(spec=IssueTracker)
+
+    async def list_by_label(label: str, *, assignee: str | None = None) -> list[Item]:
+        if label == "agent-ready":
+            raise TrackerError("boom")
+        return _make_items(0)
+
+    t.list_by_label = AsyncMock(side_effect=list_by_label)  # type: ignore[attr-defined]
+
+    async with _ShellApp(tmp_path, t).run_test(headless=True) as pilot:
+        for _ in range(5):
+            await pilot.pause()
+        screen = pilot.app.screen
+        assert isinstance(screen, CogShellScreen)
+        assert screen.queue_counts.get("ralph") is None
+        assert screen.queue_counts.get("refine") == 0
+
+
+async def test_shell_queue_counts_stale_triggers_refresh(tmp_path: Path) -> None:
+    tracker = _tracker_with_counts(**{"agent-ready": 5})
+    async with _ShellApp(tmp_path, tracker).run_test(headless=True) as pilot:
+        for _ in range(5):
+            await pilot.pause()
+        screen = pilot.app.screen
+        assert isinstance(screen, CogShellScreen)
+        # Override tracker to return a new count.
+        tracker.list_by_label = AsyncMock(  # type: ignore[attr-defined]
+            side_effect=lambda label, *, assignee=None: _make_items(
+                9 if label == "agent-ready" else 1
+            )
+        )
+        screen.post_message(QueueCountsStale())
+        for _ in range(5):
+            await pilot.pause()
+        assert screen.queue_counts.get("ralph") == 9
+
+
+async def test_sidebar_renders_count_for_workflow_rows(tmp_path: Path) -> None:
+    async with _ShellApp(tmp_path).run_test(headless=True) as pilot:
+        await pilot.pause()
+        sidebar = pilot.app.query_one(Sidebar)
+        # Inject counts directly and re-render.
+        sidebar._counts = {"ralph": 5, "refine": 0}
+        sidebar._rerender_row("ralph")
+        sidebar._rerender_row("refine")
+        await pilot.pause()
+
+        ralph_label = sidebar.query_one("#nav-ralph").query_one("Label")
+        refine_label = sidebar.query_one("#nav-refine").query_one("Label")
+        assert "5" in str(ralph_label.renderable)
+        assert "0" in str(refine_label.renderable)
+
+
+async def test_sidebar_renders_blank_slot_for_none_count(tmp_path: Path) -> None:
+    async with _ShellApp(tmp_path).run_test(headless=True) as pilot:
+        await pilot.pause()
+        sidebar = pilot.app.query_one(Sidebar)
+        # None means loading/error — count slot should be blank (no digit).
+        sidebar._counts = {"ralph": None}
+        sidebar._rerender_row("ralph")
+        await pilot.pause()
+        ralph_label = sidebar.query_one("#nav-ralph").query_one("Label")
+        rendered = str(ralph_label.renderable)
+        # No digit in the count slot area — keybind still present.
+        assert "^3" in rendered
+
+
+async def test_sidebar_renders_blank_slot_for_non_workflow_rows(tmp_path: Path) -> None:
+    async with _ShellApp(tmp_path).run_test(headless=True) as pilot:
+        await pilot.pause()
+        sidebar = pilot.app.query_one(Sidebar)
+        # Dashboard row should never have a count digit even if _counts is populated.
+        sidebar._counts = {"ralph": 99, "refine": 1}
+        sidebar._rerender_row("dashboard")
+        await pilot.pause()
+        dash_label = sidebar.query_one("#nav-dashboard").query_one("Label")
+        rendered = str(dash_label.renderable)
+        assert "^1" in rendered
+        # 99 should not appear in the dashboard row.
+        assert "99" not in rendered
+
+
+async def test_sidebar_count_updates_via_reactive(tmp_path: Path) -> None:
+    tracker = _tracker_with_counts(**{"agent-ready": 4, "needs-refinement": 2})
+    async with _ShellApp(tmp_path, tracker).run_test(headless=True) as pilot:
+        for _ in range(5):
+            await pilot.pause()
+        sidebar = pilot.app.query_one(Sidebar)
+        ralph_label = sidebar.query_one("#nav-ralph").query_one("Label")
+        assert "4" in str(ralph_label.renderable)
+        refine_label = sidebar.query_one("#nav-refine").query_one("Label")
+        assert "2" in str(refine_label.renderable)


### PR DESCRIPTION
## Summary

Adds a dim, right-aligned 3-character count slot to each sidebar row so queue depth is always visible without switching to the Dashboard view.

**What changed and why:**

The `CogShellScreen` gets a new `queue_counts: reactive[dict[str, int | None]]` — the first use of Textual reactives in cog. On mount and whenever any view posts `QueueCountsStale`, the shell runs `refresh_queue_counts()` as an exclusive worker (`group="queue_counts"` so concurrent triggers collapse). The `Sidebar` subscribes via `self.watch(self.screen, "queue_counts", ...)` and re-renders all rows on change, inserting a formatted count slot (`"  3"`, `"  0"`, `"   "` for blank) between the name+dot and the keybind.

Ralph posts `QueueCountsStale` in `_switch_to("post_run")` (alongside the existing `ViewAttention`); refine posts it after a successful `StageExecutor().run()` (i.e., after the relabel). The dashboard delegates its queue panel to the same reactive instead of fetching directly, and its `on_show` now posts `QueueCountsStale` instead of calling `refresh_all()` for counts.

## Key changes

- New `queue_counts` reactive + `refresh_queue_counts()` + `on_queue_counts_stale()` on `CogShellScreen`; shell is the single source of truth for queue counts
- `Sidebar._label_for` updated to a 4-column layout: name+dot, padding, 3-char count slot, keybind; `on_mount` subscribes to the shell reactive
- `QueueCountsStale` message in `messages.py`; mirrors `ViewAttention` pattern
- `count_assignee: ClassVar[str | None] = "@me"` added to `Workflow` base class for scope control
- `DashboardView` delegates queue rendering to the shell reactive (`_render_queues` reads `queue_counts`); direct-fetch fallback preserved for standalone test scenarios
- Ralph and refine views post `QueueCountsStale` at the right moment (post-run / post-relabel)

## Closes

Closes #157

## Test plan

- [ ] Launch cog, open the Dashboard — verify Refine and Ralph rows show queue counts next to their keybinds
- [ ] With `needs-refinement` items in the queue, verify the Refine row shows the correct integer (e.g. `"  3"`)
- [ ] With zero `agent-ready` items, verify the Ralph row shows `"  0"`, not blank
- [ ] While on the Refine or Ralph view (not Dashboard), verify counts are still visible in the sidebar
- [ ] Start a ralph run, let it finish — verify the sidebar count updates (decrements if item got labeled `agent-failed`) without needing to switch views
- [ ] Finalize a refine session — verify both Refine count decrements and Ralph count increments in the sidebar
- [ ] Switch back to Dashboard after a workflow run — verify the Queues panel reflects the same counts as the sidebar
- [ ] Simulate a tracker error (bad token) — verify the count slot shows blank (`"   "`) for that workflow in the sidebar, while Dashboard shows the red `?` error with context
- [ ] Non-workflow rows (Dashboard, Chat) — verify their count slot is always blank, not a number

---
🤖 Generated by cog. Iteration cost: $5.562
