### PR TITLE
Ralph: persist claude's mid-run commentary in the iteration report (#165)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -162,7 +162,7 @@ directory name with non-alphanumerics replaced by `-`.
 |------|----------|
 | `state.json` | Processed / deferred item tracking. Processed entries are revived if the issue is edited after the record (`updated_at > ts`). |
 | `runs.jsonl` | One JSON line per workflow run — telemetry record. Append-only with fcntl locking. |
-| `reports/<ts>-<workflow>-<item-slug>.md` | Human-readable run report. Refine reports include the original body, proposed body, full interview transcript, and per-stage cost table. |
+| `reports/<ts>-<workflow>-<item-slug>.md` | Human-readable run report. Ralph reports include per-stage cost, iteration commentary (captured assistant-text turns, grouped by stage), and the final outcome. Refine reports include the original body, proposed body, full interview transcript, and per-stage cost table. |
 
 Ralph also writes worktrees inside the **project directory** (not the state dir):
 

--- a/docs/workflows/ralph.md
+++ b/docs/workflows/ralph.md
@@ -142,6 +142,25 @@ dashboard (Ctrl+1) mid-run and the log keeps streaming in the
 background. A yellow `●` appears on the Ralph sidebar row when the run
 finishes (attention indicator).
 
+## Iteration reports
+
+After each iteration ralph writes a markdown report to
+`$XDG_STATE_HOME/cog/<project-slug>/reports/<ts>-ralph-<slug>.md`
+(default: `~/.local/state/cog/<project-slug>/reports/`).
+
+Report sections (in order):
+
+| Section | Content |
+|---------|---------|
+| `## Item` | Item number, title, and URL |
+| `## Stages` | Per-stage cost, token counts, and duration |
+| `## Iteration commentary` | All text Claude emitted during stage execution, grouped by stage. Headings inside the commentary are demoted one level. Omitted if Claude produced no text output. |
+| `## Outcome` | Final outcome label and any error message |
+
+The commentary section is useful when running headless (`--headless`) — it
+lets you recover what Claude said about its decisions without having watched
+the live TUI pane.
+
 ## Related
 
 - [Architecture](../ARCHITECTURE.md) — harness internals and seams

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -30,7 +30,15 @@ from cog.core.errors import (
 from cog.core.host import GitHost, PrChecks, PullRequest
 from cog.core.item import Item
 from cog.core.outcomes import Outcome, StageResult
-from cog.core.runner import AgentRunner, StatusEvent
+from cog.core.runner import (
+    AgentRunner,
+    AssistantTextEvent,
+    RunEvent,
+    StageEndEvent,
+    StageStartEvent,
+    StatusEvent,
+)
+from cog.core.sinks import RunEventSink
 from cog.core.stage import Stage
 from cog.core.tracker import IssueTracker
 from cog.core.workflow import IterationOutcome, StageExecutor, Workflow
@@ -183,6 +191,49 @@ def _split_final_message(message: str) -> dict[str, str]:
     return sections
 
 
+_HEADING_DEMOTE_RE = re.compile(r"^(#+)(\s)", re.MULTILINE)
+
+
+def _demote_headings(text: str) -> str:
+    return _HEADING_DEMOTE_RE.sub(r"#\1\2", text)
+
+
+class CommentaryCapture:
+    """Wraps a RunEventSink and accumulates per-stage assistant-text turns."""
+
+    def __init__(self, inner: RunEventSink | None) -> None:
+        self._inner = inner
+        self._current_stage: str | None = None
+        self._turns: list[tuple[str, str]] = []  # (stage_name, text)
+
+    async def emit(self, event: RunEvent) -> None:
+        match event:
+            case StageStartEvent(stage_name=name):
+                self._current_stage = name
+            case StageEndEvent():
+                self._current_stage = None
+            case AssistantTextEvent(text=text):
+                if self._current_stage is not None and text.strip():
+                    self._turns.append((self._current_stage, text))
+        if self._inner is not None:
+            await self._inner.emit(event)
+
+    def render(self) -> str:
+        if not self._turns:
+            return ""
+        stages: list[str] = list(dict.fromkeys(stage for stage, _ in self._turns))
+        parts: list[str] = []
+        for stage in stages:
+            stage_turns = [t for s, t in self._turns if s == stage]
+            if not stage_turns:
+                continue
+            parts.append(f"### {stage}")
+            parts.append("")
+            parts.append("\n\n".join(_demote_headings(t) for t in stage_turns))
+            parts.append("")
+        return "\n".join(parts)
+
+
 class RalphWorkflow(Workflow):
     """Autonomous agent workflow."""
 
@@ -208,6 +259,7 @@ class RalphWorkflow(Workflow):
         self._ci_retries: dict[str, int] = {}
         # item_ids with known stuck (dirty/unregistered) worktrees — skipped during pick
         self._stuck_worktree_item_ids: set[str] = set()
+        self._commentary: CommentaryCapture | None = None
 
     async def _apply_orphan_scan(self, project_dir: Path) -> None:
         """Run orphan scan, label stuck items, and populate _stuck_worktree_item_ids."""
@@ -386,6 +438,8 @@ class RalphWorkflow(Workflow):
         ctx.work_branch = work_branch
         ctx.worktree_path = wt_path
         self._stuck_worktree_item_ids.discard(item.item_id)
+        self._commentary = CommentaryCapture(inner=ctx.event_sink)
+        ctx.event_sink = self._commentary
 
     async def _create_fresh_worktree(
         self, ctx: ExecutionContext, wt_path: Path, branch: str, default: str
@@ -426,6 +480,7 @@ class RalphWorkflow(Workflow):
         return _TeardownAction.PUSH_THEN_REMOVE_OR_STUCK if ahead else _TeardownAction.REMOVE
 
     async def iteration_end(self, ctx: ExecutionContext, outcome: IterationOutcome) -> None:
+        self._commentary = None
         wt_path, branch = ctx.worktree_path, ctx.work_branch
         if wt_path is None or not wt_path.exists() or branch is None:
             return
@@ -929,6 +984,12 @@ class RalphWorkflow(Workflow):
                     lines.append("")
             except Exception:
                 pass
+
+        if self._commentary is not None:
+            commentary_text = self._commentary.render()
+            if commentary_text:
+                lines.append("## Iteration commentary\n")
+                lines.append(commentary_text)
 
         lines.append(f"## Outcome\n\n**{outcome}**")
         if error:

--- a/tests/test_workflows/test_commentary_capture.py
+++ b/tests/test_workflows/test_commentary_capture.py
@@ -1,0 +1,236 @@
+"""Unit tests for CommentaryCapture."""
+
+from __future__ import annotations
+
+import pytest
+
+from cog.core.runner import (
+    AssistantTextEvent,
+    RunEvent,
+    StageEndEvent,
+    StageStartEvent,
+    ToolUseEvent,
+)
+from cog.workflows.ralph import CommentaryCapture
+from tests.fakes import RecordingEventSink
+
+# ---------------------------------------------------------------------------
+# render() with no turns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_render_empty_returns_empty_string() -> None:
+    cap = CommentaryCapture(inner=None)
+    assert cap.render() == ""
+
+
+@pytest.mark.asyncio
+async def test_render_with_only_stage_events_but_no_text_returns_empty() -> None:
+    cap = CommentaryCapture(inner=None)
+    await cap.emit(StageStartEvent(stage_name="build", model="m"))
+    await cap.emit(StageEndEvent(stage_name="build", cost_usd=0.0, exit_status=0))
+    assert cap.render() == ""
+
+
+# ---------------------------------------------------------------------------
+# Basic stage grouping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_stages_rendered_in_order() -> None:
+    cap = CommentaryCapture(inner=None)
+    await cap.emit(StageStartEvent(stage_name="build", model="m"))
+    await cap.emit(AssistantTextEvent(text="build note"))
+    await cap.emit(StageEndEvent(stage_name="build", cost_usd=0.0, exit_status=0))
+    await cap.emit(StageStartEvent(stage_name="review", model="m"))
+    await cap.emit(AssistantTextEvent(text="review note"))
+    await cap.emit(StageEndEvent(stage_name="review", cost_usd=0.0, exit_status=0))
+
+    rendered = cap.render()
+    build_pos = rendered.index("### build")
+    review_pos = rendered.index("### review")
+    assert build_pos < review_pos
+    assert "build note" in rendered
+    assert "review note" in rendered
+
+
+@pytest.mark.asyncio
+async def test_multiple_turns_within_stage_separated_by_blank_line() -> None:
+    cap = CommentaryCapture(inner=None)
+    await cap.emit(StageStartEvent(stage_name="build", model="m"))
+    await cap.emit(AssistantTextEvent(text="first"))
+    await cap.emit(AssistantTextEvent(text="second"))
+    await cap.emit(StageEndEvent(stage_name="build", cost_usd=0.0, exit_status=0))
+
+    rendered = cap.render()
+    assert "first\n\nsecond" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Drop rules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("text", ["", "   ", "\n\n", "\t  "])
+@pytest.mark.asyncio
+async def test_whitespace_only_text_is_dropped(text: str) -> None:
+    cap = CommentaryCapture(inner=None)
+    await cap.emit(StageStartEvent(stage_name="build", model="m"))
+    await cap.emit(AssistantTextEvent(text=text))
+    await cap.emit(StageEndEvent(stage_name="build", cost_usd=0.0, exit_status=0))
+
+    assert cap.render() == ""
+
+
+@pytest.mark.asyncio
+async def test_text_before_first_stage_start_is_dropped() -> None:
+    cap = CommentaryCapture(inner=None)
+    await cap.emit(AssistantTextEvent(text="pre-stage text"))
+    await cap.emit(StageStartEvent(stage_name="build", model="m"))
+    await cap.emit(AssistantTextEvent(text="in-stage text"))
+    await cap.emit(StageEndEvent(stage_name="build", cost_usd=0.0, exit_status=0))
+
+    rendered = cap.render()
+    assert "pre-stage text" not in rendered
+    assert "in-stage text" in rendered
+
+
+@pytest.mark.asyncio
+async def test_text_between_stages_is_dropped() -> None:
+    cap = CommentaryCapture(inner=None)
+    await cap.emit(StageStartEvent(stage_name="build", model="m"))
+    await cap.emit(AssistantTextEvent(text="build text"))
+    await cap.emit(StageEndEvent(stage_name="build", cost_usd=0.0, exit_status=0))
+    await cap.emit(AssistantTextEvent(text="between stages"))
+    await cap.emit(StageStartEvent(stage_name="review", model="m"))
+    await cap.emit(AssistantTextEvent(text="review text"))
+    await cap.emit(StageEndEvent(stage_name="review", cost_usd=0.0, exit_status=0))
+
+    rendered = cap.render()
+    assert "between stages" not in rendered
+    assert "build text" in rendered
+    assert "review text" in rendered
+
+
+@pytest.mark.asyncio
+async def test_text_after_final_stage_end_is_dropped() -> None:
+    cap = CommentaryCapture(inner=None)
+    await cap.emit(StageStartEvent(stage_name="build", model="m"))
+    await cap.emit(AssistantTextEvent(text="in-stage text"))
+    await cap.emit(StageEndEvent(stage_name="build", cost_usd=0.0, exit_status=0))
+    await cap.emit(AssistantTextEvent(text="post-stage text"))
+
+    rendered = cap.render()
+    assert "post-stage text" not in rendered
+    assert "in-stage text" in rendered
+
+
+@pytest.mark.asyncio
+async def test_stage_with_only_whitespace_turns_omits_heading() -> None:
+    cap = CommentaryCapture(inner=None)
+    await cap.emit(StageStartEvent(stage_name="build", model="m"))
+    await cap.emit(AssistantTextEvent(text="  "))
+    await cap.emit(StageEndEvent(stage_name="build", cost_usd=0.0, exit_status=0))
+
+    assert "### build" not in cap.render()
+
+
+# ---------------------------------------------------------------------------
+# Tool events pass-through but not buffered
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tool_use_event_forwarded_not_buffered() -> None:
+    inner = RecordingEventSink()
+    cap = CommentaryCapture(inner=inner)
+    await cap.emit(StageStartEvent(stage_name="build", model="m"))
+    tool_event = ToolUseEvent(tool="Read", input={"file_path": "/foo"})
+    await cap.emit(tool_event)
+    await cap.emit(StageEndEvent(stage_name="build", cost_usd=0.0, exit_status=0))
+
+    assert tool_event in inner.events
+    assert cap.render() == ""
+
+
+# ---------------------------------------------------------------------------
+# Inner sink receives all events
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_inner", [True, False])
+async def test_inner_sink_receives_all_events(use_inner: bool) -> None:
+    inner = RecordingEventSink() if use_inner else None
+    cap = CommentaryCapture(inner=inner)
+
+    events: list[RunEvent] = [
+        StageStartEvent(stage_name="build", model="m"),
+        AssistantTextEvent(text="hello"),
+        ToolUseEvent(tool="Read", input={}),
+        StageEndEvent(stage_name="build", cost_usd=0.0, exit_status=0),
+    ]
+    for e in events:
+        await cap.emit(e)
+
+    if use_inner:
+        assert inner is not None
+        assert inner.events == events
+
+
+# ---------------------------------------------------------------------------
+# Heading demotion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "input_text,expected_fragment",
+    [
+        ("# Title", "## Title"),
+        ("## Section", "### Section"),
+        ("### Sub", "#### Sub"),
+        ("see #42 and #100", "see #42 and #100"),  # inline # untouched
+        ("no heading here", "no heading here"),
+        ("```\n# code comment\n```", "```\n## code comment\n```"),  # line-anchored, acceptable
+    ],
+)
+async def test_heading_demotion(input_text: str, expected_fragment: str) -> None:
+    cap = CommentaryCapture(inner=None)
+    await cap.emit(StageStartEvent(stage_name="build", model="m"))
+    await cap.emit(AssistantTextEvent(text=input_text))
+    await cap.emit(StageEndEvent(stage_name="build", cost_usd=0.0, exit_status=0))
+
+    assert expected_fragment in cap.render()
+
+
+@pytest.mark.asyncio
+async def test_code_fence_bullets_blockquotes_pass_through() -> None:
+    text = "- item\n> quote\n```python\nprint('hi')\n```"
+    cap = CommentaryCapture(inner=None)
+    await cap.emit(StageStartEvent(stage_name="build", model="m"))
+    await cap.emit(AssistantTextEvent(text=text))
+    await cap.emit(StageEndEvent(stage_name="build", cost_usd=0.0, exit_status=0))
+
+    rendered = cap.render()
+    assert "- item" in rendered
+    assert "> quote" in rendered
+    assert "```python" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Intra-turn line breaks preserved
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_intra_turn_line_breaks_preserved() -> None:
+    cap = CommentaryCapture(inner=None)
+    await cap.emit(StageStartEvent(stage_name="build", model="m"))
+    await cap.emit(AssistantTextEvent(text="line one\nline two\nline three"))
+    await cap.emit(StageEndEvent(stage_name="build", cost_usd=0.0, exit_status=0))
+
+    rendered = cap.render()
+    assert "line one\nline two\nline three" in rendered

--- a/tests/test_workflows/test_ralph_finalization.py
+++ b/tests/test_workflows/test_ralph_finalization.py
@@ -10,8 +10,9 @@ import pytest
 from cog.core.context import ExecutionContext
 from cog.core.errors import HostError, StageError
 from cog.core.host import CheckRun, GitHost, PrChecks, PullRequest
+from cog.core.runner import AssistantTextEvent, StageEndEvent, StageStartEvent
 from cog.core.tracker import IssueTracker
-from cog.workflows.ralph import RalphWorkflow, _split_final_message
+from cog.workflows.ralph import CommentaryCapture, RalphWorkflow, _split_final_message
 from tests.fakes import InMemoryStateCache, RecordingEventSink, make_item, make_stage_result
 
 
@@ -995,3 +996,109 @@ async def test_finalize_error_telemetry_error_string_contains_cause(tmp_path: Pa
     record = tel.write.call_args.args[0]
     assert record.error is not None
     assert "runner exploded" in record.error
+
+
+# ---------------------------------------------------------------------------
+# Iteration commentary in report
+# ---------------------------------------------------------------------------
+
+
+async def _make_commentary_with_turns() -> CommentaryCapture:
+    cap = CommentaryCapture(inner=None)
+    await cap.emit(StageStartEvent(stage_name="build", model="m"))
+    await cap.emit(AssistantTextEvent(text="claude's build commentary"))
+    await cap.emit(StageEndEvent(stage_name="build", cost_usd=0.0, exit_status=0))
+    return cap
+
+
+@pytest.mark.parametrize("outcome", ["success", "noop", "error"])
+async def test_write_report_includes_commentary_section(tmp_path: Path, outcome: str) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    wf._commentary = await _make_commentary_with_turns()
+
+    report_path = await wf.write_report(ctx, [make_stage_result("build")], outcome)  # type: ignore[arg-type]
+    assert report_path is not None
+    content = report_path.read_text()
+    assert "## Iteration commentary" in content
+    assert "claude's build commentary" in content
+
+
+async def test_write_report_omits_commentary_section_when_no_turns(tmp_path: Path) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    wf._commentary = CommentaryCapture(inner=None)  # no turns emitted
+
+    report_path = await wf.write_report(ctx, [make_stage_result("build")], "success")
+    assert report_path is not None
+    content = report_path.read_text()
+    assert "## Iteration commentary" not in content
+
+
+async def test_write_report_omits_commentary_section_when_commentary_is_none(
+    tmp_path: Path,
+) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    wf._commentary = None
+
+    report_path = await wf.write_report(ctx, [make_stage_result("build")], "success")
+    assert report_path is not None
+    content = report_path.read_text()
+    assert "## Iteration commentary" not in content
+
+
+async def test_write_report_commentary_section_order(tmp_path: Path) -> None:
+    """Commentary appears after Stages/Commits and before Outcome."""
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    wf._commentary = await _make_commentary_with_turns()
+
+    report_path = await wf.write_report(ctx, [make_stage_result("build")], "success")
+    assert report_path is not None
+    content = report_path.read_text()
+
+    stages_pos = content.index("## Stages")
+    commentary_pos = content.index("## Iteration commentary")
+    outcome_pos = content.index("## Outcome")
+    assert stages_pos < commentary_pos < outcome_pos
+
+
+async def test_write_report_commentary_heading_demotion(tmp_path: Path) -> None:
+    """Headings in claude's text are demoted in the on-disk file."""
+    cap = CommentaryCapture(inner=None)
+    await cap.emit(StageStartEvent(stage_name="build", model="m"))
+    await cap.emit(AssistantTextEvent(text="# Top-level heading from claude"))
+    await cap.emit(StageEndEvent(stage_name="build", cost_usd=0.0, exit_status=0))
+
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    wf._commentary = cap
+
+    report_path = await wf.write_report(ctx, [make_stage_result("build")], "success")
+    assert report_path is not None
+    content = report_path.read_text()
+    assert "## Top-level heading from claude" in content
+    assert "# Top-level heading from claude" not in content.split("## Top-level")[0]
+
+
+async def test_write_report_commentary_subsection_per_stage(tmp_path: Path) -> None:
+    """Each stage with turns gets its own ### subsection."""
+    cap = CommentaryCapture(inner=None)
+    await cap.emit(StageStartEvent(stage_name="build", model="m"))
+    await cap.emit(AssistantTextEvent(text="build commentary"))
+    await cap.emit(StageEndEvent(stage_name="build", cost_usd=0.0, exit_status=0))
+    await cap.emit(StageStartEvent(stage_name="review", model="m"))
+    await cap.emit(AssistantTextEvent(text="review commentary"))
+    await cap.emit(StageEndEvent(stage_name="review", cost_usd=0.0, exit_status=0))
+
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    wf._commentary = cap
+
+    report_path = await wf.write_report(ctx, [make_stage_result("build")], "success")
+    assert report_path is not None
+    content = report_path.read_text()
+    assert "### build" in content
+    assert "### review" in content
+    assert content.index("### build") < content.index("### review")


### PR DESCRIPTION
## Summary

Added `CommentaryCapture` to `src/cog/workflows/ralph.py` — a decorator sink that wraps the existing `ctx.event_sink`, forwards every `RunEvent` to the inner sink verbatim, and accumulates `AssistantTextEvent` turns grouped by stage. `RalphWorkflow.iteration_start` now instantiates a `CommentaryCapture` and replaces `ctx.event_sink` with it; `iteration_end` clears it. `write_report` reads `self._commentary` and, when turns were captured, inserts a `## Iteration commentary` section (with `### {stage}` subsections, blank-line-separated paragraphs, and heading demotion) between the Commits section and Outcome section.

## Key changes

- New `CommentaryCapture` class + `_demote_headings` helper in `ralph.py`; workflow-local, not added to `core/`
- `iteration_start` wires `CommentaryCapture(inner=ctx.event_sink)` into the event stream; all existing sinks (TUI, headless) continue to receive events unchanged via the inner-sink forwarding
- `write_report` emits `## Iteration commentary` with per-stage `### {name}` subsections when turns exist; section is fully absent when empty
- `tests/test_workflows/test_commentary_capture.py` (new): 23 unit tests covering drop rules, stage grouping, heading demotion, inner-sink forwarding, code fence passthrough
- Integration tests added to `test_ralph_finalization.py`: section presence/absence, section ordering, heading demotion on disk, per-stage subsections, and all three outcomes

## Closes

Closes #165

## Test plan

- [ ] Run ralph on a real item; open the generated `<state>/reports/<ts>-ralph-*.md` file and verify `## Iteration commentary` appears with `### build` and `### review` subsections containing what claude said during those stages
- [ ] Confirm that any `# Heading` claude wrote appears as `## Heading` in the report (heading demotion)
- [ ] Run ralph on an item where claude emits no assistant text (e.g., a trivial noop); confirm `## Iteration commentary` is entirely absent from the report
- [ ] Confirm the TUI chat pane still shows live text as before (inner-sink forwarding unbroken)
- [ ] Confirm headless mode also captures commentary (no TUI sink, `inner=None` path)

---
🤖 Generated by cog. Iteration cost: $5.336
