### PR TITLE
Sidebar counts: drop the @me filter so they match what the view actually shows (#185)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -109,12 +109,12 @@ ctx)` per iteration with a fresh `ExecutionContext`.
 - **Deferred items aren't labels.** Ralph parses `blocked by #N` /
   `depends on #N` from body + comments; defers via `state.json` until
   blockers close. No tracker-visible state change.
-- **`@me` filter is intentionally split.** Interactive picker-flow
-  surfaces (ralph queue list, refine queue list, dashboard counts) show
-  team-wide items so users can see shared work. The autonomous ralph
-  selection loop (`RalphWorkflow.select_item`) and its state-recovery
-  counterpart (`state.py:recover_from_remote`) keep `assignee="@me"` so
-  ralph never auto-implements a teammate's item without explicit opt-in.
+- **`@me` filter applies only to autonomous selection.** All UI surfaces
+  (ralph queue list, refine queue list, sidebar counts) show team-wide
+  items so counts and views stay in sync. The autonomous ralph selection
+  loop (`RalphWorkflow.select_item`) and its state-recovery counterpart
+  (`state.py:recover_from_remote`) keep `assignee="@me"` so ralph never
+  auto-implements a teammate's item without explicit opt-in.
 - **Refine runs only in Textual mode.** Requires an ItemPicker. Headless
   refine errors out by design (no way to do interactive chat without a
   UI).

--- a/src/cog/core/workflow.py
+++ b/src/cog/core/workflow.py
@@ -41,7 +41,6 @@ class Workflow(ABC):
     needs_item_picker: ClassVar[bool] = False
     preflight_checks: ClassVar[Sequence[PreflightCheck]] = ()
     content_widget_cls: ClassVar[type[Widget] | None] = None
-    count_assignee: ClassVar[str | None] = "@me"  # assignee scope for sidebar counts
 
     @abstractmethod
     async def select_item(self, ctx: ExecutionContext) -> Item | None:

--- a/src/cog/ui/screens/shell.py
+++ b/src/cog/ui/screens/shell.py
@@ -201,10 +201,7 @@ class CogShellScreen(Screen):
         new_counts: dict[str, int | None] = {}
         for workflow_cls in WORKFLOWS:
             try:
-                items = await self._tracker.list_by_label(
-                    workflow_cls.queue_label,
-                    assignee=workflow_cls.count_assignee,
-                )
+                items = await self._tracker.list_by_label(workflow_cls.queue_label)
                 new_counts[workflow_cls.name] = len(items)
             except Exception:  # noqa: BLE001
                 new_counts[workflow_cls.name] = None

--- a/tests/test_ui/test_shell.py
+++ b/tests/test_ui/test_shell.py
@@ -387,6 +387,21 @@ async def test_shell_refresh_queue_counts_populates_reactive(tmp_path: Path) -> 
         assert screen.queue_counts.get("refine") == 7
 
 
+async def test_shell_refresh_queue_counts_no_assignee_filter(tmp_path: Path) -> None:
+    """Sidebar counts fetch all items in the queue, not just @me-assigned ones."""
+    t: IssueTracker = AsyncMock(spec=IssueTracker)
+    t.list_by_label = AsyncMock(return_value=_make_items(4))  # type: ignore[attr-defined]
+
+    async with _ShellApp(tmp_path, t).run_test(headless=True) as pilot:
+        for _ in range(5):
+            await pilot.pause()
+        screen = pilot.app.screen
+        assert isinstance(screen, CogShellScreen)
+        # Verify list_by_label was called without an assignee keyword argument.
+        for call in t.list_by_label.call_args_list:
+            assert "assignee" not in call.kwargs
+
+
 async def test_shell_refresh_queue_counts_sets_none_on_error(tmp_path: Path) -> None:
     from cog.core.errors import TrackerError
 


### PR DESCRIPTION
## Summary

Removed the `count_assignee = "@me"` class attribute from `Workflow` and dropped the `assignee` kwarg from `refresh_queue_counts` in `shell.py`. Sidebar counts now call `list_by_label` without an assignee filter, so they match exactly what the Ralph/Refine views show — all items with the queue label, regardless of who they're assigned to.

## Key changes

- Removed `count_assignee: ClassVar[str | None] = "@me"` from `Workflow` base class in `core/workflow.py` — no subclasses override it, so the removal is clean
- `refresh_queue_counts` in `shell.py` now calls `self._tracker.list_by_label(workflow_cls.queue_label)` with no assignee filter
- Added `test_shell_refresh_queue_counts_no_assignee_filter` to assert that `list_by_label` is called without an `assignee` kwarg in the sidebar count path

## Closes

Closes #185

## Test plan

- [ ] With an `agent-ready` item that has no assignees (e.g. #178), run `cog` and verify the Ralph sidebar count shows `1`, matching the count shown in the Ralph view
- [ ] Verify the Refine sidebar count also matches the Refine view's item count
- [ ] Confirm that `cog ralph --headless` still only picks up `@me`-assigned items (that filter lives in `RalphWorkflow.select_item`, which was not changed)

---
🤖 Generated by cog. Iteration cost: $1.812
