### PR TITLE
Add a Stewardship principle to ralph build/review prompts so adjacent improvements get folded in instead of left behind (#133)

### DIFF
--- a/docs/workflows/ralph.md
+++ b/docs/workflows/ralph.md
@@ -43,6 +43,23 @@ Override each via `COG_RALPH_BUILD_MODEL` / `COG_RALPH_REVIEW_MODEL` /
 Prompts live in [`src/cog/prompts/claude/ralph/`](../../src/cog/prompts/claude/ralph/)
 as markdown. Change prompt behavior by editing the markdown, not Python.
 
+### Stewardship
+
+The build stage is expected to fold small adjacent improvements into the same
+PR rather than leave them behind. A noticed fix belongs in the PR only when all
+three of the following hold; otherwise it goes under `### Follow-up items`:
+
+- **Small** — roughly one function or a handful of lines; must not grow the
+  diff by more than ~30% or pull in a new module.
+- **Adjacent** — the file or area is already open as part of the primary work.
+- **Same-shape** — a bug fix, a missing test, or a local refactor.
+  Abstraction redesigns or public interface changes are not same-shape.
+
+The review stage is briefed on these criteria and will not flag stewardship
+folds as scope creep. Changes that cross into unrelated areas of the codebase
+or that modify a public interface unrelated to the primary task are still
+genuine scope concerns and will be flagged.
+
 ## PR body
 
 Each main stage ends its final message with four structured sections that

--- a/docs/workflows/ralph.md
+++ b/docs/workflows/ralph.md
@@ -45,6 +45,15 @@ as markdown. Change prompt behavior by editing the markdown, not Python.
 
 ### Stewardship
 
+<!-- Stewardship criteria (Small / Adjacent / Same-shape) appear in three
+     places. Keep the criteria definitions consistent across:
+       - src/cog/prompts/claude/ralph/build.md
+       - src/cog/prompts/claude/ralph/review.md
+       - docs/workflows/ralph.md (this file)
+     The surrounding framing differs per context (build prompt = "do this",
+     review prompt = "don't flag these", these docs = "the system does this");
+     only the three criteria themselves must stay in sync. -->
+
 The build stage is expected to fold small adjacent improvements into the same
 PR rather than leave them behind. A noticed fix belongs in the PR only when all
 three of the following hold; otherwise it goes under `### Follow-up items`:

--- a/src/cog/prompts/claude/ralph/build.md
+++ b/src/cog/prompts/claude/ralph/build.md
@@ -28,7 +28,9 @@ file; pipe through `head -c 30000` or use `--jq` to stay bounded.
    context** above). Item number and title are already in the runtime
    context.
 2. Implement the change required by the item.
-3. Write or update tests that exercise the new or changed behavior. See **Stewardship** below for when to extend coverage beyond the directly-changed code.
+3. Write or update tests that exercise the new or changed behavior. See
+   **Stewardship** below for when to extend coverage beyond the
+   directly-changed code.
 4. Run the project's test suite. Fix any failures.
 5. Run the project's linter. Fix any errors.
 6. Commit your work with a clear message that references the issue number

--- a/src/cog/prompts/claude/ralph/build.md
+++ b/src/cog/prompts/claude/ralph/build.md
@@ -61,6 +61,15 @@ The project's `CLAUDE.md` may override these thresholds — its rules win.
 
 ## Stewardship
 
+<!-- Stewardship criteria (Small / Adjacent / Same-shape) appear in three
+     places. Keep the criteria definitions consistent across:
+       - src/cog/prompts/claude/ralph/build.md
+       - src/cog/prompts/claude/ralph/review.md
+       - docs/workflows/ralph.md
+     The surrounding framing differs per context (this prompt = "do this",
+     review prompt = "don't flag these", docs = "the system does this");
+     only the three criteria themselves must stay in sync. -->
+
 Be a steward of the code. When you notice something wrong in code you're
 already working in — a missing test case, a small bug, a local refactor
 opportunity — the default is to fix it in this PR, not to walk past it.

--- a/src/cog/prompts/claude/ralph/build.md
+++ b/src/cog/prompts/claude/ralph/build.md
@@ -28,7 +28,7 @@ file; pipe through `head -c 30000` or use `--jq` to stay bounded.
    context** above). Item number and title are already in the runtime
    context.
 2. Implement the change required by the item.
-3. Write or update tests that exercise the new or changed behavior.
+3. Write or update tests that exercise the new or changed behavior. See **Stewardship** below for when to extend coverage beyond the directly-changed code.
 4. Run the project's test suite. Fix any failures.
 5. Run the project's linter. Fix any errors.
 6. Commit your work with a clear message that references the issue number
@@ -56,6 +56,40 @@ These are concrete maintainability rules, not stylistic preferences:
   workaround).
 
 The project's `CLAUDE.md` may override these thresholds — its rules win.
+
+## Stewardship
+
+Be a steward of the code. When you notice something wrong in code you're
+already working in — a missing test case, a small bug, a local refactor
+opportunity — the default is to fix it in this PR, not to walk past it.
+The `### Follow-up items` PR section is the escape valve when a fix is
+too large or too far afield to fold in.
+
+A noticed improvement belongs in this PR only when **all three** of the
+following hold. If any one fails, list it under `### Follow-up items`
+instead.
+
+- **Small** — the fix is bounded: roughly one function or a handful of
+  lines, a single missing test case, a single local refactor. As a rough
+  ceiling, it should not grow the diff by more than ~30% and must not
+  pull in a new module.
+- **Adjacent** — the file or area is already open as part of the primary
+  work, and you understand it from doing that work. "While I'm here, let
+  me jump three modules over" is not adjacent.
+- **Same-shape** — the fix is a bug fix, a missing test, or a local
+  refactor. Redesigning an abstraction, changing a public interface, or
+  restructuring a module is not same-shape and belongs in a follow-up
+  regardless of size.
+
+All three criteria must hold; any failing criterion sends the item to
+`### Follow-up items`.
+
+*Fold in*: while modifying `parse_event()`, you notice it has no test
+for empty input — add the test in this PR.
+
+*Follow up*: while modifying `parse_event()`, you notice the surrounding
+module mixes sync and async APIs inconsistently — file as a follow-up,
+don't refactor here.
 
 ## Bounded tool calls (important)
 

--- a/src/cog/prompts/claude/ralph/review.md
+++ b/src/cog/prompts/claude/ralph/review.md
@@ -22,6 +22,18 @@ final message.
    prevents? Near-duplicate blocks that should be extracted? Comments that
    restate what the code does?
 
+**Stewardship scope** — the build stage is expected to fold in small,
+adjacent, same-shape improvements noticed while working: a missing test
+case, a nearby bug fix, a local refactor. Do not flag these as scope
+creep. The three criteria that define a legitimate stewardship fold are:
+small (bounded to roughly one function or a handful of lines, no new
+modules), adjacent (already open as part of the primary work), and
+same-shape (bug fix, missing test, or local refactor — not an abstraction
+redesign or public interface change). Changes that cross into unrelated
+areas of the codebase, refactors that grew beyond local cleanup, or
+modifications to a public interface unrelated to the primary task are
+still genuine scope concerns and should be flagged.
+
 ## Item context
 
 To see the item's current body and comments:

--- a/src/cog/prompts/claude/ralph/review.md
+++ b/src/cog/prompts/claude/ralph/review.md
@@ -22,6 +22,15 @@ final message.
    prevents? Near-duplicate blocks that should be extracted? Comments that
    restate what the code does?
 
+<!-- Stewardship criteria (Small / Adjacent / Same-shape) appear in three
+     places. Keep the criteria definitions consistent across:
+       - src/cog/prompts/claude/ralph/build.md
+       - src/cog/prompts/claude/ralph/review.md
+       - docs/workflows/ralph.md
+     The surrounding framing differs per context (build prompt = "do this",
+     this prompt = "don't flag these", docs = "the system does this");
+     only the three criteria themselves must stay in sync. -->
+
 **Stewardship scope** — the build stage is expected to fold in small,
 adjacent, same-shape improvements noticed while working: a missing test
 case, a nearby bug fix, a local refactor. Do not flag these as scope


### PR DESCRIPTION
## Summary

Adds a `## Stewardship` section to `build.md` (the build-stage prompt) instructing the agent to fold small adjacent improvements into the same PR rather than leaving them behind, and a `**Stewardship scope**` paragraph to `review.md` calibrating the reviewer to not flag those folds as scope creep. The three criteria — small, adjacent, same-shape — define when a noticed improvement belongs in the current PR versus a follow-up item.

## Key changes

- New `## Stewardship` section in `build.md`: defines the three criteria (small, adjacent, same-shape) with examples of fold-in vs. follow-up, and points to `### Follow-up items` as the escape valve
- New `**Stewardship scope**` paragraph in `review.md`: briefs the reviewer on the same criteria so stewardship folds aren't flagged as scope creep; distinguishes legitimate folds from genuine scope concerns
- New `### Stewardship` subsection in `docs/workflows/ralph.md`: user-facing explanation of the behavior so PR reviewers understand why a ralph PR may include improvements beyond the literal issue scope

## Test plan

- [ ] Run ralph on an issue; verify that in the build stage, small adjacent fixes (e.g. a missing test case for a function being modified) are folded in rather than left as follow-up items
- [ ] Verify the review stage does not flag those folds as scope creep in its output
- [ ] Verify that a fix that crosses unrelated modules or redesigns an abstraction still ends up under `### Follow-up items` rather than being folded in

## Follow-up items

None.
- The build prompt and the review prompt both restate the three criteria in slightly different wording. They agree today, but the duplication is a drift risk — if a future change tweaks the rule on one side it'll be easy to forget the other. Worth considering, in a later pass, whether one prompt should reference the other rather than each carrying its own copy.

## Closes

Closes #133

---
🤖 Generated by cog. Iteration cost: $2.197
