### PR TITLE
DockerSandbox: pre-mark /work as a system-level safe.directory

### DIFF
--- a/src/cog/resources/Dockerfile
+++ b/src/cog/resources/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim-bookworm
 
 LABEL cog.fat-image="true"
-LABEL cog.image-version="2"
+LABEL cog.image-version="3"
 
 # Core system packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -44,3 +44,11 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
 # Writable HOME for --user $UID:$GID support
 RUN mkdir -p /tmp/cog-home && chmod 1777 /tmp/cog-home
 ENV HOME=/tmp/cog-home
+
+# Pre-mark /work as a safe git directory at the system level so claude doesn't
+# need to run `git config --add safe.directory /work` itself. /etc/gitconfig is
+# container-local; without this, claude's per-repo `git config` write leaks
+# into the host's bind-mounted .git/config and makes /work appear in the host
+# repo's safe.directory list — which then breaks every host-side git/gh call
+# with `fatal: Invalid path '/work': No such file or directory`.
+RUN git config --system --add safe.directory /work

--- a/src/cog/runners/docker_sandbox.py
+++ b/src/cog/runners/docker_sandbox.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from cog.core.errors import DockerImageBuildError, DockerUnavailableError, SandboxError
 
-_EXPECTED_IMAGE_VERSION = "2"
+_EXPECTED_IMAGE_VERSION = "3"
 
 
 def _read_bundled_dockerfile() -> bytes:


### PR DESCRIPTION
## Summary

Pre-configure `/work` as a system-level `safe.directory` inside the container at image-build time so claude doesn't need to add it itself, preventing pollution of the host's bind-mounted `.git/config`.

## Why

Claude inside the container runs `git config --add safe.directory /work` to suppress macOS Docker Desktop's "dubious ownership" warning on the bind-mounted repo. Without `--global`, the write goes to the *local* `.git/config` — which IS the host's bind-mounted `.git/config`. Once polluted, every host-side `git` / `gh` call fails with:

```
fatal: Invalid path '/work': No such file or directory
```

This blocks ralph's failure-handling paths (e.g., `tracker.ensure_label("agent-failed", ...)`), turning a recoverable iteration failure into a hard runtime error. Real-world hit on PR #159's iteration runs.

A related but distinct pollution mode is claude running `git config core.worktree /work/.cog/worktrees/<slug>` inside a worktree, which leaks the same way and breaks the host repo's working-tree resolution. The same root cause; fixing this one stops new pollution. Existing pollution still needs manual cleanup (see below).

## What changed

- `src/cog/resources/Dockerfile`: added `RUN git config --system --add safe.directory /work` after the `HOME` setup. `/etc/gitconfig` is container-local — not bind-mounted — so the entry stays inside the container and claude has no reason to add its own. Bumped `cog.image-version` label from `2` to `3` so users get a one-time image rebuild.
- `src/cog/runners/docker_sandbox.py`: bumped `_EXPECTED_IMAGE_VERSION` to `3` to match.

## Test plan

- [x] `uv run pytest` (1115 passed, 3 skipped — docker integration tests)
- [x] `uv run mypy src` (clean)
- [x] `uv run ruff check .` and `uv run ruff format --check .` (clean)
- [ ] On merge: users with already-polluted `.git/config` need to clean up manually (one-time, not blocked by this PR):
  ```
  git -C <repo> config --unset-all safe.directory
  # plus remove any `worktree = /work/...` line in .git/config [core] if present
  ```

## Out of scope

- Cleaning up existing host-side pollution. Per-user one-time cleanup; could be folded into a `cog doctor` check as a follow-up.
- Solving the analogous `core.worktree` pollution path. Same root cause; this PR's fix removes the reason claude would touch the config in the first place. If `core.worktree` issues persist, file as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)