### PR TITLE
Sidebar: move hotkey label to the left of the view name (#182)

### DIFF
--- a/src/cog/ui/screens/shell.py
+++ b/src/cog/ui/screens/shell.py
@@ -114,18 +114,18 @@ class Sidebar(Widget):
             self._rerender_row(v.id)
 
     def _label_for(self, v: ShellView) -> str:
-        # Layout: [name + dot][padding][count slot (3)][space][keybind]
+        # Layout: [keybind][space][name + dot][padding][count slot (3)]
         dot = " [yellow]●[/yellow]" if v.id in self._attention else "  "
         name = f"{v.label}{dot}"
         keybind = v.keybind.replace("ctrl+", "^")
-        visible_len = len(v.label) + 2  # name + dot/spacer
+        visible_name_len = len(v.label) + 2  # name + dot/spacer
 
         count = self._counts.get(v.id)
         count_slot = f"[dim]{count:>3}[/dim]" if count is not None else "   "
 
-        # Reserve 4 chars for count_slot (3) + gap (1), then right-align keybind.
-        pad = max(1, self._ROW_CONTENT_WIDTH - visible_len - 4 - len(keybind))
-        return f"{name}{' ' * pad}{count_slot} [dim]{keybind}[/dim]"
+        # Reserve len(keybind) + 1 (gap) on the left, 3 for count slot on the right.
+        pad = max(1, self._ROW_CONTENT_WIDTH - len(keybind) - 1 - visible_name_len - 3)
+        return f"[dim]{keybind}[/dim] {name}{' ' * pad}{count_slot}"
 
     def compose(self) -> ComposeResult:
         yield ListView(

--- a/tests/test_ui/test_shell.py
+++ b/tests/test_ui/test_shell.py
@@ -443,6 +443,22 @@ async def test_sidebar_renders_count_for_workflow_rows(tmp_path: Path) -> None:
         assert "0" in str(refine_label.renderable)
 
 
+async def test_sidebar_row_layout_keybind_left_count_right(tmp_path: Path) -> None:
+    """Pin the sidebar layout: keybind on the left, count on the right."""
+    async with _ShellApp(tmp_path).run_test(headless=True) as pilot:
+        await pilot.pause()
+        sidebar = pilot.app.query_one(Sidebar)
+        sidebar._counts = {"ralph": 7}
+        sidebar._rerender_row("ralph")
+        await pilot.pause()
+
+        rendered = str(sidebar.query_one("#nav-ralph").query_one("Label").renderable)
+        keybind_idx = rendered.index("^3")
+        name_idx = rendered.index("Ralph")
+        count_idx = rendered.index("7")
+        assert keybind_idx < name_idx < count_idx
+
+
 async def test_sidebar_renders_blank_slot_for_none_count(tmp_path: Path) -> None:
     async with _ShellApp(tmp_path).run_test(headless=True) as pilot:
         await pilot.pause()


### PR DESCRIPTION
## Summary

Updated `_label_for` in `src/cog/ui/screens/shell.py` to place the keybind at the left of each sidebar row and the count slot at the right. The keybind is a static fixture that doesn't change at runtime; moving it left as a permanent index label makes the count — the only dynamic element — more prominent at the right edge where the eye scans for state changes.

## Key changes

- `_label_for` in `Sidebar` now uses layout `[keybind][space][name + dot][padding][count slot (3)]` instead of `[name + dot][padding][count slot (3)][space][keybind]`
- Padding math adjusted: reserves `len(keybind) + 1` on the left and `3` for the count slot on the right (same `max(1, ...)` guard)

## Closes

Closes #182

## Test plan

- [ ] Launch cog TUI and verify sidebar rows show keybind (e.g. `^1`) at the left and view name to its right
- [ ] Verify count appears right-aligned at the end of rows that have one (Ralph, Refine)
- [ ] Verify rows without a count (Dashboard, Chat) show blank right edge — no keybind artifact at the end
- [ ] Set attention on a view and confirm the dot `●` still appears adjacent to the view name (not displaced)
- [ ] Verify total row width is unchanged — no clipping or overflow in the sidebar panel

---
🤖 Generated by cog. Iteration cost: $1.964
