### PR TITLE
Refine review: wrap proposed body in ScrollableContainer so long bodies are scrollable (#184)

### DIFF
--- a/src/cog/ui/views/refine.py
+++ b/src/cog/ui/views/refine.py
@@ -333,8 +333,10 @@ class RefineView(Widget, can_focus=True):
         right = self.query_one("#refine-right", Container)
         if self._chat_pane is not None:
             self._chat_pane.display = False
+        proposed_scroll = ScrollableContainer(id="review-proposed-scroll")
+        await right.mount(proposed_scroll)
         proposed = Static("", id="review-proposed-body")
-        await right.mount(proposed)
+        await proposed_scroll.mount(proposed)
         proposed.update(Markdown(str(proposed_body) or "*(empty)*"))
 
         self._render_title_strip(original_title, proposed_title)
@@ -347,9 +349,9 @@ class RefineView(Widget, can_focus=True):
             outcome = await self._review_future
         finally:
             self._review_future = None
-            # Restore: remove proposed body, unhide chat pane (instance preserved).
+            # Restore: remove proposed scroll wrapper, unhide chat pane (instance preserved).
             try:
-                await self.query_one("#review-proposed-body", Static).remove()
+                await self.query_one("#review-proposed-scroll", ScrollableContainer).remove()
             except Exception:  # noqa: BLE001
                 pass
             if self._chat_pane is not None:

--- a/tests/test_ui/test_refine_view.py
+++ b/tests/test_ui/test_refine_view.py
@@ -182,6 +182,73 @@ async def test_refine_view_review_panes_populated_with_bodies(
         await task
 
 
+async def test_refine_view_review_proposed_body_in_scrollable_container(
+    tmp_path: Path, xdg_state: Path
+) -> None:
+    from textual.containers import ScrollableContainer
+
+    tracker = _tracker_with([])
+    async with _RefineApp(tmp_path, tracker).run_test(headless=True) as pilot:
+        await pilot.pause()
+        view = pilot.app.query_one(RefineView)
+
+        long_body = "\n".join(f"Line {i}" for i in range(120))
+        task = asyncio.create_task(
+            view.review(
+                original_title="t",
+                original_body="o",
+                proposed_title="t",
+                proposed_body=long_body,
+                tmp_dir=tmp_path,
+            )
+        )
+        for _ in range(10):
+            await asyncio.sleep(0)
+
+        # The proposed body Static must be inside a ScrollableContainer
+        scroll = view.query_one("#review-proposed-scroll", ScrollableContainer)
+        prop = scroll.query_one("#review-proposed-body", Static)
+        assert prop is not None
+
+        # The scroll wrapper is removed after review completes
+        view.action_review_accept()
+        await task
+        assert len(view.query("#review-proposed-scroll")) == 0
+
+
+async def test_refine_view_review_edit_updates_proposed_body_in_scroll(
+    tmp_path: Path, xdg_state: Path
+) -> None:
+    from unittest.mock import patch
+
+    tracker = _tracker_with([])
+    async with _RefineApp(tmp_path, tracker).run_test(headless=True) as pilot:
+        await pilot.pause()
+        view = pilot.app.query_one(RefineView)
+
+        task = asyncio.create_task(
+            view.review(
+                original_title="t",
+                original_body="o",
+                proposed_title="t",
+                proposed_body="original proposed",
+                tmp_dir=tmp_path,
+            )
+        )
+        for _ in range(10):
+            await asyncio.sleep(0)
+
+        # Edit action must still find and update #review-proposed-body
+        with patch("cog.ui.views.refine.suspend_and_edit", return_value="edited proposed"):
+            await view.action_review_edit()
+
+        prop = view.query_one("#review-proposed-body", Static)
+        assert "edited proposed" in prop.renderable.markup  # type: ignore[attr-defined]
+
+        view.action_review_accept()
+        await task
+
+
 async def test_refine_view_chat_pane_instance_preserved_across_review_swap(
     tmp_path: Path, xdg_state: Path
 ) -> None:


### PR DESCRIPTION
## Summary

The refine review screen showed an asymmetry: the left pane (original body) was wrapped in a `ScrollableContainer` but the right pane (proposed body) was just a plain `Static` mounted directly into a non-scrollable `Container`. Long proposed bodies were silently clipped. The fix mounts a `ScrollableContainer` (`#review-proposed-scroll`) into `#refine-right` at review time, nests the `Static` inside it, and removes the wrapper on review completion. The `#refine-right` container itself stays a plain `Container` during running-state so the chat pane's internal scrolling is unaffected.

## Key changes

- `refine.py` mount path: adds `ScrollableContainer(id="review-proposed-scroll")` between `#refine-right` and `#review-proposed-body`
- `refine.py` unmount path: removes `#review-proposed-scroll` (which removes `#review-proposed-body` with it) instead of querying the inner Static directly
- Two new UI tests: one asserts the proposed body is inside a `ScrollableContainer` and the wrapper is gone post-review; one asserts the edit action still finds and updates `#review-proposed-body` through the extra nesting level

## Closes

Closes #184

## Test plan

- [ ] Start `cog refine`, run the interview through to the review screen with a proposal longer than the pane height — verify the right pane scrolls independently
- [ ] Press `e` during review, edit the body in the editor — verify the proposed pane updates with the edited content
- [ ] Accept or abandon the review — verify the proposed scroll wrapper is removed and the chat pane reappears normally for the next run

---
🤖 Generated by cog. Iteration cost: $2.063
