### PR TITLE
Restructure ralph prompts so review/document update the PR description, including a new Follow-up items section (#178)

### DIFF
--- a/docs/workflows/ralph.md
+++ b/docs/workflows/ralph.md
@@ -35,13 +35,36 @@ flowchart TD
 |-------|---------------|---------|
 | `build` | `claude-sonnet-4-6` | Implement the change + write tests |
 | `review` | `claude-opus-4-7` | Review build output; fix issues found |
-| `document` | `claude-sonnet-4-6` | Update docs / comments. Failures don't abort the iteration — they're reported in the PR body |
+| `document` | `claude-sonnet-4-6` | Update docs / comments. Failures don't abort the iteration — they're flagged in the PR body |
 
 Override each via `COG_RALPH_BUILD_MODEL` / `COG_RALPH_REVIEW_MODEL` /
 `COG_RALPH_DOCUMENT_MODEL`.
 
 Prompts live in [`src/cog/prompts/claude/ralph/`](../../src/cog/prompts/claude/ralph/)
 as markdown. Change prompt behavior by editing the markdown, not Python.
+
+## PR body
+
+Each main stage ends its final message with four structured sections that
+ralph extracts into the PR body:
+
+| Section | Source priority | Description |
+|---------|-----------------|-------------|
+| `## Summary` | document → review → build | 2–4 sentence description of what changed and why |
+| `## Key changes` | document → review → build | Conceptual bullet list for the reviewer |
+| `## Test plan` | document → review → build | Manual verification checklist |
+| `## Follow-up items` | all stages, aggregated | Items noticed during THIS stage that don't fit the above |
+
+**Source priority** means ralph uses the first non-empty value found,
+checking document then review then build. Review and document stages
+default to copying the build stage's sections forward verbatim unless
+they have something to correct or add.
+
+**Follow-up items** are cumulative: ralph collects each stage's
+`### Follow-up items` block and appends them all under one
+`## Follow-up items` section in the PR body. Each stage only lists items
+it noticed — do not copy items from earlier stages or they will be
+duplicated.
 
 ## Outcomes
 

--- a/src/cog/prompts/claude/ralph/build.md
+++ b/src/cog/prompts/claude/ralph/build.md
@@ -112,15 +112,23 @@ only if they represent distinct logical moves (e.g., "refactor X" then
 
 ## Final message format
 
-End your final message with three structured sections in this order:
-`### Summary`, `### Key changes`, `### Test plan`. The wrapper extracts
-each section into the PR body; keeping them structured is load-bearing.
+End your final message with four structured sections in this order:
+`### Summary`, `### Key changes`, `### Test plan`, `### Follow-up items`.
+The wrapper extracts each section into the PR body; keeping them structured
+is load-bearing.
+
+These sections describe what this PR adds against the base branch, not
+what you did this iteration. Fill in each section based on the work done.
 
 ### Summary
 
 2–4 sentences explaining WHAT changed and WHY — enough for a reviewer to
 understand the PR without reading the diff. Focus on intent and the
 approach chosen; the code shows the details.
+
+If you made a judgment call between options where reviewer input would help
+(timeouts, retry counts, naming, scoping decisions), call it out so the
+reviewer can validate.
 
 Example:
 ```
@@ -192,6 +200,20 @@ Example format:
 - [ ] Toggle skip on for breakfast, save, reload — confirm it persists
 - [ ] Verify skipped meals don't appear on the weekly planner
 ```
+
+### Follow-up items
+
+Optional. If you noticed anything during this iteration the reviewer
+should know about — but doesn't fit Summary / Key changes / Test plan —
+list each as a bullet. Examples:
+
+  - The test you wrote depends on a flaky external service
+  - An unrelated bug you noticed in foo.py
+  - A workaround you took because the proper fix would balloon the PR
+  - Something worth filing as its own follow-up issue (e.g., "the
+    `_compute_cost` divide-by-zero in telemetry.py deserves its own fix")
+
+Skip this section entirely if there is nothing worth flagging.
 
 ## Git rules (hard)
 

--- a/src/cog/prompts/claude/ralph/ci_fix.md
+++ b/src/cog/prompts/claude/ralph/ci_fix.md
@@ -44,6 +44,17 @@ Consult the project's CLAUDE.md for the specific commands this project uses.
 Commit exactly once when the fix passes the full suite. If you cannot
 reproduce or fix the failure, exit without committing.
 
+## Final message format
+
+End your final message with `### Follow-up items` if there is anything
+the reviewer should know about:
+
+  - Something you noticed that doesn't fit the CI fix itself
+  - A workaround you took because the proper fix would balloon scope
+  - Something worth filing as its own follow-up issue
+
+Skip this section entirely if there is nothing worth flagging.
+
 ## Git rules (hard)
 
 - Make commits locally; do not push them. The wrapper pushes the branch.

--- a/src/cog/prompts/claude/ralph/document.md
+++ b/src/cog/prompts/claude/ralph/document.md
@@ -64,6 +64,36 @@ has been observed to hang indefinitely. To avoid this:
 - Prefer per-file inspection via `Read <file>` over patch-level inspection
   via `git diff`.
 
+## Final message format
+
+End your final message with four structured sections in this order:
+`### Summary`, `### Key changes`, `### Test plan`, `### Follow-up items`.
+The wrapper extracts each section into the PR body.
+
+These sections describe what this PR adds against the base branch, not
+what you did this iteration. Default to copying each section forward
+verbatim from the prior stages' output. Update a section only if there
+is inaccurate or missing information a reviewer needs to understand the
+scope of changes to be merged.
+
+If you made a judgment call between options where reviewer input would
+help (timeouts, retry counts, naming, scoping decisions), call it out in
+Summary so the reviewer can validate.
+
+### Follow-up items
+
+Optional. If you noticed anything during this iteration the reviewer
+should know about — but doesn't fit Summary / Key changes / Test plan —
+list each as a bullet. Examples:
+
+  - The test you wrote depends on a flaky external service
+  - An unrelated bug you noticed in foo.py
+  - A workaround you took because the proper fix would balloon the PR
+  - Something worth filing as its own follow-up issue (e.g., "the
+    `_compute_cost` divide-by-zero in telemetry.py deserves its own fix")
+
+Skip this section entirely if there is nothing worth flagging.
+
 ## Git rules (hard)
 
 - Make commits locally; do not push them.

--- a/src/cog/prompts/claude/ralph/document.md
+++ b/src/cog/prompts/claude/ralph/document.md
@@ -70,11 +70,11 @@ End your final message with four structured sections in this order:
 `### Summary`, `### Key changes`, `### Test plan`, `### Follow-up items`.
 The wrapper extracts each section into the PR body.
 
-These sections describe what this PR adds against the base branch, not
-what you did this iteration. Default to copying each section forward
-verbatim from the prior stages' output. Update a section only if there
-is inaccurate or missing information a reviewer needs to understand the
-scope of changes to be merged.
+For Summary, Key changes, and Test plan: these describe what this PR
+adds against the base branch, not what you did this iteration. Default
+to copying each section forward verbatim from the prior stages' output.
+Update a section only if there is inaccurate or missing information a
+reviewer needs to understand the scope of changes to be merged.
 
 If you made a judgment call between options where reviewer input would
 help (timeouts, retry counts, naming, scoping decisions), call it out in
@@ -82,9 +82,12 @@ Summary so the reviewer can validate.
 
 ### Follow-up items
 
-Optional. If you noticed anything during this iteration the reviewer
-should know about — but doesn't fit Summary / Key changes / Test plan —
-list each as a bullet. Examples:
+Optional. List only items you noticed during THIS stage. The wrapper
+appends follow-up items from prior stages automatically — do NOT copy
+them forward, or they will be duplicated in the PR body.
+
+Use this section for anything the reviewer should know about that
+doesn't fit Summary / Key changes / Test plan. Examples:
 
   - The test you wrote depends on a flaky external service
   - An unrelated bug you noticed in foo.py

--- a/src/cog/prompts/claude/ralph/rebase.md
+++ b/src/cog/prompts/claude/ralph/rebase.md
@@ -33,3 +33,13 @@ has been observed to hang indefinitely. To avoid this:
   `head -c 30000` or equivalent defensively.
 - Use `Read <file>` to inspect specific conflict files rather than broad
   shell expansions.
+
+## Final message format
+
+End your final message with `### Follow-up items` if you noticed anything
+during the rebase the reviewer should know about:
+
+  - A conflict resolution that involved a judgment call
+  - Something worth flagging that doesn't belong in the main PR sections
+
+Skip this section entirely if there is nothing worth flagging.

--- a/src/cog/prompts/claude/ralph/review.md
+++ b/src/cog/prompts/claude/ralph/review.md
@@ -104,11 +104,11 @@ End your final message with four structured sections in this order:
 `### Summary`, `### Key changes`, `### Test plan`, `### Follow-up items`.
 The wrapper extracts each section into the PR body.
 
-These sections describe what this PR adds against the base branch, not
-what you did this iteration. Default to copying each section forward
-verbatim from the build stage's output. Update a section only if there
-is inaccurate or missing information a reviewer needs to understand the
-scope of changes to be merged.
+For Summary, Key changes, and Test plan: these describe what this PR
+adds against the base branch, not what you did this iteration. Default
+to copying each section forward verbatim from the build stage's output.
+Update a section only if there is inaccurate or missing information a
+reviewer needs to understand the scope of changes to be merged.
 
 If you made a judgment call between options where reviewer input would
 help (timeouts, retry counts, naming, scoping decisions), call it out in
@@ -116,9 +116,12 @@ Summary so the reviewer can validate.
 
 ### Follow-up items
 
-Optional. If you noticed anything during this iteration the reviewer
-should know about — but doesn't fit Summary / Key changes / Test plan —
-list each as a bullet. Examples:
+Optional. List only items you noticed during THIS stage. The wrapper
+appends follow-up items from prior stages automatically — do NOT copy
+build's follow-ups forward, or they will be duplicated in the PR body.
+
+Use this section for anything the reviewer should know about that
+doesn't fit Summary / Key changes / Test plan. Examples:
 
   - The test you wrote depends on a flaky external service
   - An unrelated bug you noticed in foo.py

--- a/src/cog/prompts/claude/ralph/review.md
+++ b/src/cog/prompts/claude/ralph/review.md
@@ -48,8 +48,10 @@ file; pipe through `head -c 30000` or use `--jq` to stay bounded.
    implementation against the acceptance criteria.
 6. Identify any defects, missing coverage, or style violations.
 7. Fix what you can directly. Commit fixes with clear messages.
-8. In your final message, list any remaining concerns that require human
-   attention (things you couldn't fix, architectural trade-offs, etc.).
+8. End your final message with the four structured sections described
+   below. Put any remaining concerns that require human attention (things
+   you couldn't fix, architectural trade-offs, etc.) under
+   `### Follow-up items`.
 
 ## Bounded tool calls (important)
 
@@ -95,6 +97,36 @@ Consult the project's CLAUDE.md for the specific commands (test runner,
 type checker, linter) this project uses. If CLAUDE.md doesn't list them,
 infer from the project's config files (pyproject.toml, package.json,
 go.mod, etc.).
+
+## Final message format
+
+End your final message with four structured sections in this order:
+`### Summary`, `### Key changes`, `### Test plan`, `### Follow-up items`.
+The wrapper extracts each section into the PR body.
+
+These sections describe what this PR adds against the base branch, not
+what you did this iteration. Default to copying each section forward
+verbatim from the build stage's output. Update a section only if there
+is inaccurate or missing information a reviewer needs to understand the
+scope of changes to be merged.
+
+If you made a judgment call between options where reviewer input would
+help (timeouts, retry counts, naming, scoping decisions), call it out in
+Summary so the reviewer can validate.
+
+### Follow-up items
+
+Optional. If you noticed anything during this iteration the reviewer
+should know about — but doesn't fit Summary / Key changes / Test plan —
+list each as a bullet. Examples:
+
+  - The test you wrote depends on a flaky external service
+  - An unrelated bug you noticed in foo.py
+  - A workaround you took because the proper fix would balloon the PR
+  - Something worth filing as its own follow-up issue (e.g., "the
+    `_compute_cost` divide-by-zero in telemetry.py deserves its own fix")
+
+Skip this section entirely if there is nothing worth flagging.
 
 ## Git rules (hard)
 

--- a/src/cog/workflows/ralph.py
+++ b/src/cog/workflows/ralph.py
@@ -61,6 +61,7 @@ from cog.ui.widgets.log_pane import LogPaneWidget
 class RebaseOutcome:
     status: Literal["clean", "conflict"]
     final_message: str = ""  # claude's analysis on conflict; empty on clean
+    stage_result: StageResult | None = None  # populated when the stage actually ran
 
 
 def _parse_float_env(key: str, default: float) -> float:
@@ -127,7 +128,7 @@ _COLLAPSE_RE = re.compile(r"-+")
 _BLOCKER_RE = re.compile(r"\b(?:blocked by|depends on)\s+#(\d+)", re.IGNORECASE)
 _ITEM_ID_FROM_PATH_RE = re.compile(r"^(\d+)-")
 _SECTION_RE = re.compile(
-    r"^###\s+(Summary|Key changes|Test plan)\s*\n(.*?)(?=\n###\s|\Z)",
+    r"^###\s+(Summary|Key changes|Test plan|Follow-up items)[ \t]*\n(.*?)(?=\n###\s|\Z)",
     re.MULTILINE | re.DOTALL | re.IGNORECASE,
 )
 
@@ -186,7 +187,7 @@ def _make_prompt_source(stage_name: str) -> Callable[[ExecutionContext], str]:
 def _split_final_message(message: str) -> dict[str, str]:
     sections: dict[str, str] = {}
     for match in _SECTION_RE.finditer(message):
-        key = match.group(1).lower().replace(" ", "_")
+        key = match.group(1).lower().replace(" ", "_").replace("-", "_")
         sections[key] = match.group(2).strip()
     return sections
 
@@ -568,10 +569,14 @@ class RalphWorkflow(Workflow):
         assert ctx.item is not None and ctx.work_branch is not None
         assert self._host is not None, "RalphWorkflow.finalize_success requires host"
 
+        results = list(results)  # local mutable copy so ci-fix/rebase can append
+
         rebase = await self._rebase_before_push(ctx)
         if rebase.status == "conflict":
             await self._handle_rebase_conflict(ctx, results, rebase.final_message)
             return
+        if rebase.stage_result is not None:
+            results.append(rebase.stage_result)
 
         try:
             await self._host.push_branch(ctx.work_branch)
@@ -579,16 +584,7 @@ class RalphWorkflow(Workflow):
             await self._handle_push_failed(ctx, results, e)
             return
 
-        existing = await self._host.get_pr_for_branch(ctx.work_branch)
-        body = self._build_pr_body(ctx, results)
-        if existing is None:
-            title = f"{ctx.item.title} (#{ctx.item.item_id})"
-            pr = await self._host.create_pr(head=ctx.work_branch, title=title, body=body)
-        else:
-            await self._host.update_pr(existing.number, body=body)
-            pr = existing
-
-        await self._tracker.comment(ctx.item, f"🤖 Cog opened a PR for this: {pr.url}")
+        pr = await self._create_or_update_pr(ctx, results)
 
         try:
             checks = await self._wait_for_ci(ctx, pr)
@@ -600,6 +596,22 @@ class RalphWorkflow(Workflow):
             await self._mark_ci_success(ctx, results, pr)
         else:
             await self._handle_ci_failure(ctx, results, pr, checks)
+
+    async def _create_or_update_pr(
+        self, ctx: ExecutionContext, results: list[StageResult]
+    ) -> PullRequest:
+        assert ctx.item is not None and ctx.work_branch is not None
+        assert self._host is not None
+        existing = await self._host.get_pr_for_branch(ctx.work_branch)
+        body = self._build_pr_body(ctx, results)
+        if existing is None:
+            title = f"{ctx.item.title} (#{ctx.item.item_id})"
+            pr = await self._host.create_pr(head=ctx.work_branch, title=title, body=body)
+        else:
+            await self._host.update_pr(existing.number, body=body)
+            pr = existing
+        await self._tracker.comment(ctx.item, f"🤖 Cog opened a PR for this: {pr.url}")
+        return pr
 
     async def _wait_for_ci(self, ctx: ExecutionContext, pr: PullRequest) -> PrChecks:
         poll_interval = _parse_float_env("COG_CI_POLL_INTERVAL_SECONDS", _DEFAULT_POLL_INTERVAL)
@@ -708,11 +720,15 @@ class RalphWorkflow(Workflow):
                 )
                 return
 
+            results.append(fix_result)
             try:
                 await self._host.push_branch(ctx.work_branch)  # type: ignore[union-attr,arg-type]
             except HostError as e:
                 await self._handle_push_failed(ctx, results, e)
                 return
+
+            assert self._host is not None
+            await self._host.update_pr(pr.number, body=self._build_pr_body(ctx, results))
 
             try:
                 checks = await self._wait_for_ci(ctx, pr)
@@ -806,6 +822,8 @@ class RalphWorkflow(Workflow):
     ) -> None:
         assert ctx.item is not None
         assert self._host is not None
+
+        await self._host.update_pr(pr.number, body=self._build_pr_body(ctx, results))
 
         if isinstance(cause, CiRetryCapExhaustedError):
             retries_done = self._ci_retries.get(ctx.item.item_id, 0)
@@ -1000,22 +1018,43 @@ class RalphWorkflow(Workflow):
         return report_path
 
     def _build_pr_body(self, ctx: ExecutionContext, results: list[StageResult]) -> str:
-        build = next((r for r in results if r.stage.name == "build"), None)
-        sections = _split_final_message(build.final_message if build else "")
-        summary = sections.get("summary") or (build.final_message.strip() if build else "")
-        key_changes = sections.get("key_changes")
-        test_plan = sections.get("test_plan") or "- [ ] Manual verification of the change"
-        total_cost = sum(r.cost_usd for r in results)
+        by_name = {r.stage.name: r for r in results}
 
+        def _best_section(key: str) -> str | None:
+            for stage_name in ("document", "review", "build"):
+                r = by_name.get(stage_name)
+                if r is not None:
+                    val = _split_final_message(r.final_message).get(key)
+                    if val:
+                        return val
+            return None
+
+        build = by_name.get("build")
+        summary = _best_section("summary") or (build.final_message.strip() if build else "")
+        key_changes = _best_section("key_changes")
+        test_plan = _best_section("test_plan") or "- [ ] Manual verification of the change"
+
+        fixed_order = ["build", "review", "document", "rebase"]
+        ci_fix_names = sorted(n for n in by_name if n.startswith("ci-fix"))
+        follow_up_parts = [
+            _split_final_message(by_name[n].final_message).get("follow_up_items", "").strip()
+            for n in fixed_order + ci_fix_names
+            if n in by_name
+        ]
+        follow_up = "\n".join(p for p in follow_up_parts if p) or None
+
+        total_cost = sum(r.cost_usd for r in results)
         body = f"## Summary\n\n{summary}\n\n"
         if key_changes:
             body += f"## Key changes\n\n{key_changes}\n\n"
+        body += f"## Test plan\n\n{test_plan}\n\n"
+        if follow_up:
+            body += f"## Follow-up items\n\n{follow_up}\n\n"
         body += (
             f"## Closes\n\nCloses #{ctx.item.item_id}\n\n"  # type: ignore[union-attr]
-            f"## Test plan\n\n{test_plan}\n\n"
             f"---\n🤖 Generated by cog. Iteration cost: ${total_cost:.3f}\n"
         )
-        doc = next((r for r in results if r.stage.name == "document"), None)
+        doc = by_name.get("document")
         if doc is not None and doc.error is not None:
             body += f"\n⚠ Document stage failed: {doc.error}. Docs may be out of date.\n"
         return body
@@ -1053,7 +1092,7 @@ class RalphWorkflow(Workflow):
             await git.rebase_abort(git_dir)
             return RebaseOutcome(status="conflict", final_message=result.final_message)
 
-        return RebaseOutcome(status="clean")
+        return RebaseOutcome(status="clean", stage_result=result)
 
     async def _handle_rebase_conflict(
         self,

--- a/tests/test_workflows/test_ralph_finalization.py
+++ b/tests/test_workflows/test_ralph_finalization.py
@@ -209,6 +209,61 @@ def test_split_final_message_ignores_unknown_sections() -> None:
     assert "rationale" not in sections
 
 
+@pytest.mark.parametrize(
+    "msg, expected_keys, expected_follow_up",
+    [
+        # All four sections present in declared order
+        (
+            "### Summary\n\nDid it.\n\n"
+            "### Key changes\n\n- foo.py\n\n"
+            "### Test plan\n\n- [ ] step\n\n"
+            "### Follow-up items\n\n- Watch the flaky test",
+            {"summary", "key_changes", "test_plan", "follow_up_items"},
+            "- Watch the flaky test",
+        ),
+        # Follow-up items in mixed order (second)
+        (
+            "### Summary\n\nDid it.\n\n"
+            "### Follow-up items\n\n- Bug in bar.py\n\n"
+            "### Test plan\n\n- [ ] step",
+            {"summary", "follow_up_items", "test_plan"},
+            "- Bug in bar.py",
+        ),
+        # Only Follow-up items present
+        (
+            "### Follow-up items\n\n- Something odd",
+            {"follow_up_items"},
+            "- Something odd",
+        ),
+        # Follow-up items heading with whitespace-only body
+        (
+            "### Summary\n\nDid it.\n\n### Follow-up items\n\n   \n\n### Test plan\n\n- [ ] step",
+            {"summary", "follow_up_items", "test_plan"},
+            "",
+        ),
+        # No structured headings
+        (
+            "Just some free text with no headings.",
+            set(),
+            None,
+        ),
+        # Follow-up items with prose (not bullets) — forgiving extraction
+        (
+            "### Follow-up items\n\nConsider refactoring foo into two smaller functions.",
+            {"follow_up_items"},
+            "Consider refactoring foo into two smaller functions.",
+        ),
+    ],
+)
+def test_split_final_message_follow_up_items(
+    msg: str, expected_keys: set[str], expected_follow_up: str | None
+) -> None:
+    sections = _split_final_message(msg)
+    assert set(sections.keys()) == expected_keys
+    if expected_follow_up is not None:
+        assert sections.get("follow_up_items", "") == expected_follow_up
+
+
 # ---------------------------------------------------------------------------
 # _build_pr_body unit tests
 # ---------------------------------------------------------------------------
@@ -319,16 +374,18 @@ def test_build_pr_body_section_order_preserved(tmp_path: Path) -> None:
     msg = (
         "### Summary\n\nSummary text.\n\n"
         "### Key changes\n\n- file.py: change\n\n"
-        "### Test plan\n\n- [ ] step"
+        "### Test plan\n\n- [ ] step\n\n"
+        "### Follow-up items\n\n- Watch out for flaky test"
     )
     results = [make_stage_result("build", final_message=msg)]
     body = wf._build_pr_body(ctx, results)
     summary_pos = body.index("## Summary")
     key_changes_pos = body.index("## Key changes")
-    closes_pos = body.index("## Closes")
     test_plan_pos = body.index("## Test plan")
+    follow_up_pos = body.index("## Follow-up items")
+    closes_pos = body.index("## Closes")
     footer_pos = body.index("---")
-    assert summary_pos < key_changes_pos < closes_pos < test_plan_pos < footer_pos
+    assert summary_pos < key_changes_pos < test_plan_pos < follow_up_pos < closes_pos < footer_pos
 
 
 def test_build_pr_body_doc_warning_still_appended_on_document_error(tmp_path: Path) -> None:
@@ -355,6 +412,127 @@ def test_build_pr_body_cost_line_still_appears(tmp_path: Path) -> None:
     ]
     body = wf._build_pr_body(ctx, results)
     assert "0.050" in body
+
+
+def test_build_pr_body_follow_up_items_from_build_only(tmp_path: Path) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    msg = "### Summary\n\nDone.\n\n### Follow-up items\n\n- Watch the flaky test"
+    results = [make_stage_result("build", final_message=msg)]
+    body = wf._build_pr_body(ctx, results)
+    assert "## Follow-up items" in body
+    assert "- Watch the flaky test" in body
+
+
+def test_build_pr_body_follow_up_items_from_review_only(tmp_path: Path) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    review_msg = "### Summary\n\nDone.\n\n### Follow-up items\n\n- Bug in bar.py"
+    results = [
+        make_stage_result("build", final_message="### Summary\n\nDone."),
+        make_stage_result("review", final_message=review_msg),
+    ]
+    body = wf._build_pr_body(ctx, results)
+    assert "## Follow-up items" in body
+    assert "- Bug in bar.py" in body
+
+
+def test_build_pr_body_follow_up_items_concat_build_and_review(tmp_path: Path) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    build_msg = "### Summary\n\nDone.\n\n### Follow-up items\n\n- From build"
+    review_msg = "### Summary\n\nDone.\n\n### Follow-up items\n\n- From review"
+    results = [
+        make_stage_result("build", final_message=build_msg),
+        make_stage_result("review", final_message=review_msg),
+    ]
+    body = wf._build_pr_body(ctx, results)
+    assert "## Follow-up items" in body
+    follow_up_pos = body.index("## Follow-up items")
+    assert "- From build" in body[follow_up_pos:]
+    assert "- From review" in body[follow_up_pos:]
+    assert body.index("- From build") < body.index("- From review")
+
+
+def test_build_pr_body_ci_fix_follow_up_appended(tmp_path: Path) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    build_msg = "### Summary\n\nDone.\n\n### Follow-up items\n\n- From build"
+    ci_fix_msg = "### Follow-up items\n\n- From ci-fix"
+    results = [
+        make_stage_result("build", final_message=build_msg),
+        make_stage_result("ci-fix-1", final_message=ci_fix_msg),
+    ]
+    body = wf._build_pr_body(ctx, results)
+    assert "## Follow-up items" in body
+    assert "- From build" in body
+    assert "- From ci-fix" in body
+    assert body.index("- From build") < body.index("- From ci-fix")
+
+
+def test_build_pr_body_no_follow_up_items_when_none_emitted(tmp_path: Path) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    results = [
+        make_stage_result(
+            "build",
+            final_message="### Summary\n\nDone.\n\n### Test plan\n\n- [ ] step",
+        ),
+    ]
+    body = wf._build_pr_body(ctx, results)
+    assert "## Follow-up items" not in body
+
+
+def test_build_pr_body_whitespace_only_follow_up_omitted(tmp_path: Path) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    msg = "### Summary\n\nDone.\n\n### Follow-up items\n\n   "
+    results = [make_stage_result("build", final_message=msg)]
+    body = wf._build_pr_body(ctx, results)
+    assert "## Follow-up items" not in body
+
+
+def test_build_pr_body_document_summary_overwrites_build(tmp_path: Path) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    build_msg = "### Summary\n\nBuild summary."
+    doc_msg = "### Summary\n\nDocument summary."
+    results = [
+        make_stage_result("build", final_message=build_msg),
+        make_stage_result("document", final_message=doc_msg),
+    ]
+    body = wf._build_pr_body(ctx, results)
+    assert "Document summary." in body
+    assert "Build summary." not in body
+
+
+def test_build_pr_body_review_summary_overwrites_build_when_no_document(tmp_path: Path) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    build_msg = "### Summary\n\nBuild summary."
+    review_msg = "### Summary\n\nReview summary."
+    results = [
+        make_stage_result("build", final_message=build_msg),
+        make_stage_result("review", final_message=review_msg),
+    ]
+    body = wf._build_pr_body(ctx, results)
+    assert "Review summary." in body
+    assert "Build summary." not in body
+
+
+def test_build_pr_body_build_summary_survives_when_review_and_document_omit_it(
+    tmp_path: Path,
+) -> None:
+    wf = _make_wf()
+    ctx = _make_ctx(tmp_path)
+    build_msg = "### Summary\n\nBuild summary."
+    results = [
+        make_stage_result("build", final_message=build_msg),
+        make_stage_result("review", final_message="No sections here."),
+        make_stage_result("document", final_message="No sections here either."),
+    ]
+    body = wf._build_pr_body(ctx, results)
+    assert "Build summary." in body
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

All changes committed. Here's what was implemented:

**`src/cog/workflows/ralph.py`**:
- `_SECTION_RE` extended to recognize `Follow-up items` as a fourth section; changed `\s*\n` to `[ \t]*\n` in heading to prevent newlines from being consumed as heading whitespace
- `_split_final_message` now normalizes hyphens in keys (→ `follow_up_items`)
- `RebaseOutcome` gets a `stage_result` field, populated when the rebase stage ran
- `_build_pr_body` rewritten with multi-stage priority merge (document > review > build for non-Follow-up sections), concatenation of Follow-up items across all stages, and new section order (Summary, Key changes, Test plan, Follow-up items, Closes)
- `finalize_success` makes a local mutable results copy, appends rebase result when it ran, and delegates PR creation/update to `_create_or_update_pr`
- `_create_or_update_pr` extracted from `finalize_success`
- `_handle_ci_failure` appends ci-fix results to `results` after each committed fix and updates the PR body
- `_abandon_ci` updates PR body before commenting so Follow-up items are visible even on abandon

**Prompts**: All five stages (`build`, `review`, `document`, `ci_fix`, `rebase`) updated with the Follow-up items contract; `build`/`review`/`document` get the full four-section contract with cumulative-against-base-branch framing and the judgment-call line in Summary.

**Tests**: 27 new/updated tests covering `_split_final_message` Follow-up items cases, multi-stage `_build_pr_body` priority merge, Follow-up items concatenation across stages, and the corrected section order.

## Key changes

- `_SECTION_RE` and `_split_final_message` recognize `follow_up_items` as a fourth structured section; regex heading parsing tightened to avoid consuming blank lines as heading whitespace
- `_build_pr_body` now uses priority-order merge across `[document, review, build]` for Summary/Key changes/Test plan, and ordered concatenation across all stages for Follow-up items
- PR body section order changed: Summary → Key changes → Test plan → Follow-up items → Closes
- `_create_or_update_pr` extracted from `finalize_success`; rebase stage_result appended to results when rebase ran; ci-fix results appended and PR updated after each committed fix
- `_abandon_ci` updates PR body before posting the abandon comment
- Five prompts updated with the Follow-up items section and (for build/review/document) the full four-section contract

## Closes

Closes #178

## Test plan

- [ ] Trigger a ralph run; verify the PR body shows Summary, Key changes, Test plan, and Closes in that order (Follow-up items absent when none emitted)
- [ ] In a build prompt, include `### Follow-up items` with a bullet; verify the PR body shows `## Follow-up items` before `## Closes`
- [ ] Run with both review and build emitting Follow-up items; verify bullets from both appear concatenated (build order first) under one `## Follow-up items` heading
- [ ] Run with review emitting a new Summary; verify the PR body shows review's Summary, not build's
- [ ] Verify `## Follow-up items` is absent when all stages emit empty/no Follow-up items sections

---
🤖 Generated by cog. Iteration cost: $5.668
